### PR TITLE
fix: use correct namespace everywhere for langgraph-dataplane chart

### DIFF
--- a/charts/langgraph-dataplane/Chart.yaml
+++ b/charts/langgraph-dataplane/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy a langgraph dataplane on kubernetes.
 type: application
-version: 0.1.22
+version: 0.1.23
 appVersion: "0.1.0"

--- a/charts/langgraph-dataplane/README.md
+++ b/charts/langgraph-dataplane/README.md
@@ -1,6 +1,6 @@
 # langgraph-dataplane
 
-![Version: 0.1.21](https://img.shields.io/badge/Version-0.1.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.23](https://img.shields.io/badge/Version-0.1.23-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Helm chart to deploy a langgraph dataplane on kubernetes.
 
@@ -22,7 +22,7 @@ You can find the guide to deploy a LangGraph Dataplane [here](https://langchain-
 | images.imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Specified as name: value. |
 | images.listenerImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.listenerImage.repository | string | `"docker.io/langchain/hosted-langserve-backend"` |  |
-| images.listenerImage.tag | string | `"0.10.109"` |  |
+| images.listenerImage.tag | string | `"0.10.116"` |  |
 | images.operatorImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.operatorImage.repository | string | `"docker.io/langchain/langgraph-operator"` |  |
 | images.operatorImage.tag | string | `"f8f6901"` |  |
@@ -117,7 +117,7 @@ You can find the guide to deploy a LangGraph Dataplane [here](https://langchain-
 | listener.deployment.livenessProbe.exec.command[2] | string | `"--check"` |  |
 | listener.deployment.livenessProbe.failureThreshold | int | `6` |  |
 | listener.deployment.livenessProbe.periodSeconds | int | `60` |  |
-| listener.deployment.livenessProbe.timeoutSeconds | int | `30` |  |
+| listener.deployment.livenessProbe.timeoutSeconds | int | `60` |  |
 | listener.deployment.nodeSelector | object | `{}` |  |
 | listener.deployment.podSecurityContext | object | `{}` |  |
 | listener.deployment.readinessProbe.exec.command[0] | string | `"saq"` |  |
@@ -125,7 +125,7 @@ You can find the guide to deploy a LangGraph Dataplane [here](https://langchain-
 | listener.deployment.readinessProbe.exec.command[2] | string | `"--check"` |  |
 | listener.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | listener.deployment.readinessProbe.periodSeconds | int | `60` |  |
-| listener.deployment.readinessProbe.timeoutSeconds | int | `30` |  |
+| listener.deployment.readinessProbe.timeoutSeconds | int | `60` |  |
 | listener.deployment.replicas | int | `1` |  |
 | listener.deployment.resources.limits.cpu | string | `"2000m"` |  |
 | listener.deployment.resources.limits.memory | string | `"4Gi"` |  |
@@ -138,7 +138,7 @@ You can find the guide to deploy a LangGraph Dataplane [here](https://langchain-
 | listener.deployment.startupProbe.exec.command[2] | string | `"--check"` |  |
 | listener.deployment.startupProbe.failureThreshold | int | `6` |  |
 | listener.deployment.startupProbe.periodSeconds | int | `60` |  |
-| listener.deployment.startupProbe.timeoutSeconds | int | `30` |  |
+| listener.deployment.startupProbe.timeoutSeconds | int | `60` |  |
 | listener.deployment.terminationGracePeriodSeconds | int | `30` |  |
 | listener.deployment.tolerations | list | `[]` |  |
 | listener.deployment.topologySpreadConstraints | list | `[]` |  |

--- a/charts/langgraph-dataplane/templates/ingress.yaml
+++ b/charts/langgraph-dataplane/templates/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "langgraphDataplane.fullname" . }}-ingress
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   annotations:
     {{- include "langgraphDataplane.annotations" . | nindent 4 }}
     {{- with .Values.ingress.annotations }}

--- a/charts/langgraph-dataplane/templates/listener/config-map.yaml
+++ b/charts/langgraph-dataplane/templates/listener/config-map.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "langgraphDataplane.fullname" . }}-listener-config
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
   annotations:

--- a/charts/langgraph-dataplane/templates/listener/deployment.yaml
+++ b/charts/langgraph-dataplane/templates/listener/deployment.yaml
@@ -10,7 +10,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.listener.name }}
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.listener.name }}

--- a/charts/langgraph-dataplane/templates/listener/hpa.yaml
+++ b/charts/langgraph-dataplane/templates/listener/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.listener.name }}
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
 spec:

--- a/charts/langgraph-dataplane/templates/listener/pdb.yaml
+++ b/charts/langgraph-dataplane/templates/listener/pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.listener.name }}
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
 spec:

--- a/charts/langgraph-dataplane/templates/listener/rbac.yaml
+++ b/charts/langgraph-dataplane/templates/listener/rbac.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "listener.serviceAccountName" $ }}-role
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
     {{- with.Values.listener.rbac.labels }}
@@ -101,7 +101,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ include "listener.serviceAccountName" $ }}
-    namespace: {{ $.Release.Namespace }}
+    namespace: {{  .Values.namespace | default .Release.Namespace }}
 roleRef:
   kind: Role
   name: {{ include "listener.serviceAccountName" $ }}-role

--- a/charts/langgraph-dataplane/templates/listener/service-account.yaml
+++ b/charts/langgraph-dataplane/templates/listener/service-account.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "listener.serviceAccountName" . }}
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
     {{- with.Values.listener.serviceAccount.labels }}

--- a/charts/langgraph-dataplane/templates/operator/config-map.yaml
+++ b/charts/langgraph-dataplane/templates/operator/config-map.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "langgraphDataplane.fullname" . }}-config
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
   annotations:

--- a/charts/langgraph-dataplane/templates/operator/deployment.yaml
+++ b/charts/langgraph-dataplane/templates/operator/deployment.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.operator.name }}
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.operator.name }}

--- a/charts/langgraph-dataplane/templates/operator/pdb.yaml
+++ b/charts/langgraph-dataplane/templates/operator/pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.operator.name }}
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
 spec:

--- a/charts/langgraph-dataplane/templates/operator/rbac.yaml
+++ b/charts/langgraph-dataplane/templates/operator/rbac.yaml
@@ -143,7 +143,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ include "operator.serviceAccountName" $ }}
-    namespace: {{ $.Release.Namespace }}
+    namespace: {{ .Values.namespace | default .Release.Namespace }}
 roleRef:
   kind: Role
   name: {{ include "operator.serviceAccountName" $ }}-role
@@ -290,7 +290,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ include "operator.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Values.namespace | default .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ include "operator.serviceAccountName" . }}-role
@@ -301,7 +301,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "operator.serviceAccountName" . }}-leader-election-role
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
     {{- with.Values.operator.rbac.labels }}
@@ -350,7 +350,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "operator.serviceAccountName" . }}-leader-election-rolebinding
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
     {{- with.Values.operator.rbac.labels }}
@@ -364,7 +364,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ include "operator.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{  .Values.namespace | default .Release.Namespace }}
 roleRef:
   kind: Role
   name: {{ include "operator.serviceAccountName" . }}-leader-election-role

--- a/charts/langgraph-dataplane/templates/operator/service-account.yaml
+++ b/charts/langgraph-dataplane/templates/operator/service-account.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "operator.serviceAccountName" . }}
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
     {{- with.Values.operator.serviceAccount.labels }}

--- a/charts/langgraph-dataplane/templates/operator/service.yaml
+++ b/charts/langgraph-dataplane/templates/operator/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.operator.name }}
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
     {{- with.Values.operator.service.labels }}

--- a/charts/langgraph-dataplane/templates/redis/pdb.yaml
+++ b/charts/langgraph-dataplane/templates/redis/pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.redis.name }}
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
 spec:

--- a/charts/langgraph-dataplane/templates/redis/secrets.yaml
+++ b/charts/langgraph-dataplane/templates/redis/secrets.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "langgraphDataplane.redisSecretsName" .}}
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
   annotations:

--- a/charts/langgraph-dataplane/templates/redis/service-account.yaml
+++ b/charts/langgraph-dataplane/templates/redis/service-account.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "redis.serviceAccountName" . }}
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
     {{- with.Values.redis.serviceAccount.labels }}

--- a/charts/langgraph-dataplane/templates/redis/service.yaml
+++ b/charts/langgraph-dataplane/templates/redis/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.redis.name }}
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
     {{- with.Values.redis.service.labels }}

--- a/charts/langgraph-dataplane/templates/redis/stateful-set.yaml
+++ b/charts/langgraph-dataplane/templates/redis/stateful-set.yaml
@@ -7,7 +7,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.redis.name }}
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
     {{- with.Values.redis.statefulSet.labels }}

--- a/charts/langgraph-dataplane/templates/secrets.yaml
+++ b/charts/langgraph-dataplane/templates/secrets.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "langgraphDataplane.secretsName" . }}
-  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "langgraphDataplane.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
Fixes incorrect namespace for certain rolebindings. Also standardizes on not adding extra quote to string variables.

Closes INF-698