### PR TITLE
Add envFrom support to queue deployment

### DIFF
--- a/charts/langgraph-cloud/Chart.yaml
+++ b/charts/langgraph-cloud/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the LangGraph Cloud application and all services it depends on.
 type: application
-version: 0.1.16
+version: 0.1.17
 appVersion: "0.2.0"

--- a/charts/langgraph-cloud/templates/queue/deployment.yaml
+++ b/charts/langgraph-cloud/templates/queue/deployment.yaml
@@ -81,6 +81,10 @@ spec:
             {{- with .Values.queue.deployment.extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.queue.deployment.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: {{ include "langGraphCloud.image" (dict "Values" .Values "Chart" .Chart "component" "apiServerImage") | quote }}
           imagePullPolicy: {{ .Values.images.apiServerImage.pullPolicy }}
           ports:

--- a/charts/langgraph-cloud/values.yaml
+++ b/charts/langgraph-cloud/values.yaml
@@ -123,6 +123,7 @@ queue:
         cpu: 1000m
         memory: 2Gi
     extraEnv: []
+    envFrom: []  # List of ConfigMap or Secret references to load environment variables from
     sidecars: []
     nodeSelector: {}
     tolerations: []


### PR DESCRIPTION
This change adds support for envFrom configuration in the queue deployment template, allowing users to reference ConfigMaps and Secrets as environment variable sources.