### PR TITLE
feat: add auth mode validation at install time

### DIFF
--- a/charts/langsmith/templates/backend/auth-bootstrap.yaml
+++ b/charts/langsmith/templates/backend/auth-bootstrap.yaml
@@ -1,3 +1,18 @@
+{{- define "validateAuthMode" -}}
+{{- if and .Values.config.basicAuth.enabled .Values.config.oauth.enabled -}}
+  {{- fail "Error: Basic auth and OAuth are both enabled. Please enable only one." -}}
+{{- end -}}
+{{- if and (not .Values.config.basicAuth.enabled) (not .Values.config.oauth.enabled) -}}
+  {{- fail "Error: Neither Basic auth nor OAuth are enabled. Please enable one of them." -}}
+{{- end -}}
+{{- if and (ne .Values.config.authType "mixed") (ne .Values.config.authType "oauth") -}}
+  {{- fail "Error: config.authType must be either 'mixed' or 'oauth'." -}}
+{{- end -}}
+{{- if and (.Values.config.basicAuth.enabled) (ne .Values.config.authType "mixed") -}}
+  {{- fail "Error: Basic auth is enabled but config.authType is not set to 'mixed'." -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "validatePassword" -}}
 {{- $password := .Values.config.basicAuth.initialOrgAdminPassword -}}
 {{- if lt (len $password) 12 -}}
@@ -23,6 +38,7 @@
       name: {{ include "langsmith.secretsName" . }}
       key: initial_org_admin_password
 {{- end -}}
+{{- template "validateAuthMode" . -}}
 {{- if .Values.config.basicAuth.enabled }}
 {{- if not .Values.config.existingSecretName }}
 {{- template "validatePassword" . -}}


### PR DESCRIPTION
Adding more auth configuration validation to surface errors during install time.

## Test Plan
Tested these combinations and saw the appropriate error messages:
```
# Leads to: Error: Basic auth is enabled but config.authType is not set to 'mixed'.
config:
  authType: "oauth"
  basicAuth:
    enabled: true
  oauth:
    enabled: false


# Leads to: Error: config.authType must be either 'mixed' or 'oauth'.
config:
  authType: ""
  basicAuth:
    enabled: true
  oauth:
    enabled: false

# Leads to: Error: Neither Basic auth nor OAuth are enabled. Please enable one of them.
config:
  authType: ""
  basicAuth:
    enabled: false
  oauth:
    enabled: false

# Leads to: Error: Basic auth and OAuth are both enabled. Please enable only one.
config:
  authType: ""
  basicAuth:
    enabled: true
  oauth:
    enabled: true

# Works!
config:
  authType: "mixed"
  basicAuth:
    enabled: true
    initialOrgAdminPassword: "SecretPassword123!"  # Needed to get around the password length validation
  oauth:
    enabled: false

# Also works!
config:
  authType: "mixed"
  basicAuth:
    enabled: false
  oauth:
    enabled: true

```