### PR TITLE
Infra/bump charts fixes

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
 version: 0.3.6
-appVersion: "0.1.18"
+appVersion: "0.1.19"

--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.3.5
-appVersion: "0.1.0"
+version: 0.3.6
+appVersion: "0.1.18"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -35,7 +35,7 @@ Ensure you have the following tools/items ready.
 3. LangSmith License Key
     1. You can get this from your Langchain representative. Contact us at support@langchain.dev for more information.
 3. SSL(optional)
-    1. This should be attachable to a load balancer that
+    1. This should be attachable to the load balancer that you will be provisioning.
 4. OpenAI API Key(optional).
     1. Used for natural language search feature. Can specify OpenAI key in browser as well for the playground feature.
 5. Oauth Configuration(optional).
@@ -104,11 +104,7 @@ config:
 postgres:
   external:
     enabled: true
-    host: <host>
-    port: 5432
-    user: <user>
-    password: <password>
-    database: <database>
+    connectionUrl: "postgresql://<username>:<password>@<url>:5432/<dbname>"
 redis:
   external:
     enabled: true
@@ -117,6 +113,8 @@ redis:
 
 You can also use existingSecretName to avoid checking in secrets. This secret will need to follow
 the same format as the secret in the corresponding `secrets.yaml` file.
+
+More examples can be found in the `examples` directory.
 
 ### Deploying to Kubernetes:
 
@@ -216,6 +214,13 @@ We typically validate deployment using the following quickstart guide:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| apiIngress.annotations | object | `{}` |  |
+| apiIngress.enabled | bool | `false` |  |
+| apiIngress.hostname | string | `""` |  |
+| apiIngress.ingressClassName | string | `""` |  |
+| apiIngress.labels | object | `{}` |  |
+| apiIngress.subdomain | string | `""` |  |
+| apiIngress.tls | list | `[]` |  |
 | clickhouse.containerHttpPort | int | `8123` |  |
 | clickhouse.containerNativePort | int | `9000` |  |
 | clickhouse.external.database | string | `"default"` |  |
@@ -260,21 +265,21 @@ We typically validate deployment using the following quickstart guide:
 | commonLabels | object | `{}` | Labels that will be applied to all resources created by the chart |
 | fullnameOverride | string | `""` | String to fully override `"langsmith.fullname"` |
 | images.backendImage.pullPolicy | string | `"IfNotPresent"` |  |
-| images.backendImage.repository | string | `"docker.io/langchain/langchainplus-backend"` |  |
+| images.backendImage.repository | string | `"docker.io/langchain/langsmith-backend"` |  |
 | images.backendImage.tag | string | `"0.1.18"` |  |
 | images.clickhouseImage.pullPolicy | string | `"Always"` |  |
 | images.clickhouseImage.repository | string | `"docker.io/clickhouse/clickhouse-server"` |  |
 | images.clickhouseImage.tag | string | `"23.9"` |  |
 | images.frontendImage.pullPolicy | string | `"IfNotPresent"` |  |
-| images.frontendImage.repository | string | `"docker.io/langchain/langchainplus-frontend-dynamic"` |  |
+| images.frontendImage.repository | string | `"docker.io/langchain/langsmith-frontend"` |  |
 | images.frontendImage.tag | string | `"0.1.18"` |  |
 | images.hubBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
-| images.hubBackendImage.repository | string | `"docker.io/langchain/langchainhub-backend"` |  |
+| images.hubBackendImage.repository | string | `"docker.io/langchain/langhub-backend"` |  |
 | images.hubBackendImage.tag | string | `"0.1.18"` |  |
 | images.imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Specified as name: value. |
 | images.playgroundImage.pullPolicy | string | `"IfNotPresent"` |  |
-| images.playgroundImage.repository | string | `"docker.io/langchain/langchainplus-playground"` |  |
-| images.playgroundImage.tag | string | `"d2c7513"` |  |
+| images.playgroundImage.repository | string | `"docker.io/langchain/langsmith-playground"` |  |
+| images.playgroundImage.tag | string | `"0.1.18"` |  |
 | images.postgresImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.postgresImage.repository | string | `"docker.io/postgres"` |  |
 | images.postgresImage.tag | string | `"14.7"` |  |
@@ -568,7 +573,6 @@ We typically validate deployment using the following quickstart guide:
 | postgres.statefulSet.extraEnv | list | `[]` |  |
 | postgres.statefulSet.labels | object | `{}` |  |
 | postgres.statefulSet.nodeSelector | object | `{}` |  |
-| postgres.statefulSet.persistence.enabled | bool | `false` |  |
 | postgres.statefulSet.persistence.size | string | `"8Gi"` |  |
 | postgres.statefulSet.persistence.storageClassName | string | `""` |  |
 | postgres.statefulSet.podSecurityContext | object | `{}` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.18](https://img.shields.io/badge/AppVersion-0.1.18-informational?style=flat-square)
+![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.19](https://img.shields.io/badge/AppVersion-0.1.19-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -266,20 +266,20 @@ We typically validate deployment using the following quickstart guide:
 | fullnameOverride | string | `""` | String to fully override `"langsmith.fullname"` |
 | images.backendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.backendImage.repository | string | `"docker.io/langchain/langsmith-backend"` |  |
-| images.backendImage.tag | string | `"0.1.18"` |  |
+| images.backendImage.tag | string | `"0.1.19"` |  |
 | images.clickhouseImage.pullPolicy | string | `"Always"` |  |
 | images.clickhouseImage.repository | string | `"docker.io/clickhouse/clickhouse-server"` |  |
 | images.clickhouseImage.tag | string | `"23.9"` |  |
 | images.frontendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.frontendImage.repository | string | `"docker.io/langchain/langsmith-frontend"` |  |
-| images.frontendImage.tag | string | `"0.1.18"` |  |
+| images.frontendImage.tag | string | `"0.1.19"` |  |
 | images.hubBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.hubBackendImage.repository | string | `"docker.io/langchain/langhub-backend"` |  |
-| images.hubBackendImage.tag | string | `"0.1.18"` |  |
+| images.hubBackendImage.tag | string | `"0.1.19"` |  |
 | images.imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Specified as name: value. |
 | images.playgroundImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.playgroundImage.repository | string | `"docker.io/langchain/langsmith-playground"` |  |
-| images.playgroundImage.tag | string | `"0.1.18"` |  |
+| images.playgroundImage.tag | string | `"0.1.19"` |  |
 | images.postgresImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.postgresImage.repository | string | `"docker.io/postgres"` |  |
 | images.postgresImage.tag | string | `"14.7"` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.18](https://img.shields.io/badge/AppVersion-0.1.18-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -261,16 +261,16 @@ We typically validate deployment using the following quickstart guide:
 | fullnameOverride | string | `""` | String to fully override `"langsmith.fullname"` |
 | images.backendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.backendImage.repository | string | `"docker.io/langchain/langchainplus-backend"` |  |
-| images.backendImage.tag | string | `"d2c7513"` |  |
+| images.backendImage.tag | string | `"0.1.18"` |  |
 | images.clickhouseImage.pullPolicy | string | `"Always"` |  |
 | images.clickhouseImage.repository | string | `"docker.io/clickhouse/clickhouse-server"` |  |
 | images.clickhouseImage.tag | string | `"23.9"` |  |
 | images.frontendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.frontendImage.repository | string | `"docker.io/langchain/langchainplus-frontend-dynamic"` |  |
-| images.frontendImage.tag | string | `"d2c7513"` |  |
+| images.frontendImage.tag | string | `"0.1.18"` |  |
 | images.hubBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.hubBackendImage.repository | string | `"docker.io/langchain/langchainhub-backend"` |  |
-| images.hubBackendImage.tag | string | `"d2c7513"` |  |
+| images.hubBackendImage.tag | string | `"0.1.18"` |  |
 | images.imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Specified as name: value. |
 | images.playgroundImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.playgroundImage.repository | string | `"docker.io/langchain/langchainplus-playground"` |  |
@@ -590,19 +590,9 @@ We typically validate deployment using the following quickstart guide:
 | queue.autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | queue.deployment.affinity | object | `{}` |  |
 | queue.deployment.annotations | object | `{}` |  |
-| queue.deployment.command[0] | string | `"rq"` |  |
-| queue.deployment.command[10] | string | `"lc_database.queue.connection.RedisRetry"` |  |
-| queue.deployment.command[11] | string | `"--job-class"` |  |
-| queue.deployment.command[12] | string | `"lc_database.queue.job.AsyncJob"` |  |
-| queue.deployment.command[1] | string | `"worker"` |  |
-| queue.deployment.command[2] | string | `"--with-scheduler"` |  |
-| queue.deployment.command[3] | string | `"-u"` |  |
-| queue.deployment.command[4] | string | `"$(REDIS_DATABASE_URI)"` |  |
-| queue.deployment.command[5] | string | `"--serializer"` |  |
-| queue.deployment.command[6] | string | `"lc_database.queue.serializer.ORJSONSerializer"` |  |
-| queue.deployment.command[7] | string | `"--worker-class"` |  |
-| queue.deployment.command[8] | string | `"lc_database.queue.worker.Worker"` |  |
-| queue.deployment.command[9] | string | `"--connection-class"` |  |
+| queue.deployment.command[0] | string | `"saq"` |  |
+| queue.deployment.command[1] | string | `"app.async_worker.settings"` |  |
+| queue.deployment.command[2] | string | `"--quiet"` |  |
 | queue.deployment.extraContainerConfig | object | `{}` |  |
 | queue.deployment.extraEnv | list | `[]` |  |
 | queue.deployment.labels | object | `{}` |  |

--- a/charts/langsmith/README.md.gotmpl
+++ b/charts/langsmith/README.md.gotmpl
@@ -35,7 +35,7 @@ Ensure you have the following tools/items ready.
 3. LangSmith License Key
     1. You can get this from your Langchain representative. Contact us at support@langchain.dev for more information.
 3. SSL(optional)
-    1. This should be attachable to a load balancer that
+    1. This should be attachable to the load balancer that you will be provisioning.
 4. OpenAI API Key(optional).
     1. Used for natural language search feature. Can specify OpenAI key in browser as well for the playground feature.
 5. Oauth Configuration(optional).

--- a/charts/langsmith/README.md.gotmpl
+++ b/charts/langsmith/README.md.gotmpl
@@ -104,11 +104,7 @@ config:
 postgres:
   external:
     enabled: true
-    host: <host>
-    port: 5432
-    user: <user>
-    password: <password>
-    database: <database>
+    connectionUrl: "postgresql://<username>:<password>@<url>:5432/<dbname>"
 redis:
   external:
     enabled: true
@@ -117,6 +113,8 @@ redis:
 
 You can also use existingSecretName to avoid checking in secrets. This secret will need to follow
 the same format as the secret in the corresponding `secrets.yaml` file.
+
+More examples can be found in the `examples` directory.
 
 
 ### Deploying to Kubernetes:

--- a/charts/langsmith/examples/autoscaling_config.yaml
+++ b/charts/langsmith/examples/autoscaling_config.yaml
@@ -1,0 +1,62 @@
+config:
+  langsmithLicenseKey: "YOUR_LICENSE_KEY"
+
+# Note, you likely should tweak the values to match your needs
+backend:
+  deployment:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1000Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 50
+
+hubBackend:
+  deployment:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1000Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 50
+
+frontend:
+  deployment:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1000Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 50
+
+playground:
+  deployment:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1000Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 50
+
+queue:
+  deployment:
+    requests:
+      cpu: "1000m"
+      memory: "4Gi"
+  autoscaling:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 50

--- a/charts/langsmith/examples/basic_config.yaml
+++ b/charts/langsmith/examples/basic_config.yaml
@@ -1,0 +1,3 @@
+config:
+  langsmithLicenseKey: "YOUR_LICENSE_KEY"
+  # existingSecretName: "langsmith-config" You can also put the above into a secret if you want to avoid putting the license key in the values file.

--- a/charts/langsmith/examples/basic_external.yaml
+++ b/charts/langsmith/examples/basic_external.yaml
@@ -1,0 +1,14 @@
+config:
+  langsmithLicenseKey: "YOUR_LICENSE_KEY"
+
+postgres:
+  external:
+    enabled: true
+    connectionUrl: "default:foo@host:port/database?sslmode=require"
+    # existingSecretName: "postgres-secret" Can also put the above into a secret if you want to avoid putting the connection string in the values file.
+
+redis:
+  external:
+    enabled: true
+    connectionUrl: "redis://host:port"
+    # existingSecretName: "redis-secret" Can also put the above into a secret if you want to avoid putting the connection string in the values file.

--- a/charts/langsmith/examples/basic_oauth.yaml
+++ b/charts/langsmith/examples/basic_oauth.yaml
@@ -1,0 +1,6 @@
+config:
+  langsmithLicenseKey: "YOUR_LICENSE_KEY"
+  oauth:
+    enabled: true
+    oauthClientId: "YOUR_CLIENT_ID"
+    oauthIssuerUrl: "YOUR_ISSUER_URL"

--- a/charts/langsmith/examples/medium_size.yaml
+++ b/charts/langsmith/examples/medium_size.yaml
@@ -1,0 +1,90 @@
+config:
+  langsmithLicenseKey: "YOUR_LICENSE_KEY"
+  openaiApiKey: "YOUR OPENAI API KEY"
+  oauth:
+    enabled: true
+    oauthClientId: "YOUR_CLIENT_ID"
+    oauthIssuerUrl: "YOUR_ISSUER_URL"
+
+# Note, you likely should tweak the values to match your needs
+backend:
+  deployment:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1000Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 50
+
+hubBackend:
+  deployment:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1000Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 50
+
+frontend:
+  deployment:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1000Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 50
+
+playground:
+  deployment:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1000Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 50
+
+queue:
+  deployment:
+    requests:
+      cpu: "1000m"
+      memory: "4Gi"
+  autoscaling:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 50
+
+# We suggest using an external database for production use cases.
+postgres:
+  external:
+    enabled: true
+    connectionUrl: "default:foo@host:port/database?sslmode=require"
+    # existingSecretName: "postgres-secret" Can also put the above into a secret if you want to avoid putting the connection string in the values file.
+
+# We suggest using an external redis for production use cases.
+redis:
+  external:
+    enabled: true
+    connectionUrl: "redis://host:port"
+    # existingSecretName: "redis-secret" Can also put the above into a secret if you want to avoid putting the connection string in the values file.
+
+clickhouse:
+  statefulset:
+    resources:
+      requests:
+        cpu: "2000m"
+        memory: "8Gi"
+    persistence:
+      size: "50Gi"

--- a/charts/langsmith/examples/medium_size.yaml
+++ b/charts/langsmith/examples/medium_size.yaml
@@ -11,8 +11,8 @@ backend:
   deployment:
     resources:
       requests:
-        cpu: 500m
-        memory: 1000Mi
+        cpu: "500m"
+        memory: "1000Mi"
   autoscaling:
     enabled: true
     minReplicas: 1
@@ -23,8 +23,8 @@ hubBackend:
   deployment:
     resources:
       requests:
-        cpu: 500m
-        memory: 1000Mi
+        cpu: "500m"
+        memory: "1000Mi"
   autoscaling:
     enabled: true
     minReplicas: 1
@@ -35,8 +35,8 @@ frontend:
   deployment:
     resources:
       requests:
-        cpu: 500m
-        memory: 1000Mi
+        cpu: "500m"
+        memory: "1000Mi"
   autoscaling:
     enabled: true
     minReplicas: 1
@@ -47,8 +47,8 @@ playground:
   deployment:
     resources:
       requests:
-        cpu: 500m
-        memory: 1000Mi
+        cpu: "500m"
+        memory: "1000Mi"
   autoscaling:
     enabled: true
     minReplicas: 1
@@ -57,12 +57,13 @@ playground:
 
 queue:
   deployment:
-    requests:
-      cpu: "1000m"
-      memory: "4Gi"
+    resources:
+      requests:
+        cpu: "1000m"
+        memory: "4Gi"
   autoscaling:
       enabled: true
-      minReplicas: 1
+      minReplicas: 3
       maxReplicas: 10
       targetCPUUtilizationPercentage: 50
 
@@ -81,7 +82,7 @@ redis:
     # existingSecretName: "redis-secret" Can also put the above into a secret if you want to avoid putting the connection string in the values file.
 
 clickhouse:
-  statefulset:
+  statefulSet:
     resources:
       requests:
         cpu: "2000m"

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -188,6 +188,11 @@ Template containing common environment variables that are used by several servic
     secretKeyRef:
       name: {{ include "langsmith.secretsName" . }}
       key: api_key_salt
+- name: OPENAI_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "langsmith.secretsName" . }}
+      key: openai_api_key
 {{- end }}
 
 {{- define "backend.serviceAccountName" -}}

--- a/charts/langsmith/templates/api_ingress.yaml
+++ b/charts/langsmith/templates/api_ingress.yaml
@@ -24,18 +24,18 @@ spec:
   - host: {{ .Values.apiIngress.hostname }}
     http:
       paths:
-      - path: /{{ .Values.apiIngress.subdomain }}
+      - path: /{{ .Values.apiIngress.subdomain }}/api/v1
         pathType: Prefix
         backend:
           service:
             name: {{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}
             port:
               number: {{ .Values.backend.service.port }}
-      - path: /{{ .Values.apiIngress.subdomain }}
+      - path: /{{ .Values.apiIngress.subdomain }}/api-hub/v1
         pathType: Prefix
         backend:
           service:
-            name: {{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}
+            name: {{ include "langsmith.fullname" . }}-{{ .Values.hubBackend.name }}
             port:
               number: {{ .Values.backend.service.port }}
 {{- end }}

--- a/charts/langsmith/templates/api_ingress.yaml
+++ b/charts/langsmith/templates/api_ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.apiIngress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "langsmith.fullname" . }}-api-ingress
+  annotations:
+    {{- include "langsmith.annotations" . | nindent 4 }}
+    {{- with .Values.apiIngress.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.apiIngress.hostname }}
+  labels:
+    {{- include "langsmith.labels" . | nindent 4 }}
+    {{- with .Values.apiIngress.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.apiIngress.ingressClassName }}
+  {{- with .Values.apiIngress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+  - host: {{ .Values.apiIngress.hostname }}
+    http:
+      paths:
+      - path: /{{ .Values.apiIngress.subdomain }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}
+            port:
+              number: {{ .Values.backend.service.port }}
+      - path: /{{ .Values.apiIngress.subdomain }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}
+            port:
+              number: {{ .Values.backend.service.port }}
+{{- end }}

--- a/charts/langsmith/templates/backend/deployment.yaml
+++ b/charts/langsmith/templates/backend/deployment.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/backend/config-map.yaml") . | sha256sum }}
+        rollme: {{ randAlphaNum 5 | quote }}
       {{- with .Values.backend.deployment.annotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/langsmith/templates/backend/deployment.yaml
+++ b/charts/langsmith/templates/backend/deployment.yaml
@@ -49,11 +49,6 @@ spec:
           {{- end }}
           env:
             {{- include "langsmith.commonEnv" . | nindent 12 }}
-            - name: OPENAI_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "langsmith.secretsName" . }}
-                  key: openai_api_key
             - name: PORT
               value: {{ .Values.backend.containerPort | quote }}
             {{- with .Values.backend.deployment.extraEnv }}

--- a/charts/langsmith/templates/clickhouse/config-map.yaml
+++ b/charts/langsmith/templates/clickhouse/config-map.yaml
@@ -16,7 +16,17 @@ data:
                 <named_collection_control>1</named_collection_control>
                 <show_named_collections>1</show_named_collections>
                 <show_named_collections_secrets>1</show_named_collections_secrets>
+                <profile>default</profile>
             </{{ .Values.clickhouse.external.user }}>
         </users>
+        <profiles>
+            <default>
+                <async_insert>1</async_insert>
+                <async_insert_max_data_size>2000000</async_insert_max_data_size>
+                <deduplicate_blocks_in_dependent_materialized_views>1</deduplicate_blocks_in_dependent_materialized_views>
+                <wait_for_async_insert>0</wait_for_async_insert>
+                <parallel_view_processing>1</parallel_view_processing>
+            </default>
+        </profiles>
     </clickhouse>
 {{- end }}

--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -86,33 +86,6 @@ data:
             index  index.html index.htm;
             try_files $uri $uri/ /{{ .Values.ingress.subdomain }}/index.html;
         }
-
-        {{- if .Values.frontend.cache.enabled }}
-        location ~ /{{ .Values.ingress.subdomain }}/proxy/openai {
-            rewrite /{{ .Values.ingress.subdomain }}/proxy/openai/(.*) /v1/$1  break;
-            proxy_pass {{ .Values.frontend.cache.config.openAIUrl }};
-            proxy_set_header Host api.openai.com;
-
-
-            proxy_set_header Connection '';
-            proxy_ignore_headers Cache-Control;
-            proxy_ignore_headers "Set-Cookie";
-
-            proxy_buffer_size   2k;
-
-            proxy_cache llm_cache;
-            proxy_cache_methods POST;
-            proxy_cache_key "{{ .Values.frontend.cache.config.openAIUrl }}|$request_method|$request_uri|$request_body";
-            proxy_cache_valid 200 302 10m;
-            proxy_cache_valid 404      1m;
-            proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
-            proxy_cache_background_update on;
-
-            add_header X-Cache-Status $upstream_cache_status;
-            client_body_buffer_size 4m;
-            access_log /dev/stdout cache_log;
-        }
-        {{- end }}
     }
 {{- else }}
   nginx.conf: |
@@ -186,32 +159,5 @@ data:
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}:{{ .Values.backend.service.port }};
        }
-
-        {{- if .Values.frontend.cache.enabled }}
-        location ~ /proxy/openai {
-            rewrite /proxy/openai/(.*) /v1/$1  break;
-            proxy_pass {{ .Values.frontend.cache.config.openAIUrl }};
-            proxy_set_header Host api.openai.com;
-
-
-            proxy_set_header Connection '';
-            proxy_ignore_headers Cache-Control;
-            proxy_ignore_headers "Set-Cookie";
-
-            proxy_buffer_size   2k;
-
-            proxy_cache llm_cache;
-            proxy_cache_methods POST;
-            proxy_cache_key "{{ .Values.frontend.cache.config.openAIUrl }}|$request_method|$request_uri|$request_body";
-            proxy_cache_valid 200 302 10m;
-            proxy_cache_valid 404      1m;
-            proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
-            proxy_cache_background_update on;
-
-            add_header X-Cache-Status $upstream_cache_status;
-            client_body_buffer_size 4m;
-            access_log /dev/stdout cache_log;
-        }
-        {{- end }}
       }
 {{- end }}

--- a/charts/langsmith/templates/frontend/deployment.yaml
+++ b/charts/langsmith/templates/frontend/deployment.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/frontend/config-map.yaml") . | sha256sum }}
+        rollme: {{ randAlphaNum 5 | quote }}
       {{- with .Values.frontend.deployment.annotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/langsmith/templates/hub-backend/deployment.yaml
+++ b/charts/langsmith/templates/hub-backend/deployment.yaml
@@ -22,8 +22,9 @@ spec:
       app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.hubBackend.name }}
   template:
     metadata:
-      {{- with .Values.hubBackend.deployment.annotations }}
       annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
+      {{- with .Values.hubBackend.deployment.annotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/charts/langsmith/templates/playground/deployment.yaml
+++ b/charts/langsmith/templates/playground/deployment.yaml
@@ -22,8 +22,9 @@ spec:
       app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.playground.name }}
   template:
     metadata:
-      {{- with .Values.playground.deployment.annotations }}
       annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
+      {{- with .Values.playground.deployment.annotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/charts/langsmith/templates/queue/deployment.yaml
+++ b/charts/langsmith/templates/queue/deployment.yaml
@@ -22,8 +22,9 @@ spec:
       app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.queue.name }}
   template:
     metadata:
-      {{- with .Values.queue.deployment.annotations }}
       annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
+      {{- with .Values.queue.deployment.annotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/charts/langsmith/templates/queue/deployment.yaml
+++ b/charts/langsmith/templates/queue/deployment.yaml
@@ -49,6 +49,10 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
+            - name: "REDIS_MAX_CONNECTIONS"
+              value: "250"
+            - name: "ASYNCPG_POOL_MAX_SIZE"
+              value: "3"
             {{- include "langsmith.commonEnv" . | nindent 12 }}
             {{- with .Values.queue.deployment.extraEnv }}
               {{- toYaml . | nindent 12 }}

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -15,15 +15,15 @@ images:
   backendImage:
     repository: "docker.io/langchain/langchainplus-backend"
     pullPolicy: IfNotPresent
-    tag: "d2c7513"
+    tag: "0.1.18"
   frontendImage:
     repository: "docker.io/langchain/langchainplus-frontend-dynamic"
     pullPolicy: IfNotPresent
-    tag: "d2c7513"
+    tag: "0.1.18"
   hubBackendImage:
     repository: "docker.io/langchain/langchainhub-backend"
     pullPolicy: IfNotPresent
-    tag: "d2c7513"
+    tag: "0.1.18"
   playgroundImage:
     repository: "docker.io/langchain/langchainplus-playground"
     pullPolicy: IfNotPresent
@@ -198,6 +198,7 @@ clickhouse:
     affinity: {}
     volumes: []
     volumeMounts: []
+    # We recommend using a persistent volume and increasing the storage size to something like 50Gi when using in a persistent environment!
     persistence:
       size: 8Gi
       storageClassName: ""
@@ -219,11 +220,6 @@ frontend:
   name: "frontend"
   containerPort: 8080
   existingConfigMapName: ""
-  # Turn on LLM Proxy Cache
-  cache:
-    enabled: true
-    config:
-      openAIUrl: "https://api.openai.com"
   deployment:
     replicas: 1
     labels: {}
@@ -425,25 +421,15 @@ queue:
     securityContext: {}
     resources: {}
 #      limits:
-#        cpu: 1000m
-#        memory: 1Gi
+#        cpu: 2000m
+#        memory: 4Gi
 #      requests:
-#        cpu: 200m
-#        memory: 500Mi
+#        cpu: 1000m
+#        memory: 2000Mi
     command:
-      - "rq"
-      - "worker"
-      - "--with-scheduler"
-      - "-u"
-      - "$(REDIS_DATABASE_URI)"
-      - "--serializer"
-      - "lc_database.queue.serializer.ORJSONSerializer"
-      - "--worker-class"
-      - "lc_database.queue.worker.Worker"
-      - "--connection-class"
-      - "lc_database.queue.connection.RedisRetry"
-      - "--job-class"
-      - "lc_database.queue.job.AsyncJob"
+      - "saq"
+      - "app.async_worker.settings"
+      - "--quiet"
     extraContainerConfig: {}
     extraEnv: []
     sidecars: []

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -15,19 +15,19 @@ images:
   backendImage:
     repository: "docker.io/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
-    tag: "0.1.18"
+    tag: "0.1.19"
   frontendImage:
     repository: "docker.io/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
-    tag: "0.1.18"
+    tag: "0.1.19"
   hubBackendImage:
     repository: "docker.io/langchain/langhub-backend"
     pullPolicy: IfNotPresent
-    tag: "0.1.18"
+    tag: "0.1.19"
   playgroundImage:
     repository: "docker.io/langchain/langsmith-playground"
     pullPolicy: IfNotPresent
-    tag: "0.1.18"
+    tag: "0.1.19"
   postgresImage:
     repository: "docker.io/postgres"
     pullPolicy: IfNotPresent

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -42,12 +42,21 @@ images:
     tag: "23.9"
 
 ingress:
+  enabled: false
   hostname: ""
   subdomain: ""
-  enabled: false
   ingressClassName: ""
   annotations: {}
   labels: {}
+  tls: []
+
+apiIngress:
+  enabled: false
+  hostname: ""
+  subdomain: ""
+  ingressClassName: ""
+  annotations: { }
+  labels: { }
   tls: []
 
 config:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -13,21 +13,21 @@ images:
    # -- Secrets with credentials to pull images from a private registry. Specified as name: value.
   imagePullSecrets: []
   backendImage:
-    repository: "docker.io/langchain/langchainplus-backend"
+    repository: "docker.io/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
     tag: "0.1.18"
   frontendImage:
-    repository: "docker.io/langchain/langchainplus-frontend-dynamic"
+    repository: "docker.io/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
     tag: "0.1.18"
   hubBackendImage:
-    repository: "docker.io/langchain/langchainhub-backend"
+    repository: "docker.io/langchain/langhub-backend"
     pullPolicy: IfNotPresent
     tag: "0.1.18"
   playgroundImage:
-    repository: "docker.io/langchain/langchainplus-playground"
+    repository: "docker.io/langchain/langsmith-playground"
     pullPolicy: IfNotPresent
-    tag: "d2c7513"
+    tag: "0.1.18"
   postgresImage:
     repository: "docker.io/postgres"
     pullPolicy: IfNotPresent
@@ -55,8 +55,8 @@ apiIngress:
   hostname: ""
   subdomain: ""
   ingressClassName: ""
-  annotations: { }
-  labels: { }
+  annotations: {}
+  labels: {}
   tls: []
 
 config:
@@ -190,11 +190,11 @@ clickhouse:
     securityContext: {}
     resources: {}
     #      limits:
-    #        cpu: 4000m
-    #        memory: 16Gi
+    #        cpu: 5000m
+    #        memory: 20Gi
     #      requests:
-    #        cpu: 1000m
-    #        memory: 4Gi
+    #        cpu: 3000m
+    #        memory: 12Gi
     command:
       - "/bin/bash"
       - "-c"
@@ -207,7 +207,7 @@ clickhouse:
     affinity: {}
     volumes: []
     volumeMounts: []
-    # We recommend using a persistent volume and increasing the storage size to something like 50Gi when using in a persistent environment!
+    # We recommend using a persistent volume and increasing the storage size to something like 50Gi when using in a production environment!
     persistence:
       size: 8Gi
       storageClassName: ""
@@ -404,7 +404,6 @@ postgres:
     volumes: []
     volumeMounts: []
     persistence:
-      enabled: false
       size: 8Gi
       storageClassName: ""
   service:


### PR DESCRIPTION
Bump to 0.1.18 and add a bunch of examples. Swap to SAQ.