### PR TITLE
chore: bump default backend replicas

### DIFF
--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -291,7 +291,7 @@ backend:
   containerPort: 1984
   existingConfigMapName: ""
   deployment:
-    replicas: 1
+    replicas: 2
     labels: {}
     annotations: {}
     podSecurityContext: {}
@@ -478,8 +478,8 @@ backend:
     # If enabled, use the following values to configure the HPA. You can also use your own HPA configuration by not creating an HPA.
     # You may want to manage the HPA yourself if you have a custom autoscaling setup like KEDA.
     createHpa: true
-    minReplicas: 1
-    maxReplicas: 5
+    minReplicas: 2
+    maxReplicas: 6
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 80
   pdb:


### PR DESCRIPTION
## Test
Deployed internally to ensure we could handle at least 10 RPS on the read side