### PR TITLE
feat: add envFrom to apiServer

### DIFF
--- a/charts/langgraph-cloud/README.md
+++ b/charts/langgraph-cloud/README.md
@@ -363,6 +363,7 @@ the same format as the secret in the corresponding `secrets.yaml` file. Note: AP
 | apiServer.containerPort | int | `8000` |  |
 | apiServer.deployment.affinity | object | `{}` |  |
 | apiServer.deployment.annotations | object | `{}` |  |
+| apiServer.deployment.envFrom | list | `[]` | List of ConfigMap or Secret references to load environment variables from. Each item can be either a ConfigMap or Secret reference. Example: `- configMapRef: {name: my-configmap}` or `- secretRef: {name: my-secret}` |
 | apiServer.deployment.extraEnv | list | `[]` |  |
 | apiServer.deployment.labels | object | `{}` |  |
 | apiServer.deployment.nodeSelector | object | `{}` |  |

--- a/charts/langgraph-cloud/templates/api-server/deployment.yaml
+++ b/charts/langgraph-cloud/templates/api-server/deployment.yaml
@@ -78,6 +78,10 @@ spec:
             {{- with .Values.apiServer.deployment.extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.apiServer.deployment.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.images.apiServerImage.repository }}:{{ .Values.images.apiServerImage.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.images.apiServerImage.pullPolicy }}
           ports:

--- a/charts/langgraph-cloud/values.yaml
+++ b/charts/langgraph-cloud/values.yaml
@@ -65,6 +65,7 @@ apiServer:
         cpu: 1000m
         memory: 2Gi
     extraEnv: []
+    envFrom: []  # List of ConfigMap or Secret references to load environment variables from
     sidecars: []
     nodeSelector: {}
     tolerations: []


### PR DESCRIPTION
I would like to be able to add configMapRef or secretRef objects to the langgraph apiServer.

## Testing envFrom Configuration

### 1. Create Test Values File
Create a test values file (`test-values.yaml`) with the following content:

```yaml
images:
  apiServerImage:
    repository: "docker.io/langchain/langgraph-api"
    pullPolicy: Always
    tag: "3.11"

config:
  langGraphCloudLicenseKey: "test-license"

apiServer:
  deployment:
    envFrom:
      - configMapRef:
          name: test-configmap
      - secretRef:
          name: test-secret
```

### 2. Generate and Verify Manifest
Run the following command to generate the manifest and verify the envFrom configuration:

```bash
helm template langgraph-cloud charts/langgraph-cloud -f test-values.yaml | grep -A 10 "envFrom:"
```

Expected output:
```yaml
envFrom:
  - configMapRef:
      name: test-configmap
  - secretRef:
      name: test-secret
```

This verifies that:
- The envFrom template in the deployment.yaml is working correctly
- The values are being properly passed through from the values file
- The configuration is being rendered in the correct format in the final manifest