### PR TITLE
Finetune Redis TTL: reduce from 12hr to 6

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -233,8 +233,8 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | config.oauth.oauthSessionMaxSec | string | `"86400"` |  |
 | config.orgCreationDisabled | bool | `false` | Prevent organization creation. If using basic auth, this is set to true by default. |
 | config.personalOrgsDisabled | bool | `false` | Disable personal orgs. Users will need to be invited to an org manually. If using basic auth, this is set to true by default. |
-| config.settings | object | `{"redisRunsExpirySeconds":"43200"}` | Application Settings. These are used to tune the application |
-| config.settings.redisRunsExpirySeconds | string | `"43200"` | Optional. Be very careful when lowering this value as it can result in runs being lost if your queue is down/not processing items fast enough. |
+| config.settings | object | `{"redisRunsExpirySeconds":"21600"}` | Application Settings. These are used to tune the application |
+| config.settings.redisRunsExpirySeconds | string | `"21600"` | Optional. Be very careful when lowering this value as it can result in runs being lost if your queue is down/not processing items fast enough. |
 | config.ttl | object | `{"enabled":true,"ttl_period_seconds":{"longlived":"34560000","shortlived":"1209600"}}` | TTL configuration Optional. Used to set TTLS for longlived and shortlived objects. |
 | config.ttl.ttl_period_seconds.longlived | string | `"34560000"` | 400 day longlived and 14 day shortlived |
 | config.workspaceScopeOrgInvitesEnabled | bool | `false` | Enable Workspace Admins to invite users to the org and workspace. |

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -151,7 +151,7 @@ config:
   # -- Application Settings. These are used to tune the application
   settings:
     # -- Optional. Be very careful when lowering this value as it can result in runs being lost if your queue is down/not processing items fast enough.
-    redisRunsExpirySeconds: "43200"  # 12 hours
+    redisRunsExpirySeconds: "21600"  # 6 hours
 
   fullTextSearch:
     indexing:


### PR DESCRIPTION
**Summary** Refine Redis TTL to 6 hours, which after discussing with Alex and Mukil could be a balances between disaster recovery and redis mem+cpu load.

**Issue**: With a 12 hour redis TTL, 12 hour of throughput (mostly traces) will almost always be stored in redis. In case of  trace ingestion at rate of QPS 10 ~ 100 qps without object storage enabled, each hour has 2GB+ data throughput and 12hour means 24GB+ of redis memory (for small redis this means Memory is always be full and high eviction will happen causing cpu load go up and latency increase). This issue was noticed in a big langsmith self-hosted customer for exact same reason.

** Fix** Simple fix is reduce to 6 hour, which should be still enough buffer time if consumer ( clickhouse etc) down but make redis 50% less stressful in high traffic situation and prioritize latency experience. 
 
**Test** I think there is no immediate test case relevant in this repo but please correct me if wrong.  
 