### PR TITLE
chore: add references to replicated clickhouse helm chart

### DIFF
--- a/charts/langsmith/examples/replicated-clickhouse/README.md
+++ b/charts/langsmith/examples/replicated-clickhouse/README.md
@@ -1,5 +1,5 @@
 # Replicated Clickhouse Cluster
-> To setup a replicated Clickhouse cluster, you can either use the Altinity Helm chart defined [here](https://github.com/Altinity/helm-charts/tree/main/charts/clickhouse) with specific example configurations shown [here](https://github.com/Altinity/helm-charts/tree/main/charts/clickhouse/examples) or follow along with the manual installatin below. Using the Helm chart is likely easier to manage in CI, but the manual process may be best for initial development depending on your use case.
+> To setup a replicated Clickhouse cluster, you can either use the Altinity Helm chart defined [here](https://github.com/Altinity/helm-charts/tree/main/charts/clickhouse) with specific example configurations shown [here](https://github.com/Altinity/helm-charts/tree/main/charts/clickhouse/examples) or follow along with the manual installation below. Using the Helm chart is likely easier to manage in CI, but the manual process may be best for initial development depending on your use case.
 
 This folder can be used to manually setup a replicated clickhouse setup on a kubernetes cluster. You can then connect your LangSmith instance to this replicated ClickHouse setup. There are two manifest files in this folder that are used in the installation instructions below:
 - `zookeeper-3-node-config.yaml`


### PR DESCRIPTION
Looks like this:

<img width="1147" height="403" alt="Screenshot 2025-09-08 at 2 15 56 PM" src="https://github.com/user-attachments/assets/a9c86da4-0bfe-4549-b5f0-0af5fb0f3f1f" />

