### PR TITLE
feat: make jwtAudiences required in langsmith-auth-proxy

### DIFF
--- a/charts/langsmith-auth-proxy/Chart.yaml
+++ b/charts/langsmith-auth-proxy/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: brian@langchain.dev
 description: Helm chart to deploy the langsmith auth-proxy application.
 type: application
-version: 0.0.9
+version: 0.0.10
 appVersion: "1.37.0"

--- a/charts/langsmith-auth-proxy/README.md
+++ b/charts/langsmith-auth-proxy/README.md
@@ -1,6 +1,6 @@
 # langsmith-auth-proxy
 
-![Version: 0.0.9](https://img.shields.io/badge/Version-0.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.37.0](https://img.shields.io/badge/AppVersion-1.37.0-informational?style=flat-square)
+![Version: 0.0.10](https://img.shields.io/badge/Version-0.0.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.37.0](https://img.shields.io/badge/AppVersion-1.37.0-informational?style=flat-square)
 
 Helm chart to deploy the langsmith auth-proxy application.
 
@@ -133,7 +133,7 @@ Control which phases are sent to the transformer via `processingMode`:
 | authProxy.jwksCacheDurationSeconds | int | `300` | Cache duration in seconds for remote JWKS keys. Only used when jwksUri is set. |
 | authProxy.jwksJson | string | `""` | JWKS JSON string containing the public keys for JWT validation. Generate with the LangSmith JWKS tooling and paste the full JSON here. Mutually exclusive with jwksUri — if both are set, jwksUri takes precedence. |
 | authProxy.jwksUri | string | `""` | Remote JWKS endpoint URL for fetching public keys (e.g. https://langsmith.example.com/.well-known/jwks.json for self-hosted LangSmith or https://api.smith.langchain.com/.well-known/jwks.json in SaaS). When set, Envoy fetches and caches keys from this URL instead of using inline jwksJson. Mutually exclusive with jwksJson — if both are set, jwksUri takes precedence. |
-| authProxy.jwtAudiences | list | `[]` | **(required)** JWT audience claims to validate. Must match audiences in the signed JWT. |
+| authProxy.jwtAudiences | required | `[]` | JWT audience claims to validate. Must match audiences in the signed JWT. |
 | authProxy.jwtIssuer | string | `"langsmith"` | JWT issuer claim to validate |
 | authProxy.jwtValidation | object | `{"enabled":true}` | JWT validation configuration |
 | authProxy.jwtValidation.enabled | bool | `true` | Set to false to disable the envoy.filters.http.jwt_authn filter entirely. Useful for testing or when JWT validation is handled elsewhere. |

--- a/charts/langsmith-auth-proxy/README.md
+++ b/charts/langsmith-auth-proxy/README.md
@@ -133,7 +133,7 @@ Control which phases are sent to the transformer via `processingMode`:
 | authProxy.jwksCacheDurationSeconds | int | `300` | Cache duration in seconds for remote JWKS keys. Only used when jwksUri is set. |
 | authProxy.jwksJson | string | `""` | JWKS JSON string containing the public keys for JWT validation. Generate with the LangSmith JWKS tooling and paste the full JSON here. Mutually exclusive with jwksUri — if both are set, jwksUri takes precedence. |
 | authProxy.jwksUri | string | `""` | Remote JWKS endpoint URL for fetching public keys (e.g. https://langsmith.example.com/.well-known/jwks.json for self-hosted LangSmith or https://api.smith.langchain.com/.well-known/jwks.json in SaaS). When set, Envoy fetches and caches keys from this URL instead of using inline jwksJson. Mutually exclusive with jwksJson — if both are set, jwksUri takes precedence. |
-| authProxy.jwtAudiences | list | `[]` | JWT audience claims to validate. Must match audiences in the signed JWT. |
+| authProxy.jwtAudiences | list | `[]` | **(required)** JWT audience claims to validate. Must match audiences in the signed JWT. |
 | authProxy.jwtIssuer | string | `"langsmith"` | JWT issuer claim to validate |
 | authProxy.jwtValidation | object | `{"enabled":true}` | JWT validation configuration |
 | authProxy.jwtValidation.enabled | bool | `true` | Set to false to disable the envoy.filters.http.jwt_authn filter entirely. Useful for testing or when JWT validation is handled elsewhere. |

--- a/charts/langsmith-auth-proxy/e2e/oauth/values.yaml
+++ b/charts/langsmith-auth-proxy/e2e/oauth/values.yaml
@@ -26,7 +26,8 @@ authProxy:
   enabled: true
   upstream: "https://api.openai.com"  # Replace with your upstream
   jwtIssuer: "langsmith"
-  jwtAudiences: []
+  jwtAudiences:
+    - "langsmith"
   jwksJson: ""  # Fill this in with your JWKS JSON
   streamIdleTimeout: "300s"
 

--- a/charts/langsmith-auth-proxy/templates/auth-proxy/config-map.yaml
+++ b/charts/langsmith-auth-proxy/templates/auth-proxy/config-map.yaml
@@ -78,12 +78,13 @@ data:
                           providers:
                             langsmith_jwt:
                               issuer: {{ .Values.authProxy.jwtIssuer }}
-                              {{- if .Values.authProxy.jwtAudiences }}
+                              {{- if not .Values.authProxy.jwtAudiences }}
+                                {{- fail "authProxy.jwtAudiences is required and must contain at least one audience" }}
+                              {{- end }}
                               audiences:
                                 {{- range .Values.authProxy.jwtAudiences }}
                                 - {{ . | quote }}
                                 {{- end }}
-                              {{- end }}
                               {{- if $jwksUri }}
                               remote_jwks:
                                 http_uri:

--- a/charts/langsmith-auth-proxy/tests/allowed_upstream_headers_test.yaml
+++ b/charts/langsmith-auth-proxy/tests/allowed_upstream_headers_test.yaml
@@ -1,6 +1,8 @@
 suite: allowed_upstream_headers
 templates:
   - auth-proxy/config-map.yaml
+values:
+  - common-values.yaml
 tests:
   - it: should use default allowlist (authorization + x-*) when allowedUpstreamHeaders is empty
     set:

--- a/charts/langsmith-auth-proxy/tests/common-values.yaml
+++ b/charts/langsmith-auth-proxy/tests/common-values.yaml
@@ -1,0 +1,5 @@
+# Shared base values for unit tests.
+# Every test suite should include this via `values:` to satisfy required fields.
+authProxy:
+  jwtAudiences:
+    - "test-audience"

--- a/charts/langsmith-auth-proxy/tests/jwks_uri_test.yaml
+++ b/charts/langsmith-auth-proxy/tests/jwks_uri_test.yaml
@@ -1,6 +1,8 @@
 suite: jwks uri configuration
 templates:
   - auth-proxy/config-map.yaml
+values:
+  - common-values.yaml
 tests:
   - it: should use local_jwks when only jwksJson is set
     set:

--- a/charts/langsmith-auth-proxy/tests/jwt_audiences_test.yaml
+++ b/charts/langsmith-auth-proxy/tests/jwt_audiences_test.yaml
@@ -1,0 +1,35 @@
+suite: jwtAudiences validation
+templates:
+  - auth-proxy/config-map.yaml
+tests:
+  - it: should fail when jwtAudiences is empty
+    set:
+      authProxy.upstream: "https://gateway.example.com"
+      authProxy.jwksJson: '{"keys":[{"kty":"RSA"}]}'
+      authProxy.jwtAudiences: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "authProxy.jwtAudiences is required and must contain at least one audience"
+
+  - it: should render audiences when jwtAudiences has one entry
+    set:
+      authProxy.upstream: "https://gateway.example.com"
+      authProxy.jwksJson: '{"keys":[{"kty":"RSA"}]}'
+      authProxy.jwtAudiences:
+        - "my-audience"
+    asserts:
+      - matchRegex:
+          path: data["envoy.yaml"]
+          pattern: 'audiences:\s+- "my-audience"'
+
+  - it: should render multiple audiences
+    set:
+      authProxy.upstream: "https://gateway.example.com"
+      authProxy.jwksJson: '{"keys":[{"kty":"RSA"}]}'
+      authProxy.jwtAudiences:
+        - "audience-1"
+        - "audience-2"
+    asserts:
+      - matchRegex:
+          path: data["envoy.yaml"]
+          pattern: 'audiences:\s+- "audience-1"\s+- "audience-2"'

--- a/charts/langsmith-auth-proxy/tests/transformer_test.yaml
+++ b/charts/langsmith-auth-proxy/tests/transformer_test.yaml
@@ -1,6 +1,8 @@
 suite: transformer (ext_proc)
 templates:
   - auth-proxy/config-map.yaml
+values:
+  - common-values.yaml
 tests:
   - it: should not render ext_proc filter when transformer is disabled (default)
     set:

--- a/charts/langsmith-auth-proxy/tests/upstream_path_prefix_test.yaml
+++ b/charts/langsmith-auth-proxy/tests/upstream_path_prefix_test.yaml
@@ -1,6 +1,8 @@
 suite: upstream path prefix
 templates:
   - auth-proxy/config-map.yaml
+values:
+  - common-values.yaml
 tests:
   - it: should not include prefix_rewrite when upstream has no path
     set:

--- a/charts/langsmith-auth-proxy/values.yaml
+++ b/charts/langsmith-auth-proxy/values.yaml
@@ -42,7 +42,7 @@ authProxy:
   upstream: ""
   # -- JWT issuer claim to validate
   jwtIssuer: "langsmith"
-  # -- JWT audience claims to validate. Must match audiences in the signed JWT.
+  # -- (required) JWT audience claims to validate. Must match audiences in the signed JWT.
   jwtAudiences: []
   # -- JWKS JSON string containing the public keys for JWT validation.
   # Generate with the LangSmith JWKS tooling and paste the full JSON here.


### PR DESCRIPTION
## Summary
- `authProxy.jwtAudiences` is now required when `authProxy.enabled` is true — the chart fails at render time with a clear error if the list is empty
- Adds unit tests for the validation (empty fails, single/multiple audiences render correctly)
- Bumps chart version to 0.0.10

Closes LSD-1401

## Test plan
- [x] `helm template` fails with clear error when `jwtAudiences` is empty and `authProxy.enabled=true`
- [x] `helm template` succeeds when `authProxy.enabled=false` with no audiences
- [x] `helm unittest` — all 43 tests pass
- [x] All CI and e2e value files provide audiences

🤖 Generated with [Claude Code](https://claude.com/claude-code)