### PR TITLE
chore: run e2e test post upgrade

### DIFF
--- a/charts/langsmith/templates/e2e-test/job.yaml
+++ b/charts/langsmith/templates/e2e-test/job.yaml
@@ -12,7 +12,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-    "helm.sh/hook": post-install,test
+    "helm.sh/hook": post-install,test,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
     "helm.sh/hook-weight": "9999"
     "helm.sh/fail-hook-policy": fail


### PR DESCRIPTION
Let's run the e2e test post upgrade as well as post install. If someone installs with `--wait`, then e2e failures will raise a message that something is wrong.