### PR TITLE
fix: use zip format in debugging script

### DIFF
--- a/charts/langsmith/scripts/get_k8s_debugging_info.sh
+++ b/charts/langsmith/scripts/get_k8s_debugging_info.sh
@@ -50,5 +50,10 @@ for POD in $PODS; do
 done
 
 echo "Compressing directory..."
-tar -czf "${DIR}.tar.gz" -C "$(dirname "$DIR")" "$(basename "$DIR")"
-echo "Bundle written to ${DIR}.tar.gz"
+if ! command -v zip &> /dev/null; then
+  echo "Error: 'zip' command not found. Please install it first."
+  echo "Logs written to $DIR"
+  exit 1
+fi
+cd "$(dirname "$DIR")" && zip -qr "$(basename "$DIR").zip" "$(basename "$DIR")"
+echo "Bundle written to ${DIR}.zip"


### PR DESCRIPTION
Change to leverage zip instead of tar.gz as Slack doesn't allow to attach tar.gz files.  