### PR TITLE
Add HOST_BACKEND_ENDPOINT_PUBLIC env var if ingress provided

### DIFF
--- a/charts/langsmith/templates/host-backend/deployment.yaml
+++ b/charts/langsmith/templates/host-backend/deployment.yaml
@@ -7,7 +7,7 @@
 {{- end }}
 {{- if .Values.ingress.hostname }}
 - name: HOST_BACKEND_ENDPOINT_PUBLIC
-  value: {{ .Values.ingress.hostname }}{{- with .Values.ingress.subdomain }}/{{ . }}{{- end }}
+  value: {{ .Values.config.hostname }}
 {{- end }}
 {{- end -}}
 {{- $envVars := concat (include "langsmith.commonEnv" . | fromYamlArray ) (include "hostBackendEnvVars" . | fromYamlArray) .Values.hostBackend.deployment.extraEnv -}}


### PR DESCRIPTION
Currently, the host-backend docs show the Hostname as the internal Kubernetes endpoint, even if there is an ingress. This instead shows the DNS name of the ingress