### PR TITLE
chore: bump Helm chart for case-insensitive SCIM group names

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.12.33
-appVersion: "0.12.72"
+version: 0.12.34
+appVersion: "0.12.73"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -33,19 +33,19 @@ images:
   aceBackendImage:
     repository: "docker.io/langchain/langsmith-ace-backend"
     pullPolicy: IfNotPresent
-    tag: "0.12.72"
+    tag: "0.12.73"
   backendImage:
     repository: "docker.io/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
-    tag: "0.12.72"
+    tag: "0.12.73"
   frontendImage:
     repository: "docker.io/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
-    tag: "0.12.72"
+    tag: "0.12.73"
   hostBackendImage:
     repository: "docker.io/langchain/hosted-langserve-backend"
     pullPolicy: IfNotPresent
-    tag: "0.12.72"
+    tag: "0.12.73"
   operatorImage:
     repository: "docker.io/langchain/langgraph-operator"
     pullPolicy: IfNotPresent
@@ -53,11 +53,11 @@ images:
   platformBackendImage:
     repository: "docker.io/langchain/langsmith-go-backend"
     pullPolicy: IfNotPresent
-    tag: "0.12.72"
+    tag: "0.12.73"
   playgroundImage:
     repository: "docker.io/langchain/langsmith-playground"
     pullPolicy: IfNotPresent
-    tag: "0.12.72"
+    tag: "0.12.73"
   postgresImage:
     repository: "docker.io/postgres"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
this release adds support for case-insensitive SCIM group names, so a group named `ORGANIZATION ADMINS` will successfully match the `Organization Admin` role name. this applies to workspace-scoped groups as well: the role names as well as the workspace name itself.

these group names are now equivalent:
* `ORGANIZATION ADMINS`
* `Organization Admins`
* `organization admins`

and these:
* `organization user:workspace 1:editor`
* `ORGANIZATION USER:WORKSPACE 1:EDITOR`

optional prefix behavior functions as it did before: https://docs.langchain.com/langsmith/user-management#group-naming-convention