### PR TITLE
chore: disable randomize name by default

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -198,7 +198,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | backend.authBootstrap.labels | object | `{}` |  |
 | backend.authBootstrap.nodeSelector | object | `{}` |  |
 | backend.authBootstrap.podSecurityContext | object | `{}` |  |
-| backend.authBootstrap.randomizeName | bool | `true` |  |
+| backend.authBootstrap.randomizeName | bool | `false` |  |
 | backend.authBootstrap.resources.limits.cpu | string | `"1000m"` |  |
 | backend.authBootstrap.resources.limits.memory | string | `"1Gi"` |  |
 | backend.authBootstrap.resources.requests.cpu | string | `"200m"` |  |
@@ -226,7 +226,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | backend.clickhouseMigrations.labels | object | `{}` |  |
 | backend.clickhouseMigrations.nodeSelector | object | `{}` |  |
 | backend.clickhouseMigrations.podSecurityContext | object | `{}` |  |
-| backend.clickhouseMigrations.randomizeName | bool | `true` |  |
+| backend.clickhouseMigrations.randomizeName | bool | `false` |  |
 | backend.clickhouseMigrations.resources.limits.cpu | string | `"1000m"` |  |
 | backend.clickhouseMigrations.resources.limits.memory | string | `"1Gi"` |  |
 | backend.clickhouseMigrations.resources.requests.cpu | string | `"200m"` |  |
@@ -332,7 +332,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | backend.migrations.labels | object | `{}` |  |
 | backend.migrations.nodeSelector | object | `{}` |  |
 | backend.migrations.podSecurityContext | object | `{}` |  |
-| backend.migrations.randomizeName | bool | `true` |  |
+| backend.migrations.randomizeName | bool | `false` |  |
 | backend.migrations.resources.limits.cpu | string | `"1000m"` |  |
 | backend.migrations.resources.limits.memory | string | `"1Gi"` |  |
 | backend.migrations.resources.requests.cpu | string | `"200m"` |  |

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -339,7 +339,7 @@ backend:
   migrations:
     enabled: true
     # Helpful when running using helm template to avoid the job name conflict
-    randomizeName: true
+    randomizeName: false
     labels: {}
     annotations: {}
     podSecurityContext: {}
@@ -427,7 +427,7 @@ backend:
     ttlSecondsAfterFinished: 600
   authBootstrap:
     # Helpful when running using helm template to avoid the job name conflict
-    randomizeName: true
+    randomizeName: false
     labels: {}
     annotations: {}
     podSecurityContext: {}
@@ -456,7 +456,7 @@ backend:
   clickhouseMigrations:
     enabled: true
     # Helpful when running using helm template to avoid the job name conflict
-    randomizeName: true
+    randomizeName: false
     labels: {}
     annotations: {}
     podSecurityContext: {}


### PR DESCRIPTION
Disable randomizing name by default. This is only useful when running via helm template.