### PR TITLE
feat: prevent duplicate env var keys

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.7.11
+version: 0.7.10
 appVersion: "0.7.45"

--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.7.10
+version: 0.7.11
 appVersion: "0.7.45"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.7.10](https://img.shields.io/badge/Version-0.7.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.45](https://img.shields.io/badge/AppVersion-0.7.45-informational?style=flat-square)
+![Version: 0.7.11](https://img.shields.io/badge/Version-0.7.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.45](https://img.shields.io/badge/AppVersion-0.7.45-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -376,7 +376,7 @@ Template containing common environment variables that are used by several servic
 
     # If the variable is not found in .Values.commonEnv, render it
     {{- if not $found }}
-      {{ $envVar | toYaml }}
+      {{ $envVar | toYaml | nindent 2 }}
     {{- end }}
   {{- end }}
 {{- end -}}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -263,7 +263,7 @@ Template containing common environment variables that are used by several servic
 {{- end }}
 - name: FF_CH_SEARCH_ENABLED
   value: {{ .Values.config.blobStorage.chSearchEnabled | quote }}
-{{- include "langsmith.conditionalEnvVarsResolved" . -}}
+{{ include "langsmith.conditionalEnvVarsResolved" . }}
 {{- end }}
 
 {{- define "backend.serviceAccountName" -}}
@@ -360,7 +360,7 @@ Template containing common environment variables that are used by several servic
     secretKeyRef:
       name: {{ include "langsmith.secretsName" . }}
       key: api_key_salt
-{{- end -}}
+{{- end }}
 {{- define "langsmith.conditionalEnvVarsResolved" -}}
   {{- $values := .Values -}}
   {{- $envVars := include "langsmith.conditionalEnvVars" . | fromYamlArray -}}
@@ -379,4 +379,4 @@ Template containing common environment variables that are used by several servic
       {{ $envVar | toYaml | nindent 2 }}
     {{- end }}
   {{- end }}
-{{- end -}}
+{{- end }}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -356,7 +356,7 @@ Template containing common environment variables that are used by several servic
 {{- end -}}
 {{- end -}}
 
-{{/* Fail on duplicate keys in the inputted list on environment variables */}}
+{{/* Fail on duplicate keys in the inputted list of environment variables */}}
 {{- define "langsmith.detectDuplicates" -}}
 {{- $inputList := . -}}
 {{- $keyCounts := dict -}}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -335,7 +335,7 @@ Template containing common environment variables that are used by several servic
 {{- end -}}
 
 {{/* Fail on duplicate keys in the inputted list on environment variables */}}
-{{- define "langsmith-multitenant.detectDuplicates" -}}
+{{- define "langsmith.detectDuplicates" -}}
 {{- $inputList := . -}}
 {{- $keyCounts := dict -}}
 {{- $duplicates := list -}}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -333,3 +333,23 @@ Template containing common environment variables that are used by several servic
     {{ default "default" .Values.redis.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/* Fail on duplicate keys in the inputted list */}}
+{{- define "langsmith.detectDuplicates" -}}
+{{- $inputList := . }}
+{{- $duplicates := list -}}
+{{- range $key := $inputList }}
+  {{- $count := 0 -}}
+  {{- range $inputList }}
+    {{- if eq $key . }}
+      {{- $count = add $count 1 -}}
+    {{- end }}
+  {{- end }}
+  {{- if and (eq $count 2) (not (has $key $duplicates)) }}  # Add the key to duplicates if count is greater than 1
+    {{- $duplicates = append $duplicates $key -}}
+  {{- end }}
+{{- end }}
+{{- if gt (len $duplicates) 0 }}
+  {{ fail (printf "Duplicate keys detected: %v" $duplicates) }}
+{{- end }}
+{{- end -}}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -336,19 +336,21 @@ Template containing common environment variables that are used by several servic
 
 {{/* Fail on duplicate keys in the inputted list */}}
 {{- define "langsmith.detectDuplicates" -}}
-{{- $inputList := . }}
+{{- $inputList := . -}}
+{{- $keyCounts := dict -}}
 {{- $duplicates := list -}}
+
 {{- range $key := $inputList }}
-  {{- $count := 0 -}}
-  {{- range $inputList }}
-    {{- if eq $key . }}
-      {{- $count = add $count 1 -}}
-    {{- end }}
+  {{- if hasKey $keyCounts $key }}
+    {{- $_ := set $keyCounts $key (add (get $keyCounts $key) 1) -}}
+  {{- else }}
+    {{- $_ := set $keyCounts $key 1 -}}
   {{- end }}
-  {{- if and (eq $count 2) (not (has $key $duplicates)) }}  # Add the key to duplicates if count is greater than 1
+  {{- if gt (get $keyCounts $key) 1 }}
     {{- $duplicates = append $duplicates $key -}}
   {{- end }}
 {{- end }}
+
 {{- if gt (len $duplicates) 0 }}
   {{ fail (printf "Duplicate keys detected: %v" $duplicates) }}
 {{- end }}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -227,6 +227,19 @@ Template containing common environment variables that are used by several servic
   value: http://{{- include "langsmith.fullname" . }}-{{.Values.platformBackend.name}}:{{ .Values.platformBackend.service.port }}
 - name: SMITH_BACKEND_ENDPOINT
   value: http://{{- include "langsmith.fullname" . }}-{{.Values.backend.name}}:{{ .Values.backend.service.port }}
+{{- $found := false -}}
+{{- range .Values.commonEnv }}
+  {{- if eq .name "X_SERVICE_AUTH_JWT_SECRET" }}
+    {{- $found = true -}}
+  {{- end }}
+{{- end }}
+{{- if not $found }}
+- name: X_SERVICE_AUTH_JWT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "langsmith.secretsName" . }}
+      key: api_key_salt
+{{- end }}
 {{- if .Values.config.ttl.enabled }}
 - name: FF_TRACE_TIERS_ENABLED
   value: {{ .Values.config.ttl.enabled | quote }}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -227,11 +227,6 @@ Template containing common environment variables that are used by several servic
   value: http://{{- include "langsmith.fullname" . }}-{{.Values.platformBackend.name}}:{{ .Values.platformBackend.service.port }}
 - name: SMITH_BACKEND_ENDPOINT
   value: http://{{- include "langsmith.fullname" . }}-{{.Values.backend.name}}:{{ .Values.backend.service.port }}
-- name: X_SERVICE_AUTH_JWT_SECRET
-  valueFrom:
-    secretKeyRef:
-      name: {{ include "langsmith.secretsName" . }}
-      key: api_key_salt
 {{- if .Values.config.ttl.enabled }}
 - name: FF_TRACE_TIERS_ENABLED
   value: {{ .Values.config.ttl.enabled | quote }}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -362,20 +362,13 @@ Template containing common environment variables that are used by several servic
       key: api_key_salt
 {{- end }}
 {{- define "langsmith.conditionalEnvVarsResolved" -}}
-  {{- $values := .Values -}}
+  {{- $commonEnvKeys := list -}}
+  {{- range $i, $commonEnvVar := .Values.commonEnv -}}
+    {{- $commonEnvKeys = append $commonEnvKeys $commonEnvVar.name -}}
+  {{- end -}}
   {{- $envVars := include "langsmith.conditionalEnvVars" . | fromYamlArray -}}
-
   {{- range $i, $envVar := $envVars }}
-    {{- $found := false -}}
-
-    {{- range $values.commonEnv }}
-      {{- if eq .name $envVar.name }}
-        {{- $found = true -}}
-      {{- end }}
-    {{- end }}
-
-    # If the variable is not found in .Values.commonEnv, render it
-    {{- if not $found }}
+    {{- if not (has $envVar.name $commonEnvKeys) }}
       {{ $envVar | toYaml | nindent 2 }}
     {{- end }}
   {{- end }}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -334,13 +334,14 @@ Template containing common environment variables that are used by several servic
 {{- end -}}
 {{- end -}}
 
-{{/* Fail on duplicate keys in the inputted list */}}
-{{- define "langsmith.detectDuplicates" -}}
+{{/* Fail on duplicate keys in the inputted list on environment variables */}}
+{{- define "langsmith-multitenant.detectDuplicates" -}}
 {{- $inputList := . -}}
 {{- $keyCounts := dict -}}
 {{- $duplicates := list -}}
 
-{{- range $key := $inputList }}
+{{- range $i, $val := $inputList }}
+  {{- $key := $val.name -}}
   {{- if hasKey $keyCounts $key }}
     {{- $_ := set $keyCounts $key (add (get $keyCounts $key) 1) -}}
   {{- else }}

--- a/charts/langsmith/templates/backend/auth-bootstrap.yaml
+++ b/charts/langsmith/templates/backend/auth-bootstrap.yaml
@@ -1,4 +1,21 @@
+{{- define "authBootstrapEnvVars" -}}
+- name: INITIAL_ORG_ADMIN_EMAIL
+  value: {{ .Values.config.basicAuth.initialOrgAdminEmail }}
+- name: INITIAL_ORG_ADMIN_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "langsmith.secretsName" . }}
+      key: initial_org_admin_password
+{{- end -}}
 {{- if .Values.config.basicAuth.enabled }}
+{{- $envVars := concat (include "langsmith.commonEnv" . | fromYamlArray) (include "authBootstrapEnvVars" . | fromYamlArray) .Values.backend.authBootstrap.extraEnv -}}
+{{- $envKeys := list -}}
+{{- range $envVars }}
+  {{- $envKeys = append $envKeys .name -}}
+{{- end }}
+{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
+  {{ fail "Environment variables cannot contain duplicate keys" }}
+{{- end -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -47,15 +64,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- include "langsmith.commonEnv" . | nindent 12 }}
-            - name: INITIAL_ORG_ADMIN_EMAIL
-              value: {{ .Values.config.basicAuth.initialOrgAdminEmail }}
-            - name: INITIAL_ORG_ADMIN_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "langsmith.secretsName" . }}
-                  key: initial_org_admin_password
-            {{- with .Values.backend.authBootstrap.extraEnv }}
+            {{- with $envVars }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:

--- a/charts/langsmith/templates/backend/auth-bootstrap.yaml
+++ b/charts/langsmith/templates/backend/auth-bootstrap.yaml
@@ -13,9 +13,7 @@
 {{- range $envVars }}
   {{- $envKeys = append $envKeys .name -}}
 {{- end }}
-{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
-  {{ fail "Environment variables cannot contain duplicate keys" }}
-{{- end -}}
+{{- include "langsmith.detectDuplicates" $envKeys -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/langsmith/templates/backend/auth-bootstrap.yaml
+++ b/charts/langsmith/templates/backend/auth-bootstrap.yaml
@@ -8,12 +8,7 @@
       key: initial_org_admin_password
 {{- end -}}
 {{- if .Values.config.basicAuth.enabled }}
-{{- $envVars := concat (include "langsmith.commonEnv" . | fromYamlArray) (include "authBootstrapEnvVars" . | fromYamlArray) .Values.backend.authBootstrap.extraEnv -}}
-{{- $envKeys := list -}}
-{{- range $envVars }}
-  {{- $envKeys = append $envKeys .name -}}
-{{- end }}
-{{- include "langsmith.detectDuplicates" $envKeys -}}
+{{- $envVars := concat (include "langsmith.commonEnv" . | fromYamlArray) (include "authBootstrapEnvVars" . | fromYamlArray) .Values.backend.authBootstrap.extraEnv -}}{{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/langsmith/templates/backend/auth-bootstrap.yaml
+++ b/charts/langsmith/templates/backend/auth-bootstrap.yaml
@@ -8,7 +8,8 @@
       key: initial_org_admin_password
 {{- end -}}
 {{- if .Values.config.basicAuth.enabled }}
-{{- $envVars := concat (include "langsmith.commonEnv" . | fromYamlArray) (include "authBootstrapEnvVars" . | fromYamlArray) .Values.backend.authBootstrap.extraEnv -}}{{- include "langsmith.detectDuplicates" $envVars -}}
+{{- $envVars := concat (include "langsmith.commonEnv" . | fromYamlArray) (include "authBootstrapEnvVars" . | fromYamlArray) .Values.backend.authBootstrap.extraEnv -}}
+{{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/langsmith/templates/backend/clickhouse-migrations.yaml
+++ b/charts/langsmith/templates/backend/clickhouse-migrations.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.backend.clickhouseMigrations.enabled }}
-{{- $envVars := concat (include "langsmith.commonEnv" . | fromYamlArray) .Values.backend.clickhouseMigrations.extraEnv -}}{{- include "langsmith.detectDuplicates" $envVars -}}
+{{- $envVars := concat (include "langsmith.commonEnv" . | fromYamlArray) .Values.backend.clickhouseMigrations.extraEnv -}}
+{{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/langsmith/templates/backend/clickhouse-migrations.yaml
+++ b/charts/langsmith/templates/backend/clickhouse-migrations.yaml
@@ -1,4 +1,12 @@
 {{- if .Values.backend.clickhouseMigrations.enabled }}
+{{- $envVars := concat (include "langsmith.commonEnv" . | fromYamlArray) (include "clickhouseMigrationsEnvVars" . | fromYamlArray) .Values.backend.clickhouseMigrations.extraEnv -}}
+{{- $envKeys := list -}}
+{{- range $envVars }}
+  {{- $envKeys = append $envKeys .name -}}
+{{- end }}
+{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
+  {{ fail "Environment variables cannot contain duplicate keys" }}
+{{- end -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -47,8 +55,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- include "langsmith.commonEnv" . | nindent 12 }}
-            {{- with .Values.backend.clickhouseMigrations.extraEnv }}
+            {{- with $envVars }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:

--- a/charts/langsmith/templates/backend/clickhouse-migrations.yaml
+++ b/charts/langsmith/templates/backend/clickhouse-migrations.yaml
@@ -1,10 +1,5 @@
 {{- if .Values.backend.clickhouseMigrations.enabled }}
-{{- $envVars := concat (include "langsmith.commonEnv" . | fromYamlArray) .Values.backend.clickhouseMigrations.extraEnv -}}
-{{- $envKeys := list -}}
-{{- range $envVars }}
-  {{- $envKeys = append $envKeys .name -}}
-{{- end }}
-{{- include "langsmith.detectDuplicates" $envKeys -}}
+{{- $envVars := concat (include "langsmith.commonEnv" . | fromYamlArray) .Values.backend.clickhouseMigrations.extraEnv -}}{{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/langsmith/templates/backend/clickhouse-migrations.yaml
+++ b/charts/langsmith/templates/backend/clickhouse-migrations.yaml
@@ -4,9 +4,21 @@
 {{- range $envVars }}
   {{- $envKeys = append $envKeys .name -}}
 {{- end }}
-{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
-  {{ fail "Environment variables cannot contain duplicate keys" }}
-{{- end -}}
+{{- $duplicates := list -}}
+{{- range $key := $envKeys }}
+  {{- $count := 0 -}}
+  {{- range $envKeys }}
+    {{- if eq $key . }}
+      {{- $count = add $count 1 -}}
+    {{- end }}
+  {{- end }}
+  {{- if and (eq $count 2) (not (has $key $duplicates)) }}  # Add the key to duplicates if count is greater than 1
+    {{- $duplicates = append $duplicates $key -}}
+  {{- end }}
+{{- end }}
+{{- if gt (len $duplicates) 0 }}
+  {{ fail (printf "Environment variables contain duplicate keys: %v" $duplicates) }}
+{{- end }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/langsmith/templates/backend/clickhouse-migrations.yaml
+++ b/charts/langsmith/templates/backend/clickhouse-migrations.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.backend.clickhouseMigrations.enabled }}
-{{- $envVars := concat (include "langsmith.commonEnv" . | fromYamlArray) (include "clickhouseMigrationsEnvVars" . | fromYamlArray) .Values.backend.clickhouseMigrations.extraEnv -}}
+{{- $envVars := concat (include "langsmith.commonEnv" . | fromYamlArray) .Values.backend.clickhouseMigrations.extraEnv -}}
 {{- $envKeys := list -}}
 {{- range $envVars }}
   {{- $envKeys = append $envKeys .name -}}

--- a/charts/langsmith/templates/backend/clickhouse-migrations.yaml
+++ b/charts/langsmith/templates/backend/clickhouse-migrations.yaml
@@ -4,21 +4,7 @@
 {{- range $envVars }}
   {{- $envKeys = append $envKeys .name -}}
 {{- end }}
-{{- $duplicates := list -}}
-{{- range $key := $envKeys }}
-  {{- $count := 0 -}}
-  {{- range $envKeys }}
-    {{- if eq $key . }}
-      {{- $count = add $count 1 -}}
-    {{- end }}
-  {{- end }}
-  {{- if and (eq $count 2) (not (has $key $duplicates)) }}  # Add the key to duplicates if count is greater than 1
-    {{- $duplicates = append $duplicates $key -}}
-  {{- end }}
-{{- end }}
-{{- if gt (len $duplicates) 0 }}
-  {{ fail (printf "Environment variables contain duplicate keys: %v" $duplicates) }}
-{{- end }}
+{{- include "langsmith.detectDuplicates" $envKeys -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/langsmith/templates/backend/deployment.yaml
+++ b/charts/langsmith/templates/backend/deployment.yaml
@@ -6,7 +6,8 @@
   value: /{{ . }}/api
 {{- end }}
 {{- end -}}
-{{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "backendEnvVars" . | fromYamlArray) .Values.backend.deployment.extraEnv -}}{{- include "langsmith.detectDuplicates" $envVars -}}
+{{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "backendEnvVars" . | fromYamlArray) .Values.backend.deployment.extraEnv -}}
+  {{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/langsmith/templates/backend/deployment.yaml
+++ b/charts/langsmith/templates/backend/deployment.yaml
@@ -6,12 +6,7 @@
   value: /{{ . }}/api
 {{- end }}
 {{- end -}}
-{{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "backendEnvVars" . | fromYamlArray) .Values.backend.deployment.extraEnv -}}
-{{- $envKeys := list -}}
-{{- range $envVars }}
-  {{- $envKeys = append $envKeys .name -}}
-{{- end }}
-{{- include "langsmith.detectDuplicates" $envKeys -}}
+{{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "backendEnvVars" . | fromYamlArray) .Values.backend.deployment.extraEnv -}}{{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/langsmith/templates/backend/deployment.yaml
+++ b/charts/langsmith/templates/backend/deployment.yaml
@@ -7,7 +7,7 @@
 {{- end }}
 {{- end -}}
 {{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "backendEnvVars" . | fromYamlArray) .Values.backend.deployment.extraEnv -}}
-  {{- include "langsmith.detectDuplicates" $envVars -}}
+{{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/langsmith/templates/backend/deployment.yaml
+++ b/charts/langsmith/templates/backend/deployment.yaml
@@ -1,3 +1,19 @@
+{{- define "backendEnvVars" -}}
+- name: PORT
+  value: {{ .Values.backend.containerPort | quote }}
+{{- with .Values.ingress.subdomain }}
+- name: DOCS_PREFIX
+  value: /{{ . }}/api
+{{- end }}
+{{- end -}}
+{{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "backendEnvVars" . | fromYamlArray) .Values.backend.deployment.extraEnv -}}
+{{- $envKeys := list -}}
+{{- range $envVars }}
+  {{- $envKeys = append $envKeys .name -}}
+{{- end }}
+{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
+  {{ fail "Environment variables cannot contain duplicate keys" }}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,18 +66,8 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- include "langsmith.commonEnv" . | nindent 12 }}
-            - name: PORT
-              value: {{ .Values.backend.containerPort | quote }}
-            {{- with .Values.ingress.subdomain }}
-            - name: DOCS_PREFIX
-              value: /{{ . }}/api
-            {{- end }}
-            {{- with .Values.backend.deployment.extraEnv }}
+            {{- with $envVars }}
               {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.commonEnv }}
-              {{ toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
             - configMapRef:

--- a/charts/langsmith/templates/backend/deployment.yaml
+++ b/charts/langsmith/templates/backend/deployment.yaml
@@ -11,21 +11,7 @@
 {{- range $envVars }}
   {{- $envKeys = append $envKeys .name -}}
 {{- end }}
-{{- $duplicates := list -}}
-{{- range $key := $envKeys }}
-  {{- $count := 0 -}}
-  {{- range $envKeys }}
-    {{- if eq $key . }}
-      {{- $count = add $count 1 -}}
-    {{- end }}
-  {{- end }}
-  {{- if and (eq $count 2) (not (has $key $duplicates)) }}  # Add the key to duplicates if count is greater than 1
-    {{- $duplicates = append $duplicates $key -}}
-  {{- end }}
-{{- end }}
-{{- if gt (len $duplicates) 0 }}
-  {{ fail (printf "Environment variables contain duplicate keys: %v" $duplicates) }}
-{{- end }}
+{{- include "langsmith.detectDuplicates" $envKeys -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/langsmith/templates/backend/deployment.yaml
+++ b/charts/langsmith/templates/backend/deployment.yaml
@@ -11,9 +11,21 @@
 {{- range $envVars }}
   {{- $envKeys = append $envKeys .name -}}
 {{- end }}
-{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
-  {{ fail "Environment variables cannot contain duplicate keys" }}
-{{- end -}}
+{{- $duplicates := list -}}
+{{- range $key := $envKeys }}
+  {{- $count := 0 -}}
+  {{- range $envKeys }}
+    {{- if eq $key . }}
+      {{- $count = add $count 1 -}}
+    {{- end }}
+  {{- end }}
+  {{- if and (eq $count 2) (not (has $key $duplicates)) }}  # Add the key to duplicates if count is greater than 1
+    {{- $duplicates = append $duplicates $key -}}
+  {{- end }}
+{{- end }}
+{{- if gt (len $duplicates) 0 }}
+  {{ fail (printf "Environment variables contain duplicate keys: %v" $duplicates) }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/langsmith/templates/backend/postgres-migrations.yaml
+++ b/charts/langsmith/templates/backend/postgres-migrations.yaml
@@ -4,9 +4,7 @@
 {{- range $envVars }}
   {{- $envKeys = append $envKeys .name -}}
 {{- end }}
-{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
-  {{ fail "Environment variables cannot contain duplicate keys" }}
-{{- end -}}
+{{- include "langsmith.detectDuplicates" $envKeys -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/langsmith/templates/backend/postgres-migrations.yaml
+++ b/charts/langsmith/templates/backend/postgres-migrations.yaml
@@ -1,4 +1,12 @@
 {{- if .Values.backend.migrations.enabled }}
+{{- $envVars := concat (include "langsmith.commonEnv" . | fromYamlArray) .Values.backend.migrations.extraEnv -}}
+{{- $envKeys := list -}}
+{{- range $envVars }}
+  {{- $envKeys = append $envKeys .name -}}
+{{- end }}
+{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
+  {{ fail "Environment variables cannot contain duplicate keys" }}
+{{- end -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -47,8 +55,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- include "langsmith.commonEnv" . | nindent 12 }}
-            {{- with .Values.backend.migrations.extraEnv }}
+            {{- with $envVars }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:

--- a/charts/langsmith/templates/backend/postgres-migrations.yaml
+++ b/charts/langsmith/templates/backend/postgres-migrations.yaml
@@ -1,10 +1,5 @@
 {{- if .Values.backend.migrations.enabled }}
-{{- $envVars := concat (include "langsmith.commonEnv" . | fromYamlArray) .Values.backend.migrations.extraEnv -}}
-{{- $envKeys := list -}}
-{{- range $envVars }}
-  {{- $envKeys = append $envKeys .name -}}
-{{- end }}
-{{- include "langsmith.detectDuplicates" $envKeys -}}
+{{- $envVars := concat (include "langsmith.commonEnv" . | fromYamlArray) .Values.backend.migrations.extraEnv -}}{{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/langsmith/templates/backend/postgres-migrations.yaml
+++ b/charts/langsmith/templates/backend/postgres-migrations.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.backend.migrations.enabled }}
-{{- $envVars := concat (include "langsmith.commonEnv" . | fromYamlArray) .Values.backend.migrations.extraEnv -}}{{- include "langsmith.detectDuplicates" $envVars -}}
+{{- $envVars := concat (include "langsmith.commonEnv" . | fromYamlArray) .Values.backend.migrations.extraEnv -}}
+{{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/langsmith/templates/clickhouse/stateful-set.yaml
+++ b/charts/langsmith/templates/clickhouse/stateful-set.yaml
@@ -22,8 +22,6 @@
   {{- $envKeys = append $envKeys .name -}}
 {{- end }}
 {{- include "langsmith.detectDuplicates" $envKeys -}}
-  {{ fail (printf "Environment variables contain duplicate keys: %v" $duplicates) }}
-{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/langsmith/templates/clickhouse/stateful-set.yaml
+++ b/charts/langsmith/templates/clickhouse/stateful-set.yaml
@@ -1,4 +1,30 @@
+{{- define "clickhouseEnvVars" -}}
+- name: CLICKHOUSE_DB
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "langsmith.clickhouseSecretsName" . }}
+      key: clickhouse_db
+- name: CLICKHOUSE_USER
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "langsmith.clickhouseSecretsName" . }}
+      key: clickhouse_user
+- name: CLICKHOUSE_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "langsmith.clickhouseSecretsName" . }}
+      key: clickhouse_password
+{{- end }}
+{{- end -}}
 {{- if not .Values.clickhouse.external.enabled }}
+{{- $envVars := concat .Values.commonEnv (include "clickhouseEnvVars" . | fromYamlArray) .Values.clickhouse.statefulSet.extraEnv -}}
+{{- $envKeys := list -}}
+{{- range $envVars }}
+  {{- $envKeys = append $envKeys .name -}}
+{{- end }}
+{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
+  {{ fail "Environment variables cannot contain duplicate keys" }}
+{{- end -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -49,26 +75,8 @@ spec:
              {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            - name: CLICKHOUSE_DB
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "langsmith.clickhouseSecretsName" . }}
-                  key: clickhouse_db
-            - name: CLICKHOUSE_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "langsmith.clickhouseSecretsName" . }}
-                  key: clickhouse_user
-            - name: CLICKHOUSE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "langsmith.clickhouseSecretsName" . }}
-                  key: clickhouse_password
-            {{- with .Values.clickhouse.statefulSet.extraEnv }}
-               {{- toYaml . | nindent 12 }}
-             {{- end }}
-            {{- with .Values.commonEnv }}
-              {{ toYaml . | nindent 12 }}
+            {{- with $envVars }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
             - name: ch

--- a/charts/langsmith/templates/clickhouse/stateful-set.yaml
+++ b/charts/langsmith/templates/clickhouse/stateful-set.yaml
@@ -14,7 +14,6 @@
     secretKeyRef:
       name: {{ include "langsmith.clickhouseSecretsName" . }}
       key: clickhouse_password
-{{- end }}
 {{- end -}}
 {{- if not .Values.clickhouse.external.enabled }}
 {{- $envVars := concat .Values.commonEnv (include "clickhouseEnvVars" . | fromYamlArray) .Values.clickhouse.statefulSet.extraEnv -}}

--- a/charts/langsmith/templates/clickhouse/stateful-set.yaml
+++ b/charts/langsmith/templates/clickhouse/stateful-set.yaml
@@ -17,11 +17,7 @@
 {{- end -}}
 {{- if not .Values.clickhouse.external.enabled }}
 {{- $envVars := concat .Values.commonEnv (include "clickhouseEnvVars" . | fromYamlArray) .Values.clickhouse.statefulSet.extraEnv -}}
-{{- $envKeys := list -}}
-{{- range $envVars }}
-  {{- $envKeys = append $envKeys .name -}}
-{{- end }}
-{{- include "langsmith.detectDuplicates" $envKeys -}}
+{{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/langsmith/templates/clickhouse/stateful-set.yaml
+++ b/charts/langsmith/templates/clickhouse/stateful-set.yaml
@@ -21,9 +21,9 @@
 {{- range $envVars }}
   {{- $envKeys = append $envKeys .name -}}
 {{- end }}
-{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
-  {{ fail "Environment variables cannot contain duplicate keys" }}
-{{- end -}}
+{{- include "langsmith.detectDuplicates" $envKeys -}}
+  {{ fail (printf "Environment variables contain duplicate keys: %v" $duplicates) }}
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -25,8 +25,3 @@ data:
   {{- end }}
   LANGCHAIN_ENV: "local_kubernetes"
   GO_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}:{{ .Values.platformBackend.service.port }}"
-  X_SERVICE_AUTH_JWT_SECRET:
-   valueFrom:
-     secretKeyRef:
-       name: {{ include "langsmith.secretsName" . }}
-       key: api_key_salt

--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -25,3 +25,8 @@ data:
   {{- end }}
   LANGCHAIN_ENV: "local_kubernetes"
   GO_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}:{{ .Values.platformBackend.service.port }}"
+  X_SERVICE_AUTH_JWT_SECRET:
+   valueFrom:
+     secretKeyRef:
+       name: {{ include "langsmith.secretsName" . }}
+       key: api_key_salt

--- a/charts/langsmith/templates/frontend/deployment.yaml
+++ b/charts/langsmith/templates/frontend/deployment.yaml
@@ -21,9 +21,7 @@ value: {{ .Values.ingress.subdomain }}
 {{- range $envVars }}
   {{- $envKeys = append $envKeys .name -}}
 {{- end }}
-{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
-  {{ fail "Environment variables cannot contain duplicate keys" }}
-{{- end -}}
+{{- include "langsmith.detectDuplicates" $envKeys -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/langsmith/templates/frontend/deployment.yaml
+++ b/charts/langsmith/templates/frontend/deployment.yaml
@@ -17,11 +17,7 @@ value: {{ .Values.ingress.subdomain }}
 {{- end }}
 {{- end -}}
 {{- $envVars := concat .Values.commonEnv (include "frontendEnvVars" . | fromYamlArray) .Values.frontend.deployment.extraEnv -}}
-{{- $envKeys := list -}}
-{{- range $envVars }}
-  {{- $envKeys = append $envKeys .name -}}
-{{- end }}
-{{- include "langsmith.detectDuplicates" $envKeys -}}
+{{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/langsmith/templates/frontend/deployment.yaml
+++ b/charts/langsmith/templates/frontend/deployment.yaml
@@ -15,7 +15,7 @@
 - name: VITE_SUBDOMAIN
 value: {{ .Values.ingress.subdomain }}
 {{- end }}
-{{- end }}
+{{- end -}}
 {{- $envVars := concat .Values.commonEnv (include "frontendEnvVars" . | fromYamlArray) .Values.frontend.deployment.extraEnv -}}
 {{- $envKeys := list -}}
 {{- range $envVars }}

--- a/charts/langsmith/templates/frontend/deployment.yaml
+++ b/charts/langsmith/templates/frontend/deployment.yaml
@@ -1,3 +1,29 @@
+{{- define "frontendEnvVars" -}}
+{{- if .Values.config.oauth.enabled }}
+- name: VITE_OAUTH_CLIENT_ID
+  valueFrom:
+    secretKeyRef:
+      key: oauth_client_id
+      name: {{ include "langsmith.secretsName" .}}
+- name: VITE_OAUTH_ISSUER_URL
+  valueFrom:
+    secretKeyRef:
+      key: oauth_issuer_url
+      name: {{ include "langsmith.secretsName" .}}
+{{- end }}
+{{- if .Values.ingress.subdomain }}
+- name: VITE_SUBDOMAIN
+value: {{ .Values.ingress.subdomain }}
+{{- end }}
+{{- end }}
+{{- $envVars := concat .Values.commonEnv (include "frontendEnvVars" . | fromYamlArray) .Values.frontend.deployment.extraEnv -}}
+{{- $envKeys := list -}}
+{{- range $envVars }}
+  {{- $envKeys = append $envKeys .name -}}
+{{- end }}
+{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
+  {{ fail "Environment variables cannot contain duplicate keys" }}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,26 +76,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- if .Values.config.oauth.enabled }}
-            - name: VITE_OAUTH_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  key: oauth_client_id
-                  name: {{ include "langsmith.secretsName" .}}
-            - name: VITE_OAUTH_ISSUER_URL
-              valueFrom:
-                secretKeyRef:
-                  key: oauth_issuer_url
-                  name: {{ include "langsmith.secretsName" .}}
-            {{- end }}
-            {{- with .Values.frontend.deployment.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- if .Values.ingress.subdomain }}
-            - name: VITE_SUBDOMAIN
-              value: {{ .Values.ingress.subdomain }}
-            {{- end }}
-            {{- with .Values.commonEnv }}
+            {{- with $envVars }}
               {{ toYaml . | nindent 12 }}
             {{- end }}
           envFrom:

--- a/charts/langsmith/templates/platform-backend/deployment.yaml
+++ b/charts/langsmith/templates/platform-backend/deployment.yaml
@@ -1,3 +1,19 @@
+{{- define "platformBackendEnvVars" -}}
+- name: PORT
+  value: {{ .Values.platformBackend.containerPort | quote }}
+{{- with .Values.ingress.subdomain }}
+- name: DOCS_PREFIX
+  value: /{{ . }}/api
+{{- end }}
+{{- end -}}
+{{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "platformBackendEnvVars" . | fromYamlArray) .Values.platformBackend.deployment.extraEnv -}}
+{{- $envKeys := list -}}
+{{- range $envVars }}
+  {{- $envKeys = append $envKeys .name -}}
+{{- end }}
+{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
+  {{ fail "Environment variables cannot contain duplicate keys" }}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,13 +66,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- include "langsmith.commonEnv" . | nindent 12 }}
-            - name: PORT
-              value: {{ .Values.platformBackend.containerPort | quote }}
-            {{- with .Values.platformBackend.deployment.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.commonEnv }}
+            {{- with $envVars }}
               {{ toYaml . | nindent 12 }}
             {{- end }}
           envFrom:

--- a/charts/langsmith/templates/platform-backend/deployment.yaml
+++ b/charts/langsmith/templates/platform-backend/deployment.yaml
@@ -11,9 +11,7 @@
 {{- range $envVars }}
   {{- $envKeys = append $envKeys .name -}}
 {{- end }}
-{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
-  {{ fail "Environment variables cannot contain duplicate keys" }}
-{{- end -}}
+{{- include "langsmith.detectDuplicates" $envKeys -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/langsmith/templates/platform-backend/deployment.yaml
+++ b/charts/langsmith/templates/platform-backend/deployment.yaml
@@ -7,11 +7,7 @@
 {{- end }}
 {{- end -}}
 {{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "platformBackendEnvVars" . | fromYamlArray) .Values.platformBackend.deployment.extraEnv -}}
-{{- $envKeys := list -}}
-{{- range $envVars }}
-  {{- $envKeys = append $envKeys .name -}}
-{{- end }}
-{{- include "langsmith.detectDuplicates" $envKeys -}}
+{{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/langsmith/templates/playground/deployment.yaml
+++ b/charts/langsmith/templates/playground/deployment.yaml
@@ -3,9 +3,7 @@
 {{- range $envVars }}
   {{- $envKeys = append $envKeys .name -}}
 {{- end }}
-{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
-  {{ fail "Environment variables cannot contain duplicate keys" }}
-{{- end -}}
+{{- include "langsmith.detectDuplicates" $envKeys -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/langsmith/templates/playground/deployment.yaml
+++ b/charts/langsmith/templates/playground/deployment.yaml
@@ -1,9 +1,5 @@
 {{- $envVars := concat .Values.commonEnv .Values.playground.deployment.extraEnv -}}
-{{- $envKeys := list -}}
-{{- range $envVars }}
-  {{- $envKeys = append $envKeys .name -}}
-{{- end }}
-{{- include "langsmith.detectDuplicates" $envKeys -}}
+{{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/langsmith/templates/playground/deployment.yaml
+++ b/charts/langsmith/templates/playground/deployment.yaml
@@ -1,3 +1,11 @@
+{{- $envVars := concat .Values.commonEnv .Values.playground.deployment.extraEnv -}}
+{{- $envKeys := list -}}
+{{- range $envVars }}
+  {{- $envKeys = append $envKeys .name -}}
+{{- end }}
+{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
+  {{ fail "Environment variables cannot contain duplicate keys" }}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -51,13 +59,7 @@ spec:
           {{- end }}
           {{- if or .Values.playground.deployment.extraEnv .Values.commonEnv  }}
           env:
-            {{- with .Values.playground.deployment.extraEnv}}
-             {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.commonEnv}}
-             {{- toYaml . | nindent 12 }}
-            {{- end }}
-           {{- end }}
+          {{- end }}
           image: "{{ .Values.images.playgroundImage.repository }}:{{ .Values.images.playgroundImage.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.images.playgroundImage.pullPolicy }}
           ports:

--- a/charts/langsmith/templates/postgres/stateful-set.yaml
+++ b/charts/langsmith/templates/postgres/stateful-set.yaml
@@ -1,4 +1,32 @@
+{{- define "postgresEnvVars" -}}
+- name: POSTGRES_DB
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "langsmith.postgresSecretsName" .}}
+      key: postgres_db
+- name: POSTGRES_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "langsmith.postgresSecretsName" .}}
+      key: postgres_password
+- name: POSTGRES_USER
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "langsmith.postgresSecretsName" .}}
+      key: postgres_user
+- name: PGDATA
+  value: /var/lib/postgresql/data/postgres
+{{- end }}
+{{- end -}}
 {{- if not .Values.postgres.external.enabled }}
+{{- $envVars := concat .Values.commonEnv (include "postgresEnvVars" . | fromYamlArray) .Values.postgres.statefulSet.extraEnv -}}
+{{- $envKeys := list -}}
+{{- range $envVars }}
+  {{- $envKeys = append $envKeys .name -}}
+{{- end }}
+{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
+  {{ fail "Environment variables cannot contain duplicate keys" }}
+{{- end -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -47,27 +75,7 @@ spec:
              {{ . }}
           {{- end }}
           env:
-            - name: POSTGRES_DB
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "langsmith.postgresSecretsName" .}}
-                  key: postgres_db
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "langsmith.postgresSecretsName" .}}
-                  key: postgres_password
-            - name: POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "langsmith.postgresSecretsName" .}}
-                  key: postgres_user
-            - name: PGDATA
-              value: /var/lib/postgresql/data/postgres
-            {{- with .Values.postgres.statefulSet.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.commonEnv }}
+            {{- with $envVars }}
              {{- toYaml . | nindent 12 }}
             {{- end }}
           image: "{{ .Values.images.postgresImage.repository }}:{{ .Values.images.postgresImage.tag | default .Chart.AppVersion }}"

--- a/charts/langsmith/templates/postgres/stateful-set.yaml
+++ b/charts/langsmith/templates/postgres/stateful-set.yaml
@@ -19,11 +19,7 @@
 {{- end -}}
 {{- if not .Values.postgres.external.enabled }}
 {{- $envVars := concat .Values.commonEnv (include "postgresEnvVars" . | fromYamlArray) .Values.postgres.statefulSet.extraEnv -}}
-{{- $envKeys := list -}}
-{{- range $envVars }}
-  {{- $envKeys = append $envKeys .name -}}
-{{- end }}
-{{- include "langsmith.detectDuplicates" $envKeys -}}
+{{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/langsmith/templates/postgres/stateful-set.yaml
+++ b/charts/langsmith/templates/postgres/stateful-set.yaml
@@ -16,7 +16,6 @@
       key: postgres_user
 - name: PGDATA
   value: /var/lib/postgresql/data/postgres
-{{- end }}
 {{- end -}}
 {{- if not .Values.postgres.external.enabled }}
 {{- $envVars := concat .Values.commonEnv (include "postgresEnvVars" . | fromYamlArray) .Values.postgres.statefulSet.extraEnv -}}

--- a/charts/langsmith/templates/postgres/stateful-set.yaml
+++ b/charts/langsmith/templates/postgres/stateful-set.yaml
@@ -24,8 +24,6 @@
   {{- $envKeys = append $envKeys .name -}}
 {{- end }}
 {{- include "langsmith.detectDuplicates" $envKeys -}}
-  {{ fail (printf "Environment variables contain duplicate keys: %v" $duplicates) }}
-{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/langsmith/templates/postgres/stateful-set.yaml
+++ b/charts/langsmith/templates/postgres/stateful-set.yaml
@@ -23,9 +23,9 @@
 {{- range $envVars }}
   {{- $envKeys = append $envKeys .name -}}
 {{- end }}
-{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
-  {{ fail "Environment variables cannot contain duplicate keys" }}
-{{- end -}}
+{{- include "langsmith.detectDuplicates" $envKeys -}}
+  {{ fail (printf "Environment variables contain duplicate keys: %v" $duplicates) }}
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/langsmith/templates/queue/deployment.yaml
+++ b/charts/langsmith/templates/queue/deployment.yaml
@@ -5,11 +5,7 @@
   value: "3"
 {{- end -}}
 {{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "queueEnvVars" . | fromYamlArray) .Values.queue.deployment.extraEnv -}}
-{{- $envKeys := list -}}
-{{- range $envVars }}
-  {{- $envKeys = append $envKeys .name -}}
-{{- end }}
-{{- include "langsmith.detectDuplicates" $envKeys -}}
+{{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/langsmith/templates/queue/deployment.yaml
+++ b/charts/langsmith/templates/queue/deployment.yaml
@@ -1,3 +1,17 @@
+{{- define "queueEnvVars" -}}
+- name: "REDIS_MAX_CONNECTIONS"
+  value: "250"
+- name: "ASYNCPG_POOL_MAX_SIZE"
+  value: "3"
+{{- end -}}
+{{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "queueEnvVars" . | fromYamlArray) .Values.queue.deployment.extraEnv -}}
+{{- $envKeys := list -}}
+{{- range $envVars }}
+  {{- $envKeys = append $envKeys .name -}}
+{{- end }}
+{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
+  {{ fail "Environment variables cannot contain duplicate keys" }}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -51,16 +65,8 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            - name: "REDIS_MAX_CONNECTIONS"
-              value: "250"
-            - name: "ASYNCPG_POOL_MAX_SIZE"
-              value: "3"
-            {{- include "langsmith.commonEnv" . | nindent 12 }}
-            {{- with .Values.queue.deployment.extraEnv }}
+            {{- with $envVars }}
               {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.commonEnv }}
-             {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
             - configMapRef:

--- a/charts/langsmith/templates/queue/deployment.yaml
+++ b/charts/langsmith/templates/queue/deployment.yaml
@@ -9,9 +9,7 @@
 {{- range $envVars }}
   {{- $envKeys = append $envKeys .name -}}
 {{- end }}
-{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
-  {{ fail "Environment variables cannot contain duplicate keys" }}
-{{- end -}}
+{{- include "langsmith.detectDuplicates" $envKeys -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/langsmith/templates/redis/stateful-set.yaml
+++ b/charts/langsmith/templates/redis/stateful-set.yaml
@@ -1,10 +1,6 @@
 {{- if not .Values.redis.external.enabled }}
 {{- $envVars := concat .Values.commonEnv .Values.redis.statefulSet.extraEnv -}}
-{{- $envKeys := list -}}
-{{- range $envVars }}
-  {{- $envKeys = append $envKeys .name -}}
-{{- end }}
-{{- include "langsmith.detectDuplicates" $envKeys -}}
+{{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/langsmith/templates/redis/stateful-set.yaml
+++ b/charts/langsmith/templates/redis/stateful-set.yaml
@@ -1,4 +1,12 @@
 {{- if not .Values.redis.external.enabled }}
+{{- $envVars := concat .Values.commonEnv .Values.redis.statefulSet.extraEnv -}}
+{{- $envKeys := list -}}
+{{- range $envVars }}
+  {{- $envKeys = append $envKeys .name -}}
+{{- end }}
+{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
+  {{ fail "Environment variables cannot contain duplicate keys" }}
+{{- end -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -48,10 +56,7 @@ spec:
           {{- end }}
           {{- if or .Values.redis.statefulSet.extraEnv .Values.commonEnv  }}
           env:
-            {{- with .Values.redis.statefulSet.extraEnv}}
-             {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.commonEnv}}
+            {{- with $envVars }}
              {{- toYaml . | nindent 12 }}
             {{- end }}
            {{- end }}

--- a/charts/langsmith/templates/redis/stateful-set.yaml
+++ b/charts/langsmith/templates/redis/stateful-set.yaml
@@ -4,9 +4,7 @@
 {{- range $envVars }}
   {{- $envKeys = append $envKeys .name -}}
 {{- end }}
-{{- if ne (uniq $envKeys | len) (len $envKeys) -}}
-  {{ fail "Environment variables cannot contain duplicate keys" }}
-{{- end -}}
+{{- include "langsmith.detectDuplicates" $envKeys -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:


### PR DESCRIPTION
duplicate env vars cause strange behavior with Helm: https://github.com/fluxcd/helm-controller/issues/539. this can result in removing environment variables accidentally.

this change adds checks to fail fast if duplicate environment variables are detected in the `langsmith` chart