### PR TITLE
fix: Bump timeout on listener as well

### DIFF
--- a/charts/langgraph-dataplane/values.yaml
+++ b/charts/langgraph-dataplane/values.yaml
@@ -75,7 +75,7 @@ listener:
           - "--check"
       failureThreshold: 6
       periodSeconds: 60
-      timeoutSeconds: 30
+      timeoutSeconds: 60
     readinessProbe:
       exec:
         command:
@@ -84,7 +84,7 @@ listener:
           - "--check"
       failureThreshold: 6
       periodSeconds: 60
-      timeoutSeconds: 30
+      timeoutSeconds: 60
     livenessProbe:
       exec:
         command:
@@ -93,7 +93,7 @@ listener:
           - "--check"
       failureThreshold: 6
       periodSeconds: 60
-      timeoutSeconds: 30
+      timeoutSeconds: 60
     extraContainerConfig: {}
     extraEnv: []
     sidecars: []

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -854,7 +854,7 @@ listener:
           - "--check"
       failureThreshold: 6
       periodSeconds: 60
-      timeoutSeconds: 30
+      timeoutSeconds: 60
     readinessProbe:
       exec:
         command:
@@ -863,7 +863,7 @@ listener:
           - "--check"
       failureThreshold: 6
       periodSeconds: 60
-      timeoutSeconds: 30
+      timeoutSeconds: 60
     livenessProbe:
       exec:
         command:
@@ -872,7 +872,7 @@ listener:
           - "--check"
       failureThreshold: 6
       periodSeconds: 60
-      timeoutSeconds: 30
+      timeoutSeconds: 60
     extraContainerConfig: {}
     extraEnv: []
     sidecars: []


### PR DESCRIPTION
The probes take close to 30s right now. We are working on speeding that up but for now this prevents restarts.