### PR TITLE
Revert: filter K8s debugging script to LangChain resources only

### DIFF
--- a/charts/langsmith/scripts/get_k8s_debugging_info.sh
+++ b/charts/langsmith/scripts/get_k8s_debugging_info.sh
@@ -1,33 +1,17 @@
 #!/bin/bash
 
 # We expect the namespace hosting all kubernetes resources to be passed as an argument to this script
-FILTER_REGEX=""
-FILTER_LABELS=""
-
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     --namespace) NS="$2"; shift ;;
-    --filter-regex) FILTER_REGEX="$2"; shift ;;
-    --filter-labels) FILTER_LABELS="$2"; shift ;;
     *) echo "Unknown parameter passed: $1"; exit 1 ;;
   esac
   shift
 done
 
 if [ -z "$NS" ]; then
-  echo "Usage: $0 --namespace <namespace> [--filter-regex <pattern>] [--filter-labels <selector>]"
-  echo ""
-  echo "Examples:"
-  echo "  $0 --namespace langchain --filter-regex '^(langsmith-|lg-|toolbox)'"
-  echo "  $0 --namespace langchain --filter-labels 'app.kubernetes.io/instance=langsmith'"
-  echo "  $0 --namespace langchain --filter-labels 'app.kubernetes.io/part-of=langgraph'"
+  echo "Usage: $0 --namespace <namespace>"
   exit 1
-fi
-
-# Default regex filter for backward compatibility
-if [ -z "$FILTER_REGEX" ] && [ -z "$FILTER_LABELS" ]; then
-  FILTER_REGEX='^(langsmith-|lg-|toolbox)'
-  echo "No filter specified. Using default regex filter: $FILTER_REGEX"
 fi
 
 DIR=/tmp/langchain-debugging-$(date +%Y%m%d%H%M%S)
@@ -36,40 +20,20 @@ echo "Starting to pull debugging info. Creating directory $DIR..."
 mkdir -p "$DIR"
 
 echo "Pulling summary of resources..."
-if [ -n "$FILTER_LABELS" ]; then
-  kubectl get all -n "$NS" -l "$FILTER_LABELS" -o wide > "$DIR/resources_summary.txt"
-else
-  kubectl get all -n "$NS" -o wide | grep -E "^(NAME|$FILTER_REGEX)" > "$DIR/resources_summary.txt"
-fi
+kubectl get all -n "$NS" -o wide > "$DIR/resources_summary.txt"
 
 echo "Pulling details of all resources..."
-if [ -n "$FILTER_LABELS" ]; then
-  kubectl get all -n "$NS" -l "$FILTER_LABELS" -o yaml > "$DIR/resources_details.yaml"
-else
-  kubectl get all -n "$NS" -o yaml > "$DIR/resources_details_all.yaml"
-  grep -E "^(kind:|metadata:|  name: ($FILTER_REGEX))" "$DIR/resources_details_all.yaml" > "$DIR/resources_details.yaml" || cp "$DIR/resources_details_all.yaml" "$DIR/resources_details.yaml"
-  rm "$DIR/resources_details_all.yaml"
-fi
+kubectl get all -n "$NS" -o yaml > "$DIR/resources_details.yaml"
 
 echo "Pulling kubernetes events..."
 kubectl get events -n "$NS" --sort-by=.lastTimestamp > "$DIR/events.txt"
 
-echo "Pulling resource usage for filtered pods..."
-if [ -n "$FILTER_LABELS" ]; then
-  kubectl top pods -n "$NS" -l "$FILTER_LABELS" --containers > "$DIR/pod-resource-usage.txt"
-else
-  kubectl top pods -n "$NS" --containers | grep -E "^(NAME|$FILTER_REGEX)" > "$DIR/pod-resource-usage.txt"
-fi
+echo "Pulling resource usage for all pods..."
+kubectl top pods -n "$NS" --containers > "$DIR/pod-resource-usage.txt"
 
-echo "Pulling container logs for filtered pods only. Also pulling previous logs from restarted containers..."
+echo "Pulling container logs for all pods. Also pulling previous logs from restarted containers..."
 mkdir -p "$DIR/logs"
-
-# Get filtered pods
-if [ -n "$FILTER_LABELS" ]; then
-  PODS=$(kubectl get pods -n "$NS" -l "$FILTER_LABELS" -o jsonpath='{.items[*].metadata.name}')
-else
-  PODS=$(kubectl get pods -n "$NS" -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep -E "^$FILTER_REGEX" | tr '\n' ' ')
-fi
+PODS=$(kubectl get pods -n "$NS" -o jsonpath='{.items[*].metadata.name}')
 
 for POD in $PODS; do
   CONTAINERS=$(kubectl get pod "$POD" -n "$NS" -o jsonpath='{.spec.containers[*].name}')
@@ -77,17 +41,14 @@ for POD in $PODS; do
     echo "Pulling current container logs (last 24h) for $POD/$CONTAINER..."
     kubectl logs -n "$NS" "$POD" -c "$CONTAINER" --since=24h > "$DIR/logs/${POD}_${CONTAINER}_current.log" 2>/dev/null
 
-    RESTART_COUNT=$(kubectl get pod "$POD" -n "$NS" -o jsonpath='{.status.containerStatuses[?(@.name=="'$CONTAINER'")].restartCount}')
-    if [ "$RESTART_COUNT" -gt 0 ]; then
-      echo "Pulling previous container logs for $POD/$CONTAINER..."
+    RESTART_COUNT=$(kubectl get pod "$POD" -n "$NS" -o json | jq ".status.containerStatuses[] | select(.name==\"$CONTAINER\") | .restartCount // 0")
+    if [[ "$RESTART_COUNT" -gt 0 ]]; then
+      echo "  $POD/$CONTAINER restarted ($RESTART_COUNT times) — grabbing previous logs..."
       kubectl logs -n "$NS" "$POD" -c "$CONTAINER" --previous > "$DIR/logs/${POD}_${CONTAINER}_previous.log" 2>/dev/null
     fi
   done
 done
 
-echo "Compressing debugging info..."
-tar -czf "$DIR.tar.gz" -C /tmp "$(basename "$DIR")"
-
-echo "Debugging info saved to $DIR.tar.gz"
-echo "Directory contents:"
-ls -la "$DIR"
+echo "Compressing directory..."
+tar -czf "${DIR}.tar.gz" -C "$(dirname "$DIR")" "$(basename "$DIR")"
+echo "Bundle written to ${DIR}.tar.gz"


### PR DESCRIPTION
## Summary

This PR reverts commit b20ddd6b92b38b1d93e163cf65a3acff02461d70 which added filtering capabilities to the K8s debugging script.

## Changes

- Reverts the addition of `--filter-regex` and `--filter-labels` parameters
- Restores original behavior to collect debugging info for all resources in the namespace
- Removes LangChain-specific resource filtering logic

## Reverted Commit

Commit: b20ddd6b92b38b1d93e163cf65a3acff02461d70
Title: "chore: filter K8s debugging script to LangChain resources only (#467)"