### PR TITLE
fix: create backend service account before migrations run

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.14.0
+version: 0.14.1
 appVersion: "0.14.3"

--- a/charts/langsmith/templates/backend/service-account.yaml
+++ b/charts/langsmith/templates/backend/service-account.yaml
@@ -10,6 +10,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
     {{- with.Values.backend.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}

--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "langsmith.labels" . | nindent 4 }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
 data:
   {{- if and .Values.config.oauth.enabled (eq .Values.config.authType "mixed") }}

--- a/charts/langsmith/templates/secrets.yaml
+++ b/charts/langsmith/templates/secrets.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "langsmith.labels" . | nindent 4 }}
   annotations:
+    "argocd.argoproj.io/sync-wave": "-2"
     {{- include "langsmith.annotations" . | nindent 4 }}
 data:
   oauth_client_id: {{ .Values.config.oauth.oauthClientId | b64enc | quote }}


### PR DESCRIPTION
## Summary
- Backend migration jobs (`postgres-migrations`, `clickhouse-migrations`) run as ArgoCD `Sync` hooks at sync-wave `-1` and reference `backend.serviceAccountName`, but the backend ServiceAccount had no sync-wave annotation (defaulted to `0`). ArgoCD therefore tried to run the migration hooks before the SA existed.
- Annotate `charts/langsmith/templates/backend/service-account.yaml` with `argocd.argoproj.io/sync-wave: "-2"` so it is created ahead of the migrations (matching the pattern already used by the postgres/redis/clickhouse SAs).
- Bump chart `version` `0.14.0` → `0.14.1`.

## Test plan
- [x] `helm template` the chart and verify the backend SA renders with `argocd.argoproj.io/sync-wave: "-2"`.
- [x] Deploy via ArgoCD against a test cluster and confirm the migration hooks run successfully on a fresh install (SA exists before the hook fires).
- [x] Confirm no regression on upgrade path — migration hook still runs `pre-upgrade` as before.