### PR TITLE
Update app.kubernetes.io labels to be consistent across templates

### DIFF
--- a/charts/langgraph-dataplane/Chart.yaml
+++ b/charts/langgraph-dataplane/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy a langgraph dataplane on kubernetes.
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: "0.1.0"

--- a/charts/langgraph-dataplane/templates/_helpers.tpl
+++ b/charts/langgraph-dataplane/templates/_helpers.tpl
@@ -64,6 +64,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "langgraphDataplane.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "langgraphDataplane.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/charts/langgraph-dataplane/templates/_helpers.tpl
+++ b/charts/langgraph-dataplane/templates/_helpers.tpl
@@ -64,7 +64,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "langgraphDataplane.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "langgraphDataplane.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/charts/langgraph-dataplane/templates/listener/deployment.yaml
+++ b/charts/langgraph-dataplane/templates/listener/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.listener.name }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.operator.name }}
+    app.kubernetes.io/component: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.listener.name }}
     {{- with.Values.listener.deployment.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/langgraph-dataplane/templates/listener/deployment.yaml
+++ b/charts/langgraph-dataplane/templates/listener/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.listener.name }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: langgraph-{{ .Values.operator.name }}
     {{- with.Values.listener.deployment.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/langgraph-dataplane/templates/listener/deployment.yaml
+++ b/charts/langgraph-dataplane/templates/listener/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.listener.name }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
-    app.kubernetes.io/component: langgraph-{{ .Values.operator.name }}
+    app.kubernetes.io/component: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.operator.name }}
     {{- with.Values.listener.deployment.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/langgraph-dataplane/templates/listener/pdb.yaml
+++ b/charts/langgraph-dataplane/templates/listener/pdb.yaml
@@ -10,7 +10,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "langgraphDataplane.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: {{ .Values.listener.name }}
+      app.kubernetes.io/component: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.listener.name }}
   {{- if .Values.listener.pdb.minAvailable }}
   minAvailable: {{ .Values.listener.pdb.minAvailable }}
   {{- end }}

--- a/charts/langgraph-dataplane/templates/operator/deployment.yaml
+++ b/charts/langgraph-dataplane/templates/operator/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.operator.name }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
-    app.kubernetes.io/component: langgraph-{{ .Values.operator.name }}
+    app.kubernetes.io/component: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.operator.name }}
     {{- with .Values.operator.deployment.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/langgraph-dataplane/templates/operator/deployment.yaml
+++ b/charts/langgraph-dataplane/templates/operator/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.operator.name }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
-    app.kubernetes.io/name: langgraph-{{ .Values.operator.name }}
+    app.kubernetes.io/component: langgraph-{{ .Values.operator.name }}
     {{- with .Values.operator.deployment.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -19,7 +19,7 @@ spec:
   selector:
     matchLabels:
       {{- include "langgraphDataplane.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ include "langgraphDataplane.fullname" . }}-operator
+      app.kubernetes.io/component: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.operator.name }}
   template:
     metadata:
       annotations:
@@ -29,7 +29,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/operator/config-map.yaml") . | sha256sum }}
       labels:
         {{- include "langgraphDataplane.labels" . | nindent 8 }}
-        app.kubernetes.io/component: {{ include "langgraphDataplane.fullname" . }}-operator
+        app.kubernetes.io/component: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.operator.name }}
         {{- with .Values.operator.deployment.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/langgraph-dataplane/templates/operator/pdb.yaml
+++ b/charts/langgraph-dataplane/templates/operator/pdb.yaml
@@ -10,7 +10,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "langgraphDataplane.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: {{ .Values.operator.name }}
+      app.kubernetes.io/component: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.operator.name }}
   {{- if .Values.operator.pdb.minAvailable }}
   minAvailable: {{ .Values.operator.pdb.minAvailable }}
   {{- end }}


### PR DESCRIPTION
This label is already hard-coded in the deployment templates, it's causing duplication issues when we template the chart with kustomize. LMK if you need more info