### PR TITLE
fix: bump default probe timeout for queue workers to allow for higher scale

### DIFF
--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1281,7 +1281,7 @@ queue:
           - "--check"
       failureThreshold: 6
       periodSeconds: 60
-      timeoutSeconds: 30
+      timeoutSeconds: 60
     livenessProbe:
       exec:
         command:
@@ -1290,7 +1290,7 @@ queue:
           - "--check"
       failureThreshold: 6
       periodSeconds: 60
-      timeoutSeconds: 30
+      timeoutSeconds: 60
     extraContainerConfig: {}
     extraEnv: []
     sidecars: []


### PR DESCRIPTION
During load testing, we saaw the liveness and readiness probes require a larger timeout to prevent them from killing healthy queue workers. To achieve the higher scale of 100 TPS this change is needed. Let's bump the default timeout value so users do not have to configure this if they want to reach higher scale.

## Testing
Tested this out during a 30m load test. Without this bump, queue workers get restarted which leads to a build up in incomplete tasks when they restart when running 100 TPS. With this change, workers don't get restarted and the incomplete tasks stay under control.