### PR TITLE
chore: Explicitly specify `revisionHistoryLimit` for `operator` deployment template

### DIFF
--- a/charts/langgraph-dataplane/values.yaml
+++ b/charts/langgraph-dataplane/values.yaml
@@ -207,6 +207,7 @@ operator:
         namespace: ${namespace}
       spec:
         replicas: ${replicas}
+        revisionHistoryLimit: 10
         selector:
           matchLabels:
             app: ${name}

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1124,6 +1124,7 @@ operator:
         namespace: ${namespace}
       spec:
         replicas: ${replicas}
+        revisionHistoryLimit: 10
         selector:
           matchLabels:
             app: ${name}


### PR DESCRIPTION
### Summary
We're including the `spec.revisionHistoryLimit` in the `operator` deployment template to make it explicit that this field can be configured (defaults to 10).

Context:
1. The `operator` creates a K8s Deployment resource for a LangSmith Deployment.
1. When a new revision is created in the LangSmith Deployment UI, a new Replica Set is created for the underlying K8s Deployment.

It's possible that a "bad" deployment may accumulate Replica Sets that are left in a non-functional state (e.g. pods are in `CrashLoopBackOff`), which may result in resources (CPU, memory) being wasted. `spec.revisionHistoryLimit` can be configured to a lower number to reduce the number of revisions that are held.

This is useful in non-production environments (`test`, `dev`, `staging`, etc).