### PR TITLE
fix: self-hosted agent-builder routing

### DIFF
--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -149,6 +149,15 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
 
+        location /{{ .Values.config.basePath }}/api/v1/agent-builder/ {
+            rewrite /{{ .Values.config.basePath }}/api/v1/agent-builder/(.*) /v1/agent-builder/$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
         location = /{{ .Values.config.basePath }}/api/v1/runs/multipart {
             rewrite /{{ .Values.config.basePath }}/api/v1/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
@@ -574,6 +583,15 @@ data:
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
          }
+
+        location /api/v1/agent-builder/ {
+            rewrite /api/v1/agent-builder/(.*) /v1/agent-builder/$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
 
         location = /api/v1/runs/multipart {
             rewrite /api/v1/runs/multipart /runs/multipart  break;


### PR DESCRIPTION
## Description
- Self-hosted LangSmith deployments were missing an explicit frontend nginx route for `/api/v1/agent-builder/*`.
- Because of that, Fleet access-control requests such as `/api/v1/agent-builder/integrations` fell through to the generic `/api/v1` backend proxy and were sent to the Python backend instead of the Go platform backend. In practice, that caused self-hosted Fleet access controls to fail with 404s.
- This change adds explicit frontend nginx routing for `/api/v1/agent-builder/` in both the basePath and non-basePath chart templates so those requests are rewritten to `/v1/agent-builder/*` and forwarded to the platform backend.

## Test Plan
- [x] none