### PR TITLE
test: Validate admin password in the helm template during install

### DIFF
--- a/charts/langsmith/docker-compose/.env.example
+++ b/charts/langsmith/docker-compose/.env.example
@@ -34,4 +34,4 @@ CH_SEARCH_ENABLED=true # Set to false if you do not want to store tokenized inpu
 BASIC_AUTH_ENABLED=false # Set to true if you want to enable basic auth
 BASIC_AUTH_JWT_SECRET=your-jwt-secret # Change to your desired basic auth JWT secret
 INITIAL_ORG_ADMIN_EMAIL=your-email # Change to your desired initial org admin email. Only used if BASIC_AUTH_ENABLED=true
-INITIAL_ORG_ADMIN_PASSWORD=your-password # Change to your desired initial org admin password. Only used if BASIC_AUTH_ENABLED=true
+INITIAL_ORG_ADMIN_PASSWORD=your-password # Change to your desired initial org admin password. Needs to be at least 12 characters long, contain at least one lowercase, one uppercase, and one special character. Only used if BASIC_AUTH_ENABLED=true

--- a/charts/langsmith/templates/backend/auth-bootstrap.yaml
+++ b/charts/langsmith/templates/backend/auth-bootstrap.yaml
@@ -1,17 +1,16 @@
 {{- define "validatePassword" -}}
 {{- $password := .Values.config.basicAuth.initialOrgAdminPassword -}}
-{{- $symbols := "!#$%()+,-./:?@[]^_{~}" -}}
 {{- if lt (len $password) 12 -}}
-  {{- fail "Error: Password must be at least 12 characters long" -}}
+  {{- fail "Error: Admin password must be at least 12 characters long" -}}
 {{- end -}}
 {{- if not (regexMatch "[a-z]" $password) -}}
-  {{- fail "Error: Password must contain at least one lowercase letter" -}}
+  {{- fail "Error: Admin password must contain at least one lowercase letter" -}}
 {{- end -}}
 {{- if not (regexMatch "[A-Z]" $password) -}}
-  {{- fail "Error: Password must contain at least one uppercase letter" -}}
+  {{- fail "Error: Admin password must contain at least one uppercase letter" -}}
 {{- end -}}
 {{- if not (regexMatch `[!#$%()+,./:?@\[\]\\^_{~}-]` $password) -}}
-  {{- fail "Error: Password must contain at least one symbol from: !#$%()+,-./:?@[\\]^_{~}" -}}
+  {{- fail "Error: Admin password must contain at least one symbol from: !#$%()+,-./:?@[\\]^_{~}" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/langsmith/templates/backend/auth-bootstrap.yaml
+++ b/charts/langsmith/templates/backend/auth-bootstrap.yaml
@@ -10,7 +10,7 @@
 {{- if not (regexMatch "[A-Z]" $password) -}}
   {{- fail "Error: Password must contain at least one uppercase letter" -}}
 {{- end -}}
-{{- if not (regexMatch "[!#$%()+,-./:?@[]^_{~}]" $password) -}}
+{{- if not (regexMatch "[!#$%()+,\-./:?@\[\\\]^_{~}]" $password) -}}
   {{- fail "Error: Password must contain at least one symbol from: !#$%()+,-./:?@[]^_{~}" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/langsmith/templates/backend/auth-bootstrap.yaml
+++ b/charts/langsmith/templates/backend/auth-bootstrap.yaml
@@ -1,3 +1,20 @@
+{{- define "validatePassword" -}}
+{{- $password := .Values.config.basicAuth.initialOrgAdminPassword -}}
+{{- $symbols := "!#$%()+,-./:?@[]^_{~}" -}}
+{{- if lt (len $password) 12 -}}
+  {{- fail "Error: Password must be at least 12 characters long" -}}
+{{- end -}}
+{{- if not (regexMatch "[a-z]" $password) -}}
+  {{- fail "Error: Password must contain at least one lowercase letter" -}}
+{{- end -}}
+{{- if not (regexMatch "[A-Z]" $password) -}}
+  {{- fail "Error: Password must contain at least one uppercase letter" -}}
+{{- end -}}
+{{- if not (regexMatch "[!#$%()+,-./:?@[]^_{~}]" $password) -}}
+  {{- fail "Error: Password must contain at least one symbol from: !#$%()+,-./:?@[]^_{~}" -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "authBootstrapEnvVars" -}}
 - name: INITIAL_ORG_ADMIN_EMAIL
   value: {{ .Values.config.basicAuth.initialOrgAdminEmail }}
@@ -8,6 +25,7 @@
       key: initial_org_admin_password
 {{- end -}}
 {{- if .Values.config.basicAuth.enabled }}
+{{- template "validatePassword" . -}}
 {{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "authBootstrapEnvVars" . | fromYamlArray) .Values.backend.authBootstrap.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: batch/v1

--- a/charts/langsmith/templates/backend/auth-bootstrap.yaml
+++ b/charts/langsmith/templates/backend/auth-bootstrap.yaml
@@ -10,8 +10,8 @@
 {{- if not (regexMatch "[A-Z]" $password) -}}
   {{- fail "Error: Password must contain at least one uppercase letter" -}}
 {{- end -}}
-{{- if not (regexMatch "[!#$%()+,\-./:?@\[\\\]^_{~}]" $password) -}}
-  {{- fail "Error: Password must contain at least one symbol from: !#$%()+,-./:?@[]^_{~}" -}}
+{{- if not (regexMatch `[!#$%()+,./:?@\[\]\\^_{~}-]` $password) -}}
+  {{- fail "Error: Password must contain at least one symbol from: !#$%()+,-./:?@[\\]^_{~}" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/langsmith/templates/backend/auth-bootstrap.yaml
+++ b/charts/langsmith/templates/backend/auth-bootstrap.yaml
@@ -24,7 +24,9 @@
       key: initial_org_admin_password
 {{- end -}}
 {{- if .Values.config.basicAuth.enabled }}
+{{- if not .Values.config.existingSecretName }}
 {{- template "validatePassword" . -}}
+{{- end }}
 {{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "authBootstrapEnvVars" . | fromYamlArray) .Values.backend.authBootstrap.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: batch/v1


### PR DESCRIPTION
Test plan:
- [X] Tested on a dev cluster

With password: `interVieww123`
Error on helm install:
```
joaquinborggio@Joaquin-Borggio-MacBook-ProF67FV2QWH5 helm % helm upgrade -i -f curr_smith_values.yaml langsmith charts/langsmith
Error: UPGRADE FAILED: execution error at (langsmith/templates/backend/auth-bootstrap.yaml:14:6): Error: Admin password must contain at least one symbol from: !#$%()+,-./:?@[\]^_{~}
``` 

With password: `interview`
Error on helm install:
```
joaquinborggio@Joaquin-Borggio-MacBook-ProF67FV2QWH5 helm % helm upgrade -i -f curr_smith_values.yaml langsmith charts/langsmith
Error: UPGRADE FAILED: execution error at (langsmith/templates/backend/auth-bootstrap.yaml:5:6): Error: Admin password must be at least 12 characters long
```

With password: `interviewwwwwwww`
Error on helm install:
```
joaquinborggio@Joaquin-Borggio-MacBook-ProF67FV2QWH5 helm % helm upgrade -i -f curr_smith_values.yaml langsmith charts/langsmith
Error: UPGRADE FAILED: execution error at (langsmith/templates/backend/auth-bootstrap.yaml:11:6): Error: Password must contain at least one uppercase letter
```

With password: `INTERVIEW@1234`
Error on helm install:
```
joaquinborggio@Joaquin-Borggio-MacBook-ProF67FV2QWH5 helm % helm upgrade -i -f curr_smith_values.yaml langsmith charts/langsmith
Error: UPGRADE FAILED: execution error at (langsmith/templates/backend/auth-bootstrap.yaml:8:6): Error: Admin password must contain at least one lowercase letter
```

With password: `interView@1234`
No error on helm install:
```
joaquinborggio@Joaquin-Borggio-MacBook-ProF67FV2QWH5 helm % helm upgrade -i -f curr_smith_values.yaml langsmith charts/langsmith
Release "langsmith" has been upgraded. Happy Helming!
NAME: langsmith
LAST DEPLOYED: Wed May 28 11:08:03 2025
NAMESPACE: interview
STATUS: deployed
REVISION: 5
TEST SUITE: None
NOTES:
Thank you for installing LangSmith!

This is the LangSmith application helm chart. All pods should be running! You can access the LangSmith UI by running the following command:

  kubectl port-forward svc/langsmith-frontend 8080:80

Then you can access the LangSmith UI at http://localhost:8080

By default, LangSmith will also provision a LoadBalancer service for the LangSmith Frontend. You can access the LangSmith API by running the following command:

  kubectl get svc langsmith-frontend

Then you can access the LangSmith API at http://<EXTERNAL-IP>.

Depending on your cloud provider, this LoadBalancer may be provisioned with a public IP address. Make sure to review your LoadBalancer configuration to ensure it meets your security requirements.
```

I also confirmed no errors with these passwords:
- `interView1234!`
- `inter:View1234`
- `-Interview1234`
- `-Inter()view()`
- `-Inter/\view()`

I also confirmed that this validation does not run with `existingSecretName` is set:
I set password to `interview` and added a secret. As expected, the validation of the password field did not run.