### PR TITLE
Remove allow_materialized_view_with_bad_select from ClickHouse users.xml (incompatible with ClickHouse ≥ 24.8)

### DIFF
--- a/charts/langsmith/docker-compose/users.xml
+++ b/charts/langsmith/docker-compose/users.xml
@@ -18,7 +18,6 @@
             <wait_for_async_insert_timeout>25</wait_for_async_insert_timeout>
             <allow_simdjson>0</allow_simdjson>
             <lightweight_deletes_sync>0</lightweight_deletes_sync>
-            <allow_materialized_view_with_bad_select>1</allow_materialized_view_with_bad_select>
         </default>
     </profiles>
 </clickhouse>


### PR DESCRIPTION
This patch removes the <allow_materialized_view_with_bad_select> setting from the default ClickHouse users.xml configuration included in the charts/langsmith/docker-compose setup.

The allow_materialized_view_with_bad_select setting is no longer supported in ClickHouse 24.8 and causes startup failures (error UNKNOWN_SETTING) when the chart is used with newer ClickHouse versions.

Backward compatibility note: If users rely on that setting in older versions, they may manually reintroduce the setting in a custom override (if still supported), but this is not recommended.

Changes in this PR:

- Removed the <allow_materialized_view_with_bad_select> line from the default users.xml template.

Testing:

- Verified that when deploying with ClickHouse 24.8+, ClickHouse now starts successfully and LangSmith operates normally.

Related issue / justification:

- This addresses the startup error that arises due to unknown setting in ClickHouse.

- Users have reported this issue when upgrading.

Please let me know if you’d like a version-guard or conditional logic instead of outright removal, but upstream compatibility strongly suggests the removal is safer long-term.