### PR TITLE
chore: filter K8s debugging script to LangChain resources only

### DIFF
--- a/charts/langsmith/scripts/get_k8s_debugging_info.sh
+++ b/charts/langsmith/scripts/get_k8s_debugging_info.sh
@@ -1,17 +1,33 @@
 #!/bin/bash
 
 # We expect the namespace hosting all kubernetes resources to be passed as an argument to this script
+FILTER_REGEX=""
+FILTER_LABELS=""
+
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     --namespace) NS="$2"; shift ;;
+    --filter-regex) FILTER_REGEX="$2"; shift ;;
+    --filter-labels) FILTER_LABELS="$2"; shift ;;
     *) echo "Unknown parameter passed: $1"; exit 1 ;;
   esac
   shift
 done
 
 if [ -z "$NS" ]; then
-  echo "Usage: $0 --namespace <namespace>"
+  echo "Usage: $0 --namespace <namespace> [--filter-regex <pattern>] [--filter-labels <selector>]"
+  echo ""
+  echo "Examples:"
+  echo "  $0 --namespace langchain --filter-regex '^(langsmith-|lg-|toolbox)'"
+  echo "  $0 --namespace langchain --filter-labels 'app.kubernetes.io/instance=langsmith'"
+  echo "  $0 --namespace langchain --filter-labels 'app.kubernetes.io/part-of=langgraph'"
   exit 1
+fi
+
+# Default regex filter for backward compatibility
+if [ -z "$FILTER_REGEX" ] && [ -z "$FILTER_LABELS" ]; then
+  FILTER_REGEX='^(langsmith-|lg-|toolbox)'
+  echo "No filter specified. Using default regex filter: $FILTER_REGEX"
 fi
 
 DIR=/tmp/langchain-debugging-$(date +%Y%m%d%H%M%S)
@@ -20,25 +36,40 @@ echo "Starting to pull debugging info. Creating directory $DIR..."
 mkdir -p "$DIR"
 
 echo "Pulling summary of resources..."
-kubectl get all -n "$NS" -o wide | grep -E '^(NAME|langsmith-|lg-|toolbox)' > "$DIR/resources_summary.txt"
+if [ -n "$FILTER_LABELS" ]; then
+  kubectl get all -n "$NS" -l "$FILTER_LABELS" -o wide > "$DIR/resources_summary.txt"
+else
+  kubectl get all -n "$NS" -o wide | grep -E "^(NAME|$FILTER_REGEX)" > "$DIR/resources_summary.txt"
+fi
 
 echo "Pulling details of all resources..."
-kubectl get all -n "$NS" -o yaml > "$DIR/resources_details_all.yaml"
-# Filter for langchain-related resources only
-grep -E '^(kind:|metadata:|  name: (langsmith-|lg-|toolbox))' "$DIR/resources_details_all.yaml" > "$DIR/resources_details.yaml" || cp "$DIR/resources_details_all.yaml" "$DIR/resources_details.yaml"
-rm "$DIR/resources_details_all.yaml"
+if [ -n "$FILTER_LABELS" ]; then
+  kubectl get all -n "$NS" -l "$FILTER_LABELS" -o yaml > "$DIR/resources_details.yaml"
+else
+  kubectl get all -n "$NS" -o yaml > "$DIR/resources_details_all.yaml"
+  grep -E "^(kind:|metadata:|  name: ($FILTER_REGEX))" "$DIR/resources_details_all.yaml" > "$DIR/resources_details.yaml" || cp "$DIR/resources_details_all.yaml" "$DIR/resources_details.yaml"
+  rm "$DIR/resources_details_all.yaml"
+fi
 
 echo "Pulling kubernetes events..."
 kubectl get events -n "$NS" --sort-by=.lastTimestamp > "$DIR/events.txt"
 
-echo "Pulling resource usage for langchain-related pods..."
-kubectl top pods -n "$NS" --containers | grep -E '^(NAME|langsmith-|lg-|toolbox)' > "$DIR/pod-resource-usage.txt"
+echo "Pulling resource usage for filtered pods..."
+if [ -n "$FILTER_LABELS" ]; then
+  kubectl top pods -n "$NS" -l "$FILTER_LABELS" --containers > "$DIR/pod-resource-usage.txt"
+else
+  kubectl top pods -n "$NS" --containers | grep -E "^(NAME|$FILTER_REGEX)" > "$DIR/pod-resource-usage.txt"
+fi
 
-echo "Pulling container logs for langchain-related pods only. Also pulling previous logs from restarted containers..."
+echo "Pulling container logs for filtered pods only. Also pulling previous logs from restarted containers..."
 mkdir -p "$DIR/logs"
 
-# Filter for langchain-related pods based on naming conventions
-PODS=$(kubectl get pods -n "$NS" -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep -E '^(langsmith-|lg-|toolbox)' | tr '\n' ' ')
+# Get filtered pods
+if [ -n "$FILTER_LABELS" ]; then
+  PODS=$(kubectl get pods -n "$NS" -l "$FILTER_LABELS" -o jsonpath='{.items[*].metadata.name}')
+else
+  PODS=$(kubectl get pods -n "$NS" -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep -E "^$FILTER_REGEX" | tr '\n' ' ')
+fi
 
 for POD in $PODS; do
   CONTAINERS=$(kubectl get pod "$POD" -n "$NS" -o jsonpath='{.spec.containers[*].name}')


### PR DESCRIPTION
## Summary
- Updates `get_k8s_debugging_info.sh` to filter results for only LangChain-related resources
- Allows customers to embed other resources in the same cluster without polluting debug output
- Removes `jq` dependency by using `jsonpath` for restart count check

## Changes
- **Resource filtering**: Added grep filters for `langsmith-*`, `lg-*`, and `toolbox*` prefixes to:
  - Resource summary output
  - Resource details YAML
  - Pod resource usage
  - Pod log collection
- **Simplified restart count check**: Changed from `jq` to `jsonpath` for better portability
- **Improved output messages**: Updated echo statements for clarity

## Test Plan
- [ ] Test script on namespace with mixed LangChain and non-LangChain resources
- [ ] Verify only LangChain resources appear in output files
- [ ] Test with pods that have restart counts > 0
- [ ] Confirm no `jq` dependency required