### PR TITLE
add docs changelog trigger

### DIFF
--- a/.github/workflows/release_charts.yaml
+++ b/.github/workflows/release_charts.yaml
@@ -36,3 +36,10 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true
+
+      - name: Trigger self-hosted changelog bot
+        run: |
+          curl -X POST "${{ secrets.HELM_CHANGELOG_BOT_URL }}/trigger" \
+            -H "X-Api-Key: ${{ secrets.LANGSMITH_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            --fail --silent --show-error


### PR DESCRIPTION
Adds a trigger for the [Helm Changelog Bot](https://github.com/langchain-ai/helm-changelog-bot), which opens a docs PR to add to the [Self-hosted LangSmith changelog](https://docs.langchain.com/langsmith/self-hosted-changelog)