### PR TITLE
fix: bump default timeout of queue startup probe

### DIFF
--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1395,7 +1395,7 @@ queue:
           - "--check"
       failureThreshold: 6
       periodSeconds: 60
-      timeoutSeconds: 30
+      timeoutSeconds: 60
     readinessProbe:
       exec:
         command:


### PR DESCRIPTION
Startup probe default timeout is a bit short. Some clusters see this command take roughly 40 seconds. Bumping default timeout here.