### PR TITLE
bug: update default oauth env variables to prevent issue with basic auth in docker compose version

### DIFF
--- a/charts/langsmith/docker-compose/.env.example
+++ b/charts/langsmith/docker-compose/.env.example
@@ -3,9 +3,9 @@ _REGISTRY=docker.io # Change to your desired Docker registry if you are using a 
 _LANGSMITH_IMAGE_VERSION=0.10.25 # Change to the desired Langsmith image version
 LANGSMITH_LICENSE_KEY=your-license-key # Change to your Langsmith license key
 AUTH_TYPE=none # Set to oauth if you want to use OAuth2.0 with PKCE. Set to mixed for basic auth or OAuth2.0 with OAuth2.0 client secret
-OAUTH_CLIENT_ID=your-client-id # Required if AUTH_TYPE=oauth or mixed with OAuth2.0 with OAuth2.0 client secret
-OAUTH_ISSUER_URL=https://your-issuer-url # Required if AUTH_TYPE=oauth or mixed with OAuth2.0 with OAuth2.0 client secret
-OAUTH_CLIENT_SECRET=your-client-secret # Required if AUTH_TYPE=mixed with OAuth2.0 with OAuth2.0 client secret
+OAUTH_CLIENT_ID="" # Required if AUTH_TYPE=oauth or mixed with OAuth2.0 with OAuth2.0 client secret
+OAUTH_ISSUER_URL="" # Required if AUTH_TYPE=oauth or mixed with OAuth2.0 with OAuth2.0 client secret (https://your-issuer-url)
+OAUTH_CLIENT_SECRET="" # Required if AUTH_TYPE=mixed with OAuth2.0 with OAuth2.0 client secret
 LANGSMITH_URL=http://localhost:1980 # Change to your hosted Langsmith URL. Required if AUTH_TYPE=mixed with OAuth2.0 client secret
 API_KEY_SALT=super # Change to your desired API key salt. Can be any random value. Must be set if AUTH_TYPE=oauth
 POSTGRES_DATABASE_URI=postgres:postgres@langchain-db:5432/postgres # Change to your database URI if using external postgres. Otherwise, leave it as is


### PR DESCRIPTION
The old values would lead to an error on the login page if you tried to enable basic auth with these default values.

Once these values are set to empty string, you are able to get a proper sign in screen with basic auth in docker compose version.

Error before:
<img width="697" alt="Screenshot 2025-06-05 at 7 19 58 PM" src="https://github.com/user-attachments/assets/626071e6-5f0e-4eb6-a11a-62c253e44a59" />

After this change:
