### PR TITLE
chore: bump version for blob storage fix

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.10.4
-appVersion: "0.10.20"
+version: 0.10.5
+appVersion: "0.10.23"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -17,19 +17,19 @@ images:
   aceBackendImage:
     repository: "docker.io/langchain/langsmith-ace-backend"
     pullPolicy: IfNotPresent
-    tag: "0.10.20"
+    tag: "0.10.23"
   backendImage:
     repository: "docker.io/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
-    tag: "0.10.20"
+    tag: "0.10.23"
   frontendImage:
     repository: "docker.io/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
-    tag: "0.10.20"
+    tag: "0.10.23"
   hostBackendImage:
     repository: "docker.io/langchain/hosted-langserve-backend"
     pullPolicy: IfNotPresent
-    tag: "0.10.20"
+    tag: "0.10.23"
   operatorImage:
     repository: "docker.io/langchain/langgraph-operator"
     pullPolicy: IfNotPresent
@@ -37,11 +37,11 @@ images:
   platformBackendImage:
     repository: "docker.io/langchain/langsmith-go-backend"
     pullPolicy: IfNotPresent
-    tag: "0.10.20"
+    tag: "0.10.23"
   playgroundImage:
     repository: "docker.io/langchain/langsmith-playground"
     pullPolicy: IfNotPresent
-    tag: "0.10.20"
+    tag: "0.10.23"
   postgresImage:
     repository: "docker.io/postgres"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
removes `backend` startup ping to cloud storage