### PR TITLE
[Closes LSO-1447] Self-hosted customers don't have adhoc queue

### DIFF
--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -13,7 +13,9 @@ commonPodAnnotations: {}
 # -- Labels that will be applied to all resources created by the chart
 commonLabels: {}
 # -- Common environment variables that will be applied to all deployments/statefulsets except for the playground/aceBackend services (which are sandboxed). Be careful not to override values already specified by the chart.
-commonEnv: []
+commonEnv:
+  - name: ADHOC_QUEUE
+    value: "default"
 # -- Common volumes added to all deployments/statefulsets except for the playground/aceBackend services (which are sandboxed).
 commonVolumes: []
 # -- Common volume mounts added to all deployments/statefulsets except for the playground/aceBackend services (which are sandboxed).


### PR DESCRIPTION
Self-hosted customers don't have adhoc queue
But go alerts is defaulting to "adhoc"
Need to use "default"
So alerts can be picked up by saq-adhoc-queue worker for processing

Affects self-hosted who have
1. GO_QUEUE_ENABLED_ALL=true (Go ingestion path)

2. singleQueueProcessorMode=true (single queue worker - self-hosted default) (