### PR TITLE
fix: add missing microsoftOAuthProvider mapping (#672)

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -289,6 +289,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | config.agentBuilder.oauth.googleOAuthProvider | string | `""` |  |
 | config.agentBuilder.oauth.linearOAuthProvider | string | `""` |  |
 | config.agentBuilder.oauth.linkedinOAuthProvider | string | `""` |  |
+| config.agentBuilder.oauth.microsoftOAuthProvider | string | `""` |  |
 | config.agentBuilder.oauth.slackBotId | string | `""` |  |
 | config.agentBuilder.oauth.slackOAuthProvider | string | `""` |  |
 | config.agentBuilder.oauth.slackSigningSecret | string | `""` |  |

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -755,6 +755,10 @@ Strip protocol (http://, https://, etc.) from hostname
 - name: "GITHUB_OAUTH_PROVIDER"
   value: {{ .Values.config.agentBuilder.oauth.githubOAuthProvider | quote }}
 {{- end }}
+{{- if .Values.config.agentBuilder.oauth.microsoftOAuthProvider }}
+- name: "MICROSOFT_OAUTH_PROVIDER"
+  value: {{ .Values.config.agentBuilder.oauth.microsoftOAuthProvider | quote }}
+{{- end }}
 {{- end -}}
 
 {{- define "agentBuilderToolServerEnvVars" -}}

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -190,11 +190,13 @@ config:
     # - linkedinOAuthProvider: LinkedIn tools
     # - linearOAuthProvider: Linear tools
     # - githubOAuthProvider: GitHub tools
+    # - microsoftOAuthProvider: Outlook, Teams, SharePoint tools + Outlook trigger
     oauth:
       googleOAuthProvider: ""
       linkedinOAuthProvider: ""
       linearOAuthProvider: ""
       githubOAuthProvider: ""
+      microsoftOAuthProvider: ""
       slackOAuthProvider: ""
       slackSigningSecret: ""
       slackBotId: ""


### PR DESCRIPTION
* fix: add missing microsoftOAuthProvider mapping to Helm chart

The MICROSOFT_OAUTH_PROVIDER env var was never wired up in the Helm chart, causing self-hosted customers who set microsoftOAuthProvider in their values to have Outlook, Teams, SharePoint, and 365 Docs tools silently disabled. The trigger server also skipped the Outlook cron trigger.

Adds the value to values.yaml and the env var mapping in agentBuilderOAuthEnvVars, following the same pattern as the existing five OAuth providers (Google, Slack, LinkedIn, Linear, GitHub).



* chore: bump image versions to 0.13.41



---------