### PR TITLE
chore: bump 0.11.4 and fix public sharing

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.11.3
+version: 0.11.4
 appVersion: "0.11.13"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.11.3](https://img.shields.io/badge/Version-0.11.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.13](https://img.shields.io/badge/AppVersion-0.11.13-informational?style=flat-square)
+![Version: 0.11.4](https://img.shields.io/badge/Version-0.11.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.13](https://img.shields.io/badge/AppVersion-0.11.13-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 

--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -186,7 +186,7 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.platformBackend.service.port }};
         }
 
-        location /{{ .Values.ingress.subdomain }}/api/v1/public {
+        location = /{{ .Values.ingress.subdomain }}/api/v1/public/download {
             rewrite /{{ .Values.ingress.subdomain }}/api/v1/public/(.*) /public/$1 break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
@@ -517,7 +517,7 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.platformBackend.service.port }};
         }
 
-        location /api/v1/public {
+        location = /api/v1/public/download {
             rewrite /api/v1/public/(.*) /public/$1  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;


### PR DESCRIPTION
We have a collision with our other public api routes so we should only explicitly route the /public/download routes to platform backend.