### PR TITLE
feat: Add a script to help pull important kubernetes info for debugging

### DIFF
--- a/charts/langsmith/scripts/get_k8s_debugging_info.sh
+++ b/charts/langsmith/scripts/get_k8s_debugging_info.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# We expect the namespace hosting all kubernetes resources to be passed as an argument to this script
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --namespace) NS="$2"; shift ;;
+    *) echo "Unknown parameter passed: $1"; exit 1 ;;
+  esac
+  shift
+done
+
+if [ -z "$NS" ]; then
+  echo "Usage: $0 --namespace <namespace>"
+  exit 1
+fi
+
+DIR=/tmp/langchain-debugging-$(date +%Y%m%d%H%M%S)
+
+echo "Starting to pull debugging info. Creating directory $DIR..."
+mkdir -p "$DIR"
+
+echo "Pulling summary of resources..."
+kubectl get all -n "$NS" -o wide > "$DIR/resources_summary.txt"
+
+echo "Pulling details of all resources..."
+kubectl get all -n "$NS" -o yaml > "$DIR/resources_details.yaml"
+
+echo "Pulling kubernetes events..."
+kubectl get events -n "$NS" --sort-by=.lastTimestamp > "$DIR/events.txt"
+
+echo "Pulling resource usage for all pods..."
+kubectl top pods -n "$NS" --containers > "$DIR/pod-resource-usage.txt"
+
+echo "Pulling container logs for all pods. Also pulling previous logs from restarted containers..."
+PODS=$(kubectl get pods -n "$NS" -l app="$NS" -o jsonpath='{.items[*].metadata.name}')
+
+for POD in $PODS; do
+  CONTAINERS=$(kubectl get pod "$POD" -n "$NS" -o jsonpath='{.spec.containers[*].name}')
+  for CONTAINER in $CONTAINERS; do
+    echo "Pulling current container logs (last 24h)..."
+    kubectl logs -n "$NS" "$POD" -c "$CONTAINER" --since=24h > "$DIR/${POD}_${CONTAINER}_current.log" 2>/dev/null
+
+    RESTART_COUNT=$(kubectl get pod "$POD" -n "$NS" -o json | jq ".status.containerStatuses[] | select(.name==\"$CONTAINER\") | .restartCount // 0")
+    if [[ "$RESTART_COUNT" -gt 0 ]]; then
+      echo "  $POD/$CONTAINER restarted ($RESTART_COUNT times) — grabbing previous logs..."
+      kubectl logs -n "$NS" "$POD" -c "$CONTAINER" --previous > "$DIR/${POD}_${CONTAINER}_previous.log" 2>/dev/null
+    fi
+  done
+done
+
+echo "Compressing directory..."
+tar -czf "${DIR}.tar.gz" -C "$(dirname "$DIR")" "$(basename "$DIR")"
+echo "Bundle written to ${DIR}.tar.gz"


### PR DESCRIPTION
Here we add a script to help pull important kubernetes info for debugging langsmith.

Usage example:
`bash get_k8s_debugging_info.sh --namespace langsmith`

What this script pulls for the namespace passed in as an argument:
- A wide summary view of all resources
- A detailed yaml view of all resources
- Kubernetes events
- Resource usage for all containers within every pod in the namespace
- All container logs from the last 24 hours
- For containers that have restarted, we pull the previous container logs
Next step: Add a link to this in our troubleshooting page: https://docs.smith.langchain.com/self_hosting/troubleshooting

Testing:

I ran this on a cluster and got this:
```
% bash charts/langsmith/scripts/get_k8s_debugging_info.sh --namespace interview
Starting to pull debugging info. Creating directory /tmp/langchain-debugging-20250530135745...
Pulling summary of resources...
Pulling details of all resources...
Pulling kubernetes events...
Pulling resource usage for all pods...
Pulling container logs for all pods. Also pulling previous logs from restarted containers...
Pulling current container logs (last 24h) for langsmith-ace-backend-7b8b8c5d7-zbkj9/ace-backend...
Pulling current container logs (last 24h) for langsmith-backend-5d56649b59-mbltl/backend...
  langsmith-backend-5d56649b59-mbltl/backend restarted (2 times) — grabbing previous logs...
Pulling current container logs (last 24h) for langsmith-backend-ch-migrations-mo0vu-z2gl6/ch-migrations...
Pulling current container logs (last 24h) for langsmith-clickhouse-0/clickhouse...
Pulling current container logs (last 24h) for langsmith-frontend-74cb898dc6-l6kj2/frontend...
Pulling current container logs (last 24h) for langsmith-platform-backend-8466477664-2hbjz/platform-backend...
Pulling current container logs (last 24h) for langsmith-platform-backend-8466477664-ltmsz/platform-backend...
Pulling current container logs (last 24h) for langsmith-platform-backend-8466477664-x9pjm/platform-backend...
Pulling current container logs (last 24h) for langsmith-playground-56648968cf-kwgt7/playground...
Pulling current container logs (last 24h) for langsmith-postgres-0/postgres...
Pulling current container logs (last 24h) for langsmith-queue-67859f9798-5n68j/queue...
Pulling current container logs (last 24h) for langsmith-queue-67859f9798-hx4bj/queue...
Pulling current container logs (last 24h) for langsmith-queue-67859f9798-vmvjp/queue...
Pulling current container logs (last 24h) for redis-test/redis-test...
Compressing directory...
Bundle written to /tmp/langchain-debugging-20250530135745.tar.gz
```

When i pass in invalid params:
```
joaquinborggio@Joaquin-Borggio-MacBook-ProF67FV2QWH5 helm % bash charts/langsmith/scripts/get_k8s_debugging_info.sh --cluster test
Unknown parameter passed: --cluster
joaquinborggio@Joaquin-Borggio-MacBook-ProF67FV2QWH5 helm % bash charts/langsmith/scripts/get_k8s_debugging_info.sh
Usage: charts/langsmith/scripts/get_k8s_debugging_info.sh --namespace <namespace>
```

Then I saw these files:
```
% ls /tmp
langchain-debugging-20250530131752
langchain-debugging-20250530131752.tar.gz
```

and the folder has this info:
```
% ls /tmp/langchain-debugging-20250530135745
events.txt		logs			pod-resource-usage.txt	resources_details.yaml	resources_summary.txt

% ls /tmp/langchain-debugging-20250530135745/logs
langsmith-ace-backend-7b8b8c5d7-zbkj9_ace-backend_current.log			langsmith-frontend-74cb898dc6-l6kj2_frontend_current.log			langsmith-postgres-0_postgres_current.log
langsmith-backend-5d56649b59-mbltl_backend_current.log				langsmith-platform-backend-8466477664-2hbjz_platform-backend_current.log	langsmith-queue-67859f9798-5n68j_queue_current.log
langsmith-backend-5d56649b59-mbltl_backend_previous.log				langsmith-platform-backend-8466477664-ltmsz_platform-backend_current.log	langsmith-queue-67859f9798-hx4bj_queue_current.log
langsmith-backend-ch-migrations-mo0vu-z2gl6_ch-migrations_current.log		langsmith-platform-backend-8466477664-x9pjm_platform-backend_current.log	langsmith-queue-67859f9798-vmvjp_queue_current.log
langsmith-clickhouse-0_clickhouse_current.log					langsmith-playground-56648968cf-kwgt7_playground_current.log			redis-test_redis-test_current.log

% cat /tmp/langchain-debugging-20250530131752/resources_summary.txt
NAME                                              READY   STATUS                       RESTARTS      AGE   IP            NODE                                        NOMINATED NODE   READINESS GATES
pod/langsmith-ace-backend-7b8b8c5d7-zbkj9         1/1     Running                      0             45h   10.0.2.100    ip-10-0-2-150.us-west-2.compute.internal    <none>           <none>
pod/langsmith-backend-5d56649b59-mbltl            1/1     Running                      2 (45h ago)   45h   10.0.3.248    ip-10-0-3-10.us-west-2.compute.internal     <none>           <none>
pod/langsmith-backend-ch-migrations-mo0vu-z2gl6   0/1     CreateContainerConfigError   0             47h   10.0.2.133    ip-10-0-2-119.us-west-2.compute.internal    <none>           <none>
pod/langsmith-clickhouse-0                        1/1     Running                      0             45h   10.0.3.245    ip-10-0-3-23.us-west-2.compute.internal     <none>           <none>
pod/langsmith-frontend-74cb898dc6-l6kj2           1/1     Running                      0             45h   10.0.3.202    ip-10-0-3-10.us-west-2.compute.internal     <none>           <none>
... [redacted for readability]

NAME                                 TYPE           CLUSTER-IP       EXTERNAL-IP                                                                     PORT(S)                      AGE   SELECTOR
service/langsmith-ace-backend        ClusterIP      172.20.26.41     <none>                                                                          1987/TCP                     22d   app.kubernetes.io/component=langsmith-ace-backend,app.kubernetes.io/instance=langsmith,app.kubernetes.io/name=langsmith
service/langsmith-backend            ClusterIP      172.20.207.168   <none>                                                                          1984/TCP                     22d   app.kubernetes.io/component=langsmith-backend,app.kubernetes.io/instance=langsmith,app.kubernetes.io/name=langsmith
service/langsmith-clickhouse         ClusterIP      172.20.191.68    <none>                                                                          8123/TCP,9000/TCP            22d   app.kubernetes.io/component=langsmith-clickhouse,app.kubernetes.io/instance=langsmith,app.kubernetes.io/name=langsmith
service/langsmith-frontend           LoadBalancer   172.20.92.150    k8s-intervie-langsmit-2146bd90f3-ae28ca02b102d0eb.elb.us-west-2.amazonaws.com   80:32525/TCP,443:31547/TCP   22d   app.kubernetes.io/component=langsmith-frontend,app.kubernetes.io/instance=langsmith,app.kubernetes.io/name=langsmith
service/langsmith-platform-backend   ClusterIP      172.20.65.210    <none>                                                                          1986/TCP                     22d   app.kubernetes.io/component=langsmith-platform-backend,app.kubernetes.io/instance=langsmith,app.kubernetes.io/name=langsmith
service/langsmith-playground         ClusterIP      172.20.88.107    <none>                                                                          1988/TCP                     22d   app.kubernetes.io/component=langsmith-playground,app.kubernetes.io/instance=langsmith,app.kubernetes.io/name=langsmith
service/langsmith-postgres           ClusterIP      172.20.30.242    <none>                                                                          5432/TCP                     22d   app.kubernetes.io/component=langsmith-postgres,app.kubernetes.io/instance=langsmith,app.kubernetes.io/name=langsmith

NAME                                         READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS         IMAGES                                              SELECTOR
deployment.apps/langsmith-ace-backend        1/1     1            1           22d   ace-backend        docker.io/langchain/langsmith-ace-backend:0.10.60   app.kubernetes.io/component=langsmith-ace-backend,app.kubernetes.io/instance=langsmith,app.kubernetes.io/name=langsmith
deployment.apps/langsmith-backend            1/1     1            1           22d   backend            docker.io/langchain/langsmith-backend:0.10.60       app.kubernetes.io/component=langsmith-backend,app.kubernetes.io/instance=langsmith,app.kubernetes.io/name=langsmith
deployment.apps/langsmith-frontend           1/1     1            1           22d   frontend           docker.io/langchain/langsmith-frontend:0.10.60      app.kubernetes.io/component=langsmith-frontend,app.kubernetes.io/instance=langsmith,app.kubernetes.io/name=langsmith
deployment.apps/langsmith-platform-backend   3/3     3            3           22d   platform-backend   docker.io/langchain/langsmith-go-backend:0.10.60    app.kubernetes.io/component=langsmith-platform-backend,app.kubernetes.io/instance=langsmith,app.kubernetes.io/name=langsmith
deployment.apps/langsmith-playground         1/1     1            1           22d   playground         docker.io/langchain/langsmith-playground:0.10.60    app.kubernetes.io/component=langsmith-playground,app.kubernetes.io/instance=langsmith,app.kubernetes.io/name=langsmith
deployment.apps/langsmith-queue              3/3     3            3           22d   queue              docker.io/langchain/langsmith-backend:0.10.60       app.kubernetes.io/component=langsmith-queue,app.kubernetes.io/instance=langsmith,app.kubernetes.io/name=langsmith

NAME                                                    DESIRED   CURRENT   READY   AGE    CONTAINERS         IMAGES                                              SELECTOR
replicaset.apps/langsmith-ace-backend-5497b5459b        0         0         0       2d2h   ace-backend        docker.io/langchain/langsmith-ace-backend:0.10.60   app.kubernetes.io/component=langsmith-ace-backend,app.kubernetes.io/instance=langsmith,app.kubernetes.io/name=langsmith,pod-template-hash=5497b5459b
replicaset.apps/langsmith-ace-backend-5557bfb5ff        0         0         0       14d    ace-backend        docker.io/langchain/langsmith-ace-backend:0.10.32   app.kubernetes.io/component=langsmith-ace-backend,app.kubernetes.io/instance=langsmith,app.kubernetes.io/name=langsmith,pod-template-hash=5557bfb5ff
replicaset.apps/langsmith-ace-backend-5b6f746b9b        0         0         0       2d2h   ace-backend        docker.io/langchain/langsmith-ace-backend:0.10.60   app.kubernetes.io/component=langsmith-ace-backend,app.kubernetes.io/instance=langsmith,app.kubernetes.io/name=langsmith,pod-template-hash=5b6f746b9b
... [redacted for readability]

NAME                                    READY   AGE   CONTAINERS   IMAGES
statefulset.apps/langsmith-clickhouse   1/1     22d   clickhouse   docker.io/clickhouse/clickhouse-server:24.8
statefulset.apps/langsmith-postgres     1/1     22d   postgres     docker.io/postgres:14.7

NAME                                              COMPLETIONS   DURATION   AGE   CONTAINERS      IMAGES                                          SELECTOR
job.batch/langsmith-backend-ch-migrations-mo0vu   0/1           47h        47h   ch-migrations   docker.io/langchain/langsmith-backend:0.10.60   batch.kubernetes.io/controller-uid=564cd5df-9311-4856-a2f7-e9287974534f


% head -n 20 /tmp/langchain-debugging-20250530131752/resources_details.yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: Pod
  metadata:
    annotations:
      checksum/clickhouse: e297adb39b4e85b62ee2b12a3f467a15062b8cc2e554050abfd7953a9ae2ed3c
      checksum/config: 5656dab17606727e79f26adde78376f1cc33523f578813912cfa471ab19b00be
      checksum/postgres: 838be0bf6778791a436917689dc89adbaf4fda1c7840305d679da710bb8082c8
      checksum/redis: 1c3811e36032fdccfea6ab2fc9dfe3865af38f1f9cfc3cfaa5864b23ae006f71
      checksum/secrets: 2b8b8adb67f353a2096d9c06d3c98c5999300416157d496b697207774bfed2c9
      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: datadog
      kubectl.kubernetes.io/restartedAt: "2025-05-22T13:06:56-04:00"
    creationTimestamp: "2025-05-28T22:56:05Z"
    generateName: langsmith-ace-backend-7b8b8c5d7-
    labels:
      app.kubernetes.io/component: langsmith-ace-backend
      app.kubernetes.io/instance: langsmith
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/name: langsmith


joaquinborggio@Joaquin-Borggio-MacBook-ProF67FV2QWH5 helm % cat /tmp/langchain-debugging-20250530131752/pod-resource-usage.txt
POD                                           NAME               CPU(cores)   MEMORY(bytes)
langsmith-ace-backend-7b8b8c5d7-zbkj9         ace-backend        1m           33Mi
langsmith-backend-5d56649b59-mbltl            backend            3m           633Mi
langsmith-clickhouse-0                        clickhouse         28m          2082Mi
langsmith-frontend-74cb898dc6-l6kj2           frontend           2m           21Mi
langsmith-platform-backend-8466477664-2hbjz   platform-backend   1m           58Mi
langsmith-platform-backend-8466477664-ltmsz   platform-backend   1m           59Mi
langsmith-platform-backend-8466477664-x9pjm   platform-backend   1m           64Mi
langsmith-playground-56648968cf-kwgt7         playground         2m           332Mi
langsmith-postgres-0                          postgres           11m          38Mi
langsmith-queue-67859f9798-5n68j              queue              698m         1069Mi
langsmith-queue-67859f9798-hx4bj              queue              8m           1070Mi
langsmith-queue-67859f9798-vmvjp              queue              9m           1069Mi
redis-test                                    redis-test         0m           3Mi
joaquinborggio@Joaquin-Borggio-MacBook-ProF67FV2QWH5 helm % cat /tmp/langchain-debugging-20250530131752/events.txt
LAST SEEN   TYPE     REASON   OBJECT                                            MESSAGE
3m25s       Normal   Pulled   pod/langsmith-backend-ch-migrations-mo0vu-z2gl6   Container image "docker.io/langchain/langsmith-backend:0.10.60" already present on machine
```

Previous container logs:
```
 % cat /tmp/langchain-debugging-20250530135745/logs/langsmith-backend-5d56649b59-mbltl_backend_previous.log
{"logger": "root", "level": "info", "timestamp": "2025-05-28T22:56:34.724887Z", "message": "Logging initialized"}
INFO:     Started server process [1]
INFO:     Waiting for application startup.
{"logger": "app.main", "level": "info", "timestamp": "2025-05-28T22:56:41.914341Z", "message": "Starting up"}
{"logger": "app.main", "level": "info", "timestamp": "2025-05-28T22:56:41.914622Z", "message": "Connecting to Redis"}
{"logger": "app.main", "level": "info", "timestamp": "2025-05-28T22:56:41.920663Z", "message": "Connecting to Postgres"}
ERROR:    Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 693, in lifespan
  File "/usr/local/lib/python3.11/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 133, in merged_lifespan
  File "/usr/local/lib/python3.11/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 133, in merged_lifespan
  File "/usr/local/lib/python3.11/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 133, in merged_lifespan
  File "/usr/local/lib/python3.11/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 133, in merged_lifespan
  File "/usr/local/lib/python3.11/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/code/smith-backend/app/main.py", line 77, in lifespan
  File "/code/smith-backend/app/main.py", line 260, in startup_event
  File "/code/lc_database/lc_database/database.py", line 442, in create_global_asyncpg_pool
  File "/code/lc_database/lc_database/database.py", line 409, in create_asyncpg_pool
  File "/usr/local/lib/python3.11/site-packages/asyncpg/pool.py", line 418, in _async__init__
  File "/usr/local/lib/python3.11/site-packages/asyncpg/pool.py", line 445, in _initialize
  File "/usr/local/lib/python3.11/site-packages/asyncpg/pool.py", line 132, in connect
  File "/usr/local/lib/python3.11/site-packages/asyncpg/pool.py", line 517, in _get_new_connection
  File "/usr/local/lib/python3.11/site-packages/asyncpg/connection.py", line 2421, in connect
  File "/usr/local/lib/python3.11/site-packages/asyncpg/connect_utils.py", line 1075, in _connect
  File "/usr/local/lib/python3.11/site-packages/asyncpg/connect_utils.py", line 1049, in _connect
  File "/usr/local/lib/python3.11/site-packages/asyncpg/connect_utils.py", line 886, in _connect_addr
  File "/usr/local/lib/python3.11/site-packages/asyncpg/connect_utils.py", line 931, in __connect_addr
  File "/usr/local/lib/python3.11/site-packages/asyncpg/connect_utils.py", line 802, in _create_ssl_connection
  File "uvloop/loop.pyx", line 2039, in create_connection
  File "uvloop/loop.pyx", line 2016, in uvloop.loop.Loop.create_connection
ConnectionRefusedError: [Errno 111] Connection refused

ERROR:    Application startup failed. Exiting.
```