### PR TITLE
chore: update ClickHouse version in docker-compose

### DIFF
--- a/charts/langsmith/docker-compose/docker-compose.yaml
+++ b/charts/langsmith/docker-compose/docker-compose.yaml
@@ -220,7 +220,7 @@ services:
       timeout: 2s
       retries: 30
   langchain-clickhouse:
-    image: ${_REGISTRY:-docker.io}/clickhouse/clickhouse-server:24.8
+    image: ${_REGISTRY:-docker.io}/clickhouse/clickhouse-server:25.10
     user: "101:101"
     restart: always
     environment:


### PR DESCRIPTION
Similar to https://github.com/langchain-ai/helm/pull/495, I noticed there's a config mismatch between the provided `users.xml` and the ClickHouse version set in `docker-compose.yaml` for the docker compose setup for local testing. The config key of `<allow_materialized_view_with_bad_select>` isn't available until ClickHouse 25.4. This PR just updates the ClickHouse version from 24.8 to the latest stable, 25.10. 

Please feel free to close this PR if the other approach (removing the config key instead of upgrading ClickHouse) is preferred!