### PR TITLE
fix: remove ingress requirement for dataplane

### DIFF
--- a/charts/langgraph-dataplane/Chart.yaml
+++ b/charts/langgraph-dataplane/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy a langgraph dataplane on kubernetes.
 type: application
-version: 0.2.9
+version: 0.2.10
 appVersion: "0.12.4"

--- a/charts/langgraph-dataplane/README.md
+++ b/charts/langgraph-dataplane/README.md
@@ -1,6 +1,6 @@
 # langgraph-dataplane
 
-![Version: 0.2.9](https://img.shields.io/badge/Version-0.2.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.12.4](https://img.shields.io/badge/AppVersion-0.12.4-informational?style=flat-square)
+![Version: 0.2.10](https://img.shields.io/badge/Version-0.2.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.12.4](https://img.shields.io/badge/AppVersion-0.12.4-informational?style=flat-square)
 
 Helm chart to deploy a langgraph dataplane on kubernetes.
 

--- a/charts/langgraph-dataplane/templates/ingress.yaml
+++ b/charts/langgraph-dataplane/templates/ingress.yaml
@@ -1,8 +1,4 @@
 {{- define "validateIngress" -}}
-# Fail if none of ingress, gateway, or istioGateway are enabled
-{{- if and (not .Values.ingress.enabled) (not .Values.gateway.enabled) (not .Values.istioGateway.enabled)}}
-{{- fail "Either ingress, gateway, or istioGateway must be enabled." -}}
-{{- end -}}
 # Fail if more than one ingress type is enabled
 {{- $enabledCount := 0 -}}
 {{- if .Values.ingress.enabled }}{{ $enabledCount = add1 $enabledCount }}{{- end -}}


### PR DESCRIPTION
Remove ingress requirement for hybrid. Some customers relied on internal service urls.