### PR TITLE
feat: make api-server probes configurable via values.yaml

### DIFF
--- a/charts/langgraph-cloud/Chart.yaml
+++ b/charts/langgraph-cloud/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the LangGraph Cloud application and all services it depends on.
 type: application
-version: 0.1.17
+version: 0.1.18
 appVersion: "0.2.0"

--- a/charts/langgraph-cloud/templates/api-server/deployment.yaml
+++ b/charts/langgraph-cloud/templates/api-server/deployment.yaml
@@ -99,32 +99,11 @@ spec:
               containerPort: {{ .Values.apiServer.containerPort }}
               protocol: TCP
           startupProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - exec python /api/healthcheck.py
-            failureThreshold: 6
-            periodSeconds: 10
-            timeoutSeconds: 1
+            {{- toYaml .Values.apiServer.deployment.startupProbe | nindent 12 }}
           readinessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - exec python /api/healthcheck.py
-            failureThreshold: 6
-            periodSeconds: 10
-            timeoutSeconds: 1
+            {{- toYaml .Values.apiServer.deployment.readinessProbe | nindent 12 }}
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - exec python /api/healthcheck.py
-            failureThreshold: 6
-            periodSeconds: 10
-            timeoutSeconds: 1
+            {{- toYaml .Values.apiServer.deployment.livenessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.apiServer.deployment.resources | nindent 12 }}
           securityContext:

--- a/charts/langgraph-cloud/templates/queue/deployment.yaml
+++ b/charts/langgraph-cloud/templates/queue/deployment.yaml
@@ -95,26 +95,11 @@ spec:
               containerPort: {{ .Values.queue.containerPort }}
               protocol: TCP
           startupProbe:
-            httpGet:
-              port: {{ .Values.queue.containerPort }}
-              path: "/ok"
-            failureThreshold: 6
-            periodSeconds: 10
-            timeoutSeconds: 1
+            {{- toYaml .Values.queue.deployment.startupProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              port: {{ .Values.queue.containerPort }}
-              path: "/ok"
-            failureThreshold: 6
-            periodSeconds: 10
-            timeoutSeconds: 1
+            {{- toYaml .Values.queue.deployment.readinessProbe | nindent 12 }}
           livenessProbe:
-            httpGet:
-              port: {{ .Values.queue.containerPort }}
-              path: "/ok"
-            failureThreshold: 6
-            periodSeconds: 10
-            timeoutSeconds: 1
+            {{- toYaml .Values.queue.deployment.livenessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.queue.deployment.resources | nindent 12 }}
           securityContext:

--- a/charts/langgraph-cloud/templates/studio/deployment.yaml
+++ b/charts/langgraph-cloud/templates/studio/deployment.yaml
@@ -62,26 +62,11 @@ spec:
               containerPort: {{ .Values.studio.containerPort }}
               protocol: TCP
           startupProbe:
-            httpGet:
-              path: /health
-              port: {{ .Values.studio.containerPort }}
-            failureThreshold: 6
-            periodSeconds: 10
-            timeoutSeconds: 1
+            {{- toYaml .Values.studio.deployment.startupProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: {{ .Values.studio.containerPort }}
-            failureThreshold: 3
-            periodSeconds: 10
-            timeoutSeconds: 1
+            {{- toYaml .Values.studio.deployment.readinessProbe | nindent 12 }}
           livenessProbe:
-            httpGet:
-              path: /health
-              port: {{ .Values.studio.containerPort }}
-            failureThreshold: 6
-            periodSeconds: 10
-            timeoutSeconds: 1
+            {{- toYaml .Values.studio.deployment.livenessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.studio.deployment.resources | nindent 12 }}
           securityContext:

--- a/charts/langgraph-cloud/values.yaml
+++ b/charts/langgraph-cloud/values.yaml
@@ -83,6 +83,33 @@ apiServer:
     volumes: []
     volumeMounts: []
     initContainers: []
+    startupProbe:
+      exec:
+        command:
+          - /bin/sh
+          - -c
+          - exec python /api/healthcheck.py
+      failureThreshold: 6
+      periodSeconds: 10
+      timeoutSeconds: 1
+    readinessProbe:
+      exec:
+        command:
+          - /bin/sh
+          - -c
+          - exec python /api/healthcheck.py
+      failureThreshold: 6
+      periodSeconds: 10
+      timeoutSeconds: 1
+    livenessProbe:
+      exec:
+        command:
+          - /bin/sh
+          - -c
+          - exec python /api/healthcheck.py
+      failureThreshold: 6
+      periodSeconds: 10
+      timeoutSeconds: 1
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -136,6 +163,27 @@ queue:
     affinity: {}
     volumes: []
     volumeMounts: []
+    startupProbe:
+      httpGet:
+        path: "/ok"
+        port: 8000
+      failureThreshold: 6
+      periodSeconds: 10
+      timeoutSeconds: 1
+    readinessProbe:
+      httpGet:
+        path: "/ok"
+        port: 8000
+      failureThreshold: 6
+      periodSeconds: 10
+      timeoutSeconds: 1
+    livenessProbe:
+      httpGet:
+        path: "/ok"
+        port: 8000
+      failureThreshold: 6
+      periodSeconds: 10
+      timeoutSeconds: 1
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -313,6 +361,27 @@ studio:
     affinity: {}
     volumes: []
     volumeMounts: []
+    startupProbe:
+      httpGet:
+        path: /health
+        port: 3968
+      failureThreshold: 6
+      periodSeconds: 10
+      timeoutSeconds: 1
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: 3968
+      failureThreshold: 3
+      periodSeconds: 10
+      timeoutSeconds: 1
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: 3968
+      failureThreshold: 6
+      periodSeconds: 10
+      timeoutSeconds: 1
   autoscaling:  #  Autoscaling configuration. Not generally needed for studio.
     enabled: false
     minReplicas: 1


### PR DESCRIPTION
Add configurable startupProbe, readinessProbe, and livenessProbe settings to apiServer.deployment in values.yaml. This allows users to customize probe settings while maintaining existing defaults.

Changes:
- Add probe configurations to values.yaml with current defaults
- Update deployment.yaml to use values from values.yaml
- Maintains backward compatibility with existing behavior


Why:
- Slow liveness/readiness healthchecks are causing application pods to restart frequently
- We want to make liveness/readiness `httpGet` checks instead of exec, and update some of the time settings for each of the probe types.