### PR TITLE
fix: use sync waves to run migrations before app rollout

### DIFF
--- a/charts/langsmith/templates/backend/clickhouse-migrations.yaml
+++ b/charts/langsmith/templates/backend/clickhouse-migrations.yaml
@@ -14,9 +14,12 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook": post-install, pre-upgrade
     "helm.sh/hook-weight": "-1"
-    "argocd.argoproj.io/hook": "PostSync"
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "argocd.argoproj.io/hook": "Sync"
+    "argocd.argoproj.io/hook-delete-policy": "BeforeHookCreation"
+    "argocd.argoproj.io/sync-wave": "-1"
     {{- include "langsmith.annotations" . | nindent 4 }}
     {{- with.Values.backend.clickhouseMigrations.annotations }}
       {{- toYaml . | nindent 4 }}

--- a/charts/langsmith/templates/backend/postgres-migrations.yaml
+++ b/charts/langsmith/templates/backend/postgres-migrations.yaml
@@ -14,9 +14,12 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook": post-install, pre-upgrade
     "helm.sh/hook-weight": "-1"
-    "argocd.argoproj.io/hook": "PostSync"
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "argocd.argoproj.io/hook": "Sync"
+    "argocd.argoproj.io/hook-delete-policy": "BeforeHookCreation"
+    "argocd.argoproj.io/sync-wave": "-1"
     {{- include "langsmith.annotations" . | nindent 4 }}
     {{- with.Values.backend.migrations.annotations }}
       {{- toYaml . | nindent 4 }}

--- a/charts/langsmith/templates/clickhouse/config-map.yaml
+++ b/charts/langsmith/templates/clickhouse/config-map.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "langsmith.labels" . | nindent 4 }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
 data:
   users.xml: |

--- a/charts/langsmith/templates/clickhouse/pdb.yaml
+++ b/charts/langsmith/templates/clickhouse/pdb.yaml
@@ -10,6 +10,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
     {{- with .Values.clickhouse.pdb.annotations }}
       {{- toYaml . | nindent 4 }}

--- a/charts/langsmith/templates/clickhouse/secrets.yaml
+++ b/charts/langsmith/templates/clickhouse/secrets.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "langsmith.labels" . | nindent 4 }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
 data:
   {{- if .Values.clickhouse.external.enabled }}

--- a/charts/langsmith/templates/clickhouse/service-account.yaml
+++ b/charts/langsmith/templates/clickhouse/service-account.yaml
@@ -10,6 +10,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
     {{- with.Values.clickhouse.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}

--- a/charts/langsmith/templates/clickhouse/service.yaml
+++ b/charts/langsmith/templates/clickhouse/service.yaml
@@ -11,6 +11,7 @@ metadata:
     {{- end }}
     app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.clickhouse.name }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
     {{- with.Values.clickhouse.service.annotations }}
       {{- toYaml . | nindent 4 }}

--- a/charts/langsmith/templates/clickhouse/stateful-set.yaml
+++ b/charts/langsmith/templates/clickhouse/stateful-set.yaml
@@ -34,6 +34,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
     {{- with.Values.clickhouse.statefulSet.annotations }}
       {{- toYaml . | nindent 4 }}

--- a/charts/langsmith/templates/postgres/pdb.yaml
+++ b/charts/langsmith/templates/postgres/pdb.yaml
@@ -10,6 +10,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
     {{- with .Values.postgres.pdb.annotations }}
       {{- toYaml . | nindent 4 }}

--- a/charts/langsmith/templates/postgres/secrets.yaml
+++ b/charts/langsmith/templates/postgres/secrets.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "langsmith.labels" . | nindent 4 }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
 data:
   {{- if .Values.postgres.external.enabled }}

--- a/charts/langsmith/templates/postgres/service-account.yaml
+++ b/charts/langsmith/templates/postgres/service-account.yaml
@@ -10,6 +10,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
     {{- with.Values.postgres.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}

--- a/charts/langsmith/templates/postgres/service.yaml
+++ b/charts/langsmith/templates/postgres/service.yaml
@@ -11,6 +11,7 @@ metadata:
     {{- end }}
     app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.postgres.name }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
     {{- with.Values.postgres.service.annotations }}
       {{- toYaml . | nindent 4 }}

--- a/charts/langsmith/templates/postgres/stateful-set.yaml
+++ b/charts/langsmith/templates/postgres/stateful-set.yaml
@@ -36,6 +36,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
     {{- with.Values.postgres.statefulSet.annotations }}
       {{- toYaml . | nindent 4 }}

--- a/charts/langsmith/templates/redis/pdb.yaml
+++ b/charts/langsmith/templates/redis/pdb.yaml
@@ -10,6 +10,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
     {{- with .Values.redis.pdb.annotations }}
       {{- toYaml . | nindent 4 }}

--- a/charts/langsmith/templates/redis/secrets.yaml
+++ b/charts/langsmith/templates/redis/secrets.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "langsmith.labels" . | nindent 4 }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
 data:
   {{- if .Values.redis.external.enabled }}

--- a/charts/langsmith/templates/redis/service-account.yaml
+++ b/charts/langsmith/templates/redis/service-account.yaml
@@ -10,6 +10,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
     {{- with.Values.redis.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}

--- a/charts/langsmith/templates/redis/service.yaml
+++ b/charts/langsmith/templates/redis/service.yaml
@@ -11,6 +11,7 @@ metadata:
     {{- end }}
     app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.redis.name }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
     {{- with.Values.redis.service.annotations }}
       {{- toYaml . | nindent 4 }}

--- a/charts/langsmith/templates/redis/stateful-set.yaml
+++ b/charts/langsmith/templates/redis/stateful-set.yaml
@@ -14,6 +14,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
     {{- with.Values.redis.statefulSet.annotations }}
       {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
## Summary
- Switches DB migrations from PostSync hooks to sync-wave ordering so migrations complete **before** application code rolls out
- Adds `sync-wave: "-2"` to all database resources (postgres, clickhouse, redis — StatefulSets, Services, Secrets, ServiceAccounts, PDBs, ConfigMaps) so they're healthy first
- Changes migration Jobs to `Sync` hooks at `sync-wave: "-1"` (Argo CD) and `post-install, pre-upgrade` (Helm) so they run after DBs are up but before Deployments
- Auth bootstrap remains as PostSync since it depends on the running application

### Argo CD sync order
| Phase | Wave | Resources |
|-------|------|-----------|
| Sync | -2 | DB Secrets, ServiceAccounts, Services, StatefulSets |
| Sync | -1 | PG + CH migration Jobs |
| Sync | 0 | Application Deployments/Rollouts |
| PostSync | — | Auth bootstrap, agent bootstrap |

### Helm behavior
- **First install:** `post-install` — DBs are already deployed, migrations run after
- **Upgrades:** `pre-upgrade` — migrations run before new app code rolls out

## Test plan
- [ ] Verify `helm template` renders without errors
- [ ] Test fresh Argo CD install — DBs should come up at wave -2, migrations at -1, then app at 0
- [ ] Test Argo CD upgrade — migrations should complete before deployments update
- [ ] Test Helm upgrade — migrations should run as pre-upgrade hooks before new code
- [ ] Verify auth-bootstrap still runs after app is up

🤖 Generated with [Claude Code](https://claude.com/claude-code)