### PR TITLE
fix: add missing microsoftOAuthProvider mapping

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.13.39
+version: 0.13.40
 appVersion: "0.13.40"

--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
 version: 0.13.40
-appVersion: "0.13.40"
+appVersion: "0.13.41"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.13.39](https://img.shields.io/badge/Version-0.13.39-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.40](https://img.shields.io/badge/AppVersion-0.13.40-informational?style=flat-square)
+![Version: 0.13.40](https://img.shields.io/badge/Version-0.13.40-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.40](https://img.shields.io/badge/AppVersion-0.13.40-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -289,6 +289,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | config.agentBuilder.oauth.googleOAuthProvider | string | `""` |  |
 | config.agentBuilder.oauth.linearOAuthProvider | string | `""` |  |
 | config.agentBuilder.oauth.linkedinOAuthProvider | string | `""` |  |
+| config.agentBuilder.oauth.microsoftOAuthProvider | string | `""` |  |
 | config.agentBuilder.oauth.slackBotId | string | `""` |  |
 | config.agentBuilder.oauth.slackOAuthProvider | string | `""` |  |
 | config.agentBuilder.oauth.slackSigningSecret | string | `""` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.13.40](https://img.shields.io/badge/Version-0.13.40-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.40](https://img.shields.io/badge/AppVersion-0.13.40-informational?style=flat-square)
+![Version: 0.13.40](https://img.shields.io/badge/Version-0.13.40-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.41](https://img.shields.io/badge/AppVersion-0.13.41-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -140,44 +140,44 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | gateway.sectionName | string | `""` |  |
 | images.aceBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.aceBackendImage.repository | string | `"docker.io/langchain/langsmith-ace-backend"` |  |
-| images.aceBackendImage.tag | string | `"0.13.40"` |  |
+| images.aceBackendImage.tag | string | `"0.13.41"` |  |
 | images.agentBuilderImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.agentBuilderImage.repository | string | `"docker.io/langchain/agent-builder-deep-agent"` |  |
-| images.agentBuilderImage.tag | string | `"0.13.40"` |  |
+| images.agentBuilderImage.tag | string | `"0.13.41"` |  |
 | images.agentBuilderToolServerImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.agentBuilderToolServerImage.repository | string | `"docker.io/langchain/agent-builder-tool-server"` |  |
-| images.agentBuilderToolServerImage.tag | string | `"0.13.40"` |  |
+| images.agentBuilderToolServerImage.tag | string | `"0.13.41"` |  |
 | images.agentBuilderTriggerServerImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.agentBuilderTriggerServerImage.repository | string | `"docker.io/langchain/agent-builder-trigger-server"` |  |
-| images.agentBuilderTriggerServerImage.tag | string | `"0.13.40"` |  |
+| images.agentBuilderTriggerServerImage.tag | string | `"0.13.41"` |  |
 | images.backendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.backendImage.repository | string | `"docker.io/langchain/langsmith-backend"` |  |
-| images.backendImage.tag | string | `"0.13.40"` |  |
+| images.backendImage.tag | string | `"0.13.41"` |  |
 | images.clickhouseImage.pullPolicy | string | `"Always"` |  |
 | images.clickhouseImage.repository | string | `"docker.io/clickhouse/clickhouse-server"` |  |
 | images.clickhouseImage.tag | string | `"25.12"` |  |
 | images.frontendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.frontendImage.repository | string | `"docker.io/langchain/langsmith-frontend"` |  |
-| images.frontendImage.tag | string | `"0.13.40"` |  |
+| images.frontendImage.tag | string | `"0.13.41"` |  |
 | images.hostBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.hostBackendImage.repository | string | `"docker.io/langchain/hosted-langserve-backend"` |  |
-| images.hostBackendImage.tag | string | `"0.13.40"` |  |
+| images.hostBackendImage.tag | string | `"0.13.41"` |  |
 | images.imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Specified as name: value. |
 | images.insightsAgentImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.insightsAgentImage.repository | string | `"docker.io/langchain/langsmith-clio"` |  |
-| images.insightsAgentImage.tag | string | `"0.13.40"` |  |
+| images.insightsAgentImage.tag | string | `"0.13.41"` |  |
 | images.operatorImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.operatorImage.repository | string | `"docker.io/langchain/langgraph-operator"` |  |
 | images.operatorImage.tag | string | `"0.1.47"` |  |
 | images.platformBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.platformBackendImage.repository | string | `"docker.io/langchain/langsmith-go-backend"` |  |
-| images.platformBackendImage.tag | string | `"0.13.40"` |  |
+| images.platformBackendImage.tag | string | `"0.13.41"` |  |
 | images.playgroundImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.playgroundImage.repository | string | `"docker.io/langchain/langsmith-playground"` |  |
-| images.playgroundImage.tag | string | `"0.13.40"` |  |
+| images.playgroundImage.tag | string | `"0.13.41"` |  |
 | images.pollyAgentImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.pollyAgentImage.repository | string | `"docker.io/langchain/langsmith-polly"` |  |
-| images.pollyAgentImage.tag | string | `"0.13.40"` |  |
+| images.pollyAgentImage.tag | string | `"0.13.41"` |  |
 | images.postgresImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.postgresImage.repository | string | `"docker.io/postgres"` |  |
 | images.postgresImage.tag | string | `"14.7"` |  |

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -755,6 +755,10 @@ Strip protocol (http://, https://, etc.) from hostname
 - name: "GITHUB_OAUTH_PROVIDER"
   value: {{ .Values.config.agentBuilder.oauth.githubOAuthProvider | quote }}
 {{- end }}
+{{- if .Values.config.agentBuilder.oauth.microsoftOAuthProvider }}
+- name: "MICROSOFT_OAUTH_PROVIDER"
+  value: {{ .Values.config.agentBuilder.oauth.microsoftOAuthProvider | quote }}
+{{- end }}
 {{- end -}}
 
 {{- define "agentBuilderToolServerEnvVars" -}}

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -190,11 +190,13 @@ config:
     # - linkedinOAuthProvider: LinkedIn tools
     # - linearOAuthProvider: Linear tools
     # - githubOAuthProvider: GitHub tools
+    # - microsoftOAuthProvider: Outlook, Teams, SharePoint tools + Outlook trigger
     oauth:
       googleOAuthProvider: ""
       linkedinOAuthProvider: ""
       linearOAuthProvider: ""
       githubOAuthProvider: ""
+      microsoftOAuthProvider: ""
       slackOAuthProvider: ""
       slackSigningSecret: ""
       slackBotId: ""

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -40,23 +40,23 @@ images:
   aceBackendImage:
     repository: "docker.io/langchain/langsmith-ace-backend"
     pullPolicy: IfNotPresent
-    tag: "0.13.40"
+    tag: "0.13.41"
   backendImage:
     repository: "docker.io/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
-    tag: "0.13.40"
+    tag: "0.13.41"
   insightsAgentImage:
     repository: "docker.io/langchain/langsmith-clio"
     pullPolicy: IfNotPresent
-    tag: "0.13.40"
+    tag: "0.13.41"
   frontendImage:
     repository: "docker.io/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
-    tag: "0.13.40"
+    tag: "0.13.41"
   hostBackendImage:
     repository: "docker.io/langchain/hosted-langserve-backend"
     pullPolicy: IfNotPresent
-    tag: "0.13.40"
+    tag: "0.13.41"
   operatorImage:
     repository: "docker.io/langchain/langgraph-operator"
     pullPolicy: IfNotPresent
@@ -64,11 +64,11 @@ images:
   platformBackendImage:
     repository: "docker.io/langchain/langsmith-go-backend"
     pullPolicy: IfNotPresent
-    tag: "0.13.40"
+    tag: "0.13.41"
   playgroundImage:
     repository: "docker.io/langchain/langsmith-playground"
     pullPolicy: IfNotPresent
-    tag: "0.13.40"
+    tag: "0.13.41"
   # For production environments, we strongly recommend connecting to a managed PostgreSQL instance instead of using the one provided by the chart.
   # Docs: https://docs.langchain.com/langsmith/self-host-external-postgres
   postgresImage:
@@ -88,19 +88,19 @@ images:
   agentBuilderToolServerImage:
     repository: "docker.io/langchain/agent-builder-tool-server"
     pullPolicy: IfNotPresent
-    tag: "0.13.40"
+    tag: "0.13.41"
   agentBuilderTriggerServerImage:
     repository: "docker.io/langchain/agent-builder-trigger-server"
     pullPolicy: IfNotPresent
-    tag: "0.13.40"
+    tag: "0.13.41"
   agentBuilderImage:
     repository: "docker.io/langchain/agent-builder-deep-agent"
     pullPolicy: IfNotPresent
-    tag: "0.13.40"
+    tag: "0.13.41"
   pollyAgentImage:
     repository: "docker.io/langchain/langsmith-polly"
     pullPolicy: IfNotPresent
-    tag: "0.13.40"
+    tag: "0.13.41"
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Summary
- Adds `microsoftOAuthProvider` to `values.yaml` under `config.agentBuilder.oauth`
- Adds `MICROSOFT_OAUTH_PROVIDER` env var mapping in `agentBuilderOAuthEnvVars` template
- Follows the same pattern as the existing five providers (Google, Slack, LinkedIn, Linear, GitHub)

Without this, self-hosted customers who set `microsoftOAuthProvider` in their Helm values get no effect — the value is silently ignored, and all Outlook/Teams/SharePoint/365 Docs tools are disabled on the tool server. The trigger server also skips the Outlook cron trigger.

## Test plan
- [x] `helm template` dry-run with `microsoftOAuthProvider` set — `MICROSOFT_OAUTH_PROVIDER` appears on tool-server, trigger-server, and host-backend deployments
- [x] `helm template` dry-run with `microsoftOAuthProvider` empty — env var absent (no change to default behavior)
- [x] Deployed to self-hosted EKS cluster — tool server logs confirm `microsoft_tools_enabled` (19 tools), `microsoft_sharepoint_tools_enabled` (19), `microsoft_document_tools_enabled` (17)
- [x] Trigger server logs confirm `outlook_trigger_enabled` with `provider: "microsoft"`
- [x] Reverted to remote chart 0.13.39 — confirmed Outlook tools are absent without this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)