### PR TITLE
chore: bump version for org-scoped usage charts

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
 version: 0.8.21
-appVersion: "0.8.62"
+appVersion: "0.8.63"

--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.8.20
-appVersion: "0.8.53"
+version: 0.8.21
+appVersion: "0.8.62"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -17,23 +17,23 @@ images:
   aceBackendImage:
     repository: "docker.io/langchain/langsmith-ace-backend"
     pullPolicy: IfNotPresent
-    tag: "0.8.53"
+    tag: "0.8.62"
   backendImage:
     repository: "docker.io/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
-    tag: "0.8.53"
+    tag: "0.8.62"
   frontendImage:
     repository: "docker.io/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
-    tag: "0.8.53"
+    tag: "0.8.62"
   platformBackendImage:
     repository: "docker.io/langchain/langsmith-go-backend"
     pullPolicy: IfNotPresent
-    tag: "0.8.53"
+    tag: "0.8.62"
   playgroundImage:
     repository: "docker.io/langchain/langsmith-playground"
     pullPolicy: IfNotPresent
-    tag: "0.8.53"
+    tag: "0.8.62"
   postgresImage:
     repository: "docker.io/postgres"
     pullPolicy: IfNotPresent

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -17,23 +17,23 @@ images:
   aceBackendImage:
     repository: "docker.io/langchain/langsmith-ace-backend"
     pullPolicy: IfNotPresent
-    tag: "0.8.62"
+    tag: "0.8.63"
   backendImage:
     repository: "docker.io/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
-    tag: "0.8.62"
+    tag: "0.8.63"
   frontendImage:
     repository: "docker.io/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
-    tag: "0.8.62"
+    tag: "0.8.63"
   platformBackendImage:
     repository: "docker.io/langchain/langsmith-go-backend"
     pullPolicy: IfNotPresent
-    tag: "0.8.62"
+    tag: "0.8.63"
   playgroundImage:
     repository: "docker.io/langchain/langsmith-playground"
     pullPolicy: IfNotPresent
-    tag: "0.8.62"
+    tag: "0.8.63"
   postgresImage:
     repository: "docker.io/postgres"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
https://docs.smith.langchain.com/self_hosting/organization_charts