### PR TITLE
Reduce retries on Auth-bootstrap job

### DIFF
--- a/charts/langsmith/templates/backend/auth-bootstrap.yaml
+++ b/charts/langsmith/templates/backend/auth-bootstrap.yaml
@@ -80,7 +80,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  backoffLimit: 3
+  backoffLimit: 0
   ttlSecondsAfterFinished: {{ .Values.backend.authBootstrap.ttlSecondsAfterFinished }}
   template:
     metadata:


### PR DESCRIPTION
- It should only fail for misconfiguration errors. No need to retry 3 times and show the same error