### PR TITLE
Add options for TTL

### DIFF
--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -200,19 +200,13 @@ Template containing common environment variables that are used by several servic
       key: openai_api_key
 - name: GO_ENDPOINT
   value: http://{{- include "langsmith.fullname" . }}-{{.Values.platformBackend.name}}:{{ .Values.platformBackend.service.port }}
-{{- if .Values.config.ttl }}
-{{- if .Values.config.ttl.enabled }}
 - name: FF_TRACE_TIERS_ENABLED
-  value: true
-{{- if .Values.config.ttl.upgrade_enabled }}
+  value: {{ .Values.config.ttl.enabled }}
 - name: FF_UPGRADE_TRACE_TIER_ENABLED
-  value: true
-{{- end }}
-{{- if .Values.config.ttl.ttl_period_seconds }}
+  value: {{ .Values.config.ttl.upgrade_enabled }}
+{{- if .Values.config.ttl.enabled }}
 - name: TRACE_TIER_TTL_DURATION_SEC_MAP
   value: "{ \"longlived\": {{ .Values.config.ttl.ttl_period_seconds.longlived }}, \"shortlived\": {{ .Values.config.ttl.ttl_period_seconds.shortlived }} }"
-{{- end }}
-{{- end }}
 {{- end }}
 - name: FF_ORG_CREATION_DISABLED
   value: {{ .Values.config.orgCreationDisabled | quote }}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -203,10 +203,10 @@ Template containing common environment variables that are used by several servic
 {{- if .Values.config.ttl }}
 {{- if .Values.config.ttl.enabled }}
 - name: FF_TRACE_TIERS_ENABLED
-  value: "true"
+  value: true
 {{- if .Values.config.ttl.upgrade_enabled }}
 - name: FF_UPGRADE_TRACE_TIER_ENABLED
-  value: "true"
+  value: true
 {{- end }}
 {{- if .Values.config.ttl.ttl_period_seconds }}
 - name: TRACE_TIER_TTL_DURATION_SEC_MAP

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -201,9 +201,9 @@ Template containing common environment variables that are used by several servic
 - name: GO_ENDPOINT
   value: http://{{- include "langsmith.fullname" . }}-{{.Values.platformBackend.name}}:{{ .Values.platformBackend.service.port }}
 - name: FF_TRACE_TIERS_ENABLED
-  value: {{ .Values.config.ttl.enabled }}
+  value: {{ .Values.config.ttl.enabled | quote }}
 - name: FF_UPGRADE_TRACE_TIER_ENABLED
-  value: {{ .Values.config.ttl.upgrade_enabled }}
+  value: {{ .Values.config.ttl.upgrade_enabled | quote}}
 {{- if .Values.config.ttl.enabled }}
 - name: TRACE_TIER_TTL_DURATION_SEC_MAP
   value: "{ \"longlived\": {{ .Values.config.ttl.ttl_period_seconds.longlived }}, \"shortlived\": {{ .Values.config.ttl.ttl_period_seconds.shortlived }} }"

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -200,6 +200,20 @@ Template containing common environment variables that are used by several servic
       key: openai_api_key
 - name: GO_ENDPOINT
   value: http://{{- include "langsmith.fullname" . }}-{{.Values.platformBackend.name}}:{{ .Values.platformBackend.service.port }}
+{{- if .Values.config.ttl }}
+{{- if .Values.config.ttl.enabled }}
+- name: FF_TRACE_TIERS_ENABLED
+  value: "true"
+{{- if .Values.config.ttl.upgrade_enabled }}
+- name: FF_UPGRADE_TRACE_TIER_ENABLED
+  value: "true"
+{{- end }}
+{{- if .Values.config.ttl.ttl_period_seconds }}
+- name: TRACE_TIER_TTL_DURATION_SEC_MAP
+  value: "{ \"longlived\": {{ .Values.config.ttl.ttl_period_seconds.longlived }}, \"shortlived\": {{ .Values.config.ttl.ttl_period_seconds.shortlived }} }"
+{{- end }}
+{{- end }}
+{{- end }}
 - name: FF_ORG_CREATION_DISABLED
   value: {{ .Values.config.orgCreationDisabled | quote }}
 {{- end }}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -203,7 +203,7 @@ Template containing common environment variables that are used by several servic
 - name: FF_TRACE_TIERS_ENABLED
   value: {{ .Values.config.ttl.enabled | quote }}
 - name: FF_UPGRADE_TRACE_TIER_ENABLED
-  value: {{ .Values.config.ttl.upgrade_enabled | quote}}
+  value: {{ .Values.config.ttl.upgrade_enabled | quote }}
 {{- if .Values.config.ttl.enabled }}
 - name: TRACE_TIER_TTL_DURATION_SEC_MAP
   value: "{ \"longlived\": {{ .Values.config.ttl.ttl_period_seconds.longlived }}, \"shortlived\": {{ .Values.config.ttl.ttl_period_seconds.shortlived }} }"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -72,6 +72,13 @@ config:
     enabled: false
     oauthClientId: ""
     oauthIssuerUrl: ""
+  ttl:
+    enabled: false
+    upgrade_enabled: false
+    ttl_period_seconds:
+      # -- 400 day longlived and 14 day shortlived
+      longlived: "34560000"
+      shortlived: "1209600"
 
 backend:
   name: "backend"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -74,6 +74,7 @@ config:
     oauthIssuerUrl: ""
   ttl:
     enabled: false
+    # -- If upgrade is enabled traces will be upgraded to longlived on certain actions
     upgrade_enabled: false
     ttl_period_seconds:
       # -- 400 day longlived and 14 day shortlived


### PR DESCRIPTION
```
config:
  ttl:
    enabled: true
    upgrade_enabled: true
    ttl_period_seconds:
      longlived: <ll_seconds>
      shortlived: <sl_seconds>
```

To set:
```
 - name: FF_TRACE_TIERS_ENABLED
    value: "true"
  - name: FF_UPGRADE_TRACE_TIER_ENABLED
    value: "true"
  - name: TRACE_TIER_TTL_DURATION_SEC_MAP
    value: "{ \"longlived\": 1234, \"shortlived\": 567 }"
```