### PR TITLE
chore: release new wolfi images with validation

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
 version: 0.11.21
-appVersion: "0.11.61"
+appVersion: "0.11.64"

--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.11.20
-appVersion: "0.11.57"
+version: 0.11.21
+appVersion: "0.11.61"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.11.20](https://img.shields.io/badge/Version-0.11.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.57](https://img.shields.io/badge/AppVersion-0.11.57-informational?style=flat-square)
+![Version: 0.11.21](https://img.shields.io/badge/Version-0.11.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.61](https://img.shields.io/badge/AppVersion-0.11.61-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -29,29 +29,29 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | gateway.subdomain | string | `""` |  |
 | images.aceBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.aceBackendImage.repository | string | `"docker.io/langchain/langsmith-ace-backend"` |  |
-| images.aceBackendImage.tag | string | `"0.11.57"` |  |
+| images.aceBackendImage.tag | string | `"0.11.61"` |  |
 | images.backendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.backendImage.repository | string | `"docker.io/langchain/langsmith-backend"` |  |
-| images.backendImage.tag | string | `"0.11.57"` |  |
+| images.backendImage.tag | string | `"0.11.61"` |  |
 | images.clickhouseImage.pullPolicy | string | `"Always"` |  |
 | images.clickhouseImage.repository | string | `"docker.io/clickhouse/clickhouse-server"` |  |
 | images.clickhouseImage.tag | string | `"25.4"` |  |
 | images.frontendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.frontendImage.repository | string | `"docker.io/langchain/langsmith-frontend"` |  |
-| images.frontendImage.tag | string | `"0.11.57"` |  |
+| images.frontendImage.tag | string | `"0.11.61"` |  |
 | images.hostBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.hostBackendImage.repository | string | `"docker.io/langchain/hosted-langserve-backend"` |  |
-| images.hostBackendImage.tag | string | `"0.11.57"` |  |
+| images.hostBackendImage.tag | string | `"0.11.61"` |  |
 | images.imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Specified as name: value. |
 | images.operatorImage.pullPolicy | string | `"Always"` |  |
 | images.operatorImage.repository | string | `"docker.io/langchain/langgraph-operator"` |  |
 | images.operatorImage.tag | string | `"0.1.11"` |  |
 | images.platformBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.platformBackendImage.repository | string | `"docker.io/langchain/langsmith-go-backend"` |  |
-| images.platformBackendImage.tag | string | `"0.11.57"` |  |
+| images.platformBackendImage.tag | string | `"0.11.61"` |  |
 | images.playgroundImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.playgroundImage.repository | string | `"docker.io/langchain/langsmith-playground"` |  |
-| images.playgroundImage.tag | string | `"0.11.57"` |  |
+| images.playgroundImage.tag | string | `"0.11.61"` |  |
 | images.postgresImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.postgresImage.repository | string | `"docker.io/postgres"` |  |
 | images.postgresImage.tag | string | `"14.7"` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.11.21](https://img.shields.io/badge/Version-0.11.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.61](https://img.shields.io/badge/AppVersion-0.11.61-informational?style=flat-square)
+![Version: 0.11.21](https://img.shields.io/badge/Version-0.11.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.64](https://img.shields.io/badge/AppVersion-0.11.64-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -29,29 +29,29 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | gateway.subdomain | string | `""` |  |
 | images.aceBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.aceBackendImage.repository | string | `"docker.io/langchain/langsmith-ace-backend"` |  |
-| images.aceBackendImage.tag | string | `"0.11.61"` |  |
+| images.aceBackendImage.tag | string | `"0.11.64"` |  |
 | images.backendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.backendImage.repository | string | `"docker.io/langchain/langsmith-backend"` |  |
-| images.backendImage.tag | string | `"0.11.61"` |  |
+| images.backendImage.tag | string | `"0.11.64"` |  |
 | images.clickhouseImage.pullPolicy | string | `"Always"` |  |
 | images.clickhouseImage.repository | string | `"docker.io/clickhouse/clickhouse-server"` |  |
 | images.clickhouseImage.tag | string | `"25.4"` |  |
 | images.frontendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.frontendImage.repository | string | `"docker.io/langchain/langsmith-frontend"` |  |
-| images.frontendImage.tag | string | `"0.11.61"` |  |
+| images.frontendImage.tag | string | `"0.11.64"` |  |
 | images.hostBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.hostBackendImage.repository | string | `"docker.io/langchain/hosted-langserve-backend"` |  |
-| images.hostBackendImage.tag | string | `"0.11.61"` |  |
+| images.hostBackendImage.tag | string | `"0.11.64"` |  |
 | images.imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Specified as name: value. |
 | images.operatorImage.pullPolicy | string | `"Always"` |  |
 | images.operatorImage.repository | string | `"docker.io/langchain/langgraph-operator"` |  |
 | images.operatorImage.tag | string | `"0.1.11"` |  |
 | images.platformBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.platformBackendImage.repository | string | `"docker.io/langchain/langsmith-go-backend"` |  |
-| images.platformBackendImage.tag | string | `"0.11.61"` |  |
+| images.platformBackendImage.tag | string | `"0.11.64"` |  |
 | images.playgroundImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.playgroundImage.repository | string | `"docker.io/langchain/langsmith-playground"` |  |
-| images.playgroundImage.tag | string | `"0.11.61"` |  |
+| images.playgroundImage.tag | string | `"0.11.64"` |  |
 | images.postgresImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.postgresImage.repository | string | `"docker.io/postgres"` |  |
 | images.postgresImage.tag | string | `"14.7"` |  |

--- a/charts/langsmith/ci/readonly-config-values.yaml
+++ b/charts/langsmith/ci/readonly-config-values.yaml
@@ -38,17 +38,9 @@ aceBackend:
     volumes:
       - name: tmp
         emptyDir: {}
-      - name: var-run
-        emptyDir: {}
-      - name: var-lib-nginx
-        emptyDir: {}
     volumeMounts:
       - name: tmp
         mountPath: /app/node_modules
-      - name: var-run
-        mountPath: /var/run
-      - name: var-lib-nginx
-        mountPath: /var/lib/nginx
 
 backend:
   deployment:
@@ -237,9 +229,17 @@ frontend:
     volumes:
       - name: tmp
         emptyDir: {}
+      - name: var-run
+        emptyDir: {}
+      - name: var-lib-nginx
+        emptyDir: {}
     volumeMounts:
       - name: tmp
         mountPath: /tmp
+      - name: var-run
+        mountPath: /var/run
+      - name: var-lib-nginx
+        mountPath: /var/lib/nginx
 
 platformBackend:
   deployment:

--- a/charts/langsmith/ci/readonly-config-values.yaml
+++ b/charts/langsmith/ci/readonly-config-values.yaml
@@ -38,9 +38,17 @@ aceBackend:
     volumes:
       - name: tmp
         emptyDir: {}
+      - name: var-run
+        emptyDir: {}
+      - name: var-lib-nginx
+        emptyDir: {}
     volumeMounts:
       - name: tmp
         mountPath: /app/node_modules
+      - name: var-run
+        mountPath: /var/run
+      - name: var-lib-nginx
+        mountPath: /var/lib/nginx
 
 backend:
   deployment:

--- a/charts/langsmith/ci/readonly-config-values.yaml
+++ b/charts/langsmith/ci/readonly-config-values.yaml
@@ -38,9 +38,13 @@ aceBackend:
     volumes:
       - name: tmp
         emptyDir: {}
+      - name: deno-cache
+        emptyDir: {}
     volumeMounts:
       - name: tmp
         mountPath: /app/node_modules
+      - name: deno-cache
+        mountPath: /.cache
 
 backend:
   deployment:

--- a/charts/langsmith/examples/read_only_config.yaml
+++ b/charts/langsmith/examples/read_only_config.yaml
@@ -364,9 +364,17 @@ frontend:
     volumes:
       - name: tmp
         emptyDir: {}
+      - name: var-run
+        emptyDir: {}
+      - name: var-lib-nginx
+        emptyDir: {}
     volumeMounts:
       - name: tmp
         mountPath: /tmp
+      - name: var-run
+        mountPath: /var/run
+      - name: var-lib-nginx
+        mountPath: /var/lib/nginx
 
 platformBackend:
   deployment:

--- a/charts/langsmith/examples/read_only_config.yaml
+++ b/charts/langsmith/examples/read_only_config.yaml
@@ -27,9 +27,13 @@ aceBackend:
     volumes:
       - name: tmp
         emptyDir: {}
+      - name: deno-cache
+        emptyDir: {}
     volumeMounts:
       - name: tmp
         mountPath: /app/node_modules
+      - name: deno-cache
+        mountPath: /.cache
 
 backend:
   deployment:

--- a/charts/langsmith/templates/ace-backend/deployment.yaml
+++ b/charts/langsmith/templates/ace-backend/deployment.yaml
@@ -6,6 +6,18 @@
 {{- end -}}
 {{- $envVars := concat (include "aceBackendEnvVars" . | fromYamlArray) .Values.aceBackend.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
+{{- /* Validate cache mounts when readOnlyRootFilesystem is enabled */ -}}
+{{- if .Values.aceBackend.deployment.securityContext.readOnlyRootFilesystem }}
+{{- $hasCacheMount := false }}
+{{- range .Values.aceBackend.deployment.volumeMounts }}
+  {{- if eq .mountPath "/.cache" }}
+    {{- $hasCacheMount = true }}
+  {{- end }}
+{{- end }}
+{{- if not $hasCacheMount }}
+{{- fail "ERROR: When aceBackend.deployment.securityContext.readOnlyRootFilesystem is true, you must mount /.cache as a writable volume. See read_only config example." }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/langsmith/templates/frontend/deployment.yaml
+++ b/charts/langsmith/templates/frontend/deployment.yaml
@@ -1,3 +1,20 @@
+# Validate the appropriate mounts are present for the readOnlyRootFilesystem
+{{- if .Values.frontend.deployment.securityContext.readOnlyRootFilesystem }}
+{{- $hasNginxMount := false }}
+{{- $hasVarRunMount := false }}
+{{- range .Values.frontend.deployment.volumeMounts }}
+  {{- if eq .mountPath "/var/lib/nginx" }}
+    {{- $hasNginxMount = true }}
+  {{- end }}
+  {{- if eq .mountPath "/var/run" }}
+    {{- $hasVarRunMount = true }}
+  {{- end }}
+{{- end }}
+{{- if not (and $hasNginxMount $hasVarRunMount) }}
+{{- fail "ERROR: When frontend.deployment.securityContext.readOnlyRootFilesystem is true, you must mount both /var/lib/nginx and /var/run as writable volumes. Missing mounts - /var/lib/nginx: %t, /var/run: %t. Add these as emptyDir volumes. See read_only guide." (not $hasNginxMount) (not $hasVarRunMount) }}
+{{- end }}
+{{- end }}
+
 {{- define "frontendEnvVars" -}}
 {{- if .Values.config.oauth.enabled }}
 - name: VITE_OAUTH_CLIENT_ID

--- a/charts/langsmith/templates/frontend/deployment.yaml
+++ b/charts/langsmith/templates/frontend/deployment.yaml
@@ -1,20 +1,3 @@
-# Validate the appropriate mounts are present for the readOnlyRootFilesystem
-{{- if .Values.frontend.deployment.securityContext.readOnlyRootFilesystem }}
-{{- $hasNginxMount := false }}
-{{- $hasVarRunMount := false }}
-{{- range .Values.frontend.deployment.volumeMounts }}
-  {{- if eq .mountPath "/var/lib/nginx" }}
-    {{- $hasNginxMount = true }}
-  {{- end }}
-  {{- if eq .mountPath "/var/run" }}
-    {{- $hasVarRunMount = true }}
-  {{- end }}
-{{- end }}
-{{- if not (and $hasNginxMount $hasVarRunMount) }}
-{{- fail "ERROR: When frontend.deployment.securityContext.readOnlyRootFilesystem is true, you must mount both /var/lib/nginx and /var/run as writable volumes. Add emptyDir volumes for 'var-lib-nginx' mounted at /var/lib/nginx and 'var-run' mounted at /var/run. See read_only config example." }}
-{{- end }}
-{{- end }}
-
 {{- define "frontendEnvVars" -}}
 {{- if .Values.config.oauth.enabled }}
 - name: VITE_OAUTH_CLIENT_ID
@@ -47,6 +30,22 @@
 {{- include "langsmith.detectDuplicates" $envVars -}}
 {{- $volumes := concat .Values.commonVolumes .Values.frontend.deployment.volumes -}}
 {{- $volumeMounts := concat .Values.commonVolumes .Values.frontend.deployment.volumeMounts -}}
+{{- /* Validate nginx mounts when readOnlyRootFilesystem is enabled */ -}}
+{{- if .Values.frontend.deployment.securityContext.readOnlyRootFilesystem }}
+{{- $hasNginxMount := false }}
+{{- $hasVarRunMount := false }}
+{{- range $volumeMounts }}
+  {{- if eq .mountPath "/var/lib/nginx" }}
+    {{- $hasNginxMount = true }}
+  {{- end }}
+  {{- if eq .mountPath "/var/run" }}
+    {{- $hasVarRunMount = true }}
+  {{- end }}
+{{- end }}
+{{- if not (and $hasNginxMount $hasVarRunMount) }}
+{{- fail "ERROR: When frontend.deployment.securityContext.readOnlyRootFilesystem is true, you must mount both /var/lib/nginx and /var/run as writable volumes. Add emptyDir volumes for 'var-lib-nginx' mounted at /var/lib/nginx and 'var-run' mounted at /var/run. See read_only config example." }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/langsmith/templates/frontend/deployment.yaml
+++ b/charts/langsmith/templates/frontend/deployment.yaml
@@ -11,7 +11,7 @@
   {{- end }}
 {{- end }}
 {{- if not (and $hasNginxMount $hasVarRunMount) }}
-{{- fail "ERROR: When frontend.deployment.securityContext.readOnlyRootFilesystem is true, you must mount both /var/lib/nginx and /var/run as writable volumes. Missing mounts - /var/lib/nginx: %t, /var/run: %t. Add these as emptyDir volumes. See read_only guide." (not $hasNginxMount) (not $hasVarRunMount) }}
+{{- fail "ERROR: When frontend.deployment.securityContext.readOnlyRootFilesystem is true, you must mount both /var/lib/nginx and /var/run as writable volumes. Add emptyDir volumes for 'var-lib-nginx' mounted at /var/lib/nginx and 'var-run' mounted at /var/run. See read_only config example." }}
 {{- end }}
 {{- end }}
 

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -27,19 +27,19 @@ images:
   aceBackendImage:
     repository: "docker.io/langchain/langsmith-ace-backend"
     pullPolicy: IfNotPresent
-    tag: "0.11.61"
+    tag: "0.11.64"
   backendImage:
     repository: "docker.io/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
-    tag: "0.11.61"
+    tag: "0.11.64"
   frontendImage:
     repository: "docker.io/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
-    tag: "0.11.61"
+    tag: "0.11.64"
   hostBackendImage:
     repository: "docker.io/langchain/hosted-langserve-backend"
     pullPolicy: IfNotPresent
-    tag: "0.11.61"
+    tag: "0.11.64"
   operatorImage:
     repository: "docker.io/langchain/langgraph-operator"
     pullPolicy: Always
@@ -47,11 +47,11 @@ images:
   platformBackendImage:
     repository: "docker.io/langchain/langsmith-go-backend"
     pullPolicy: IfNotPresent
-    tag: "0.11.61"
+    tag: "0.11.64"
   playgroundImage:
     repository: "docker.io/langchain/langsmith-playground"
     pullPolicy: IfNotPresent
-    tag: "0.11.61"
+    tag: "0.11.64"
   postgresImage:
     repository: "docker.io/postgres"
     pullPolicy: IfNotPresent

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -27,19 +27,19 @@ images:
   aceBackendImage:
     repository: "docker.io/langchain/langsmith-ace-backend"
     pullPolicy: IfNotPresent
-    tag: "0.11.57"
+    tag: "0.11.61"
   backendImage:
     repository: "docker.io/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
-    tag: "0.11.57"
+    tag: "0.11.61"
   frontendImage:
     repository: "docker.io/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
-    tag: "0.11.57"
+    tag: "0.11.61"
   hostBackendImage:
     repository: "docker.io/langchain/hosted-langserve-backend"
     pullPolicy: IfNotPresent
-    tag: "0.11.57"
+    tag: "0.11.61"
   operatorImage:
     repository: "docker.io/langchain/langgraph-operator"
     pullPolicy: Always
@@ -47,11 +47,11 @@ images:
   platformBackendImage:
     repository: "docker.io/langchain/langsmith-go-backend"
     pullPolicy: IfNotPresent
-    tag: "0.11.57"
+    tag: "0.11.61"
   playgroundImage:
     repository: "docker.io/langchain/langsmith-playground"
     pullPolicy: IfNotPresent
-    tag: "0.11.57"
+    tag: "0.11.61"
   postgresImage:
     repository: "docker.io/postgres"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Testing

Confirmed that without the volume mounts you get a validation error with readonly:
```
Error: INSTALLATION FAILED: execution error at (langsmith/templates/frontend/deployment.yaml:46:4): ERROR: When frontend.deployment.securityContext.readOnlyRootFilesystem is true, you must mount both /var/lib/nginx and /var/run as writable volumes. Add emptyDir volumes for 'var-lib-nginx' mounted at /var/lib/nginx and 'var-run' mounted at /var/run. See read_only config example.
```

Once you add volume mounts the error goes away.

Confirmed that without the ace volume you also get an error:
```
Error: INSTALLATION FAILED: execution error at (langsmith/templates/ace-backend/deployment.yaml:18:4): ERROR: When aceBackend.deployment.securityContext.readOnlyRootFilesystem is true, you must mount /.cache as a writable volume. See read_only config example.
```