### PR TITLE
feat(langgraph-dataplane): make HOST_QUEUE configurable

### DIFF
--- a/charts/langgraph-dataplane/Chart.yaml
+++ b/charts/langgraph-dataplane/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy a langgraph dataplane on kubernetes.
 type: application
-version: 0.2.19
+version: 0.2.20
 appVersion: "0.13.9"

--- a/charts/langgraph-dataplane/README.md
+++ b/charts/langgraph-dataplane/README.md
@@ -1,6 +1,6 @@
 # langgraph-dataplane
 
-![Version: 0.2.19](https://img.shields.io/badge/Version-0.2.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.9](https://img.shields.io/badge/AppVersion-0.13.9-informational?style=flat-square)
+![Version: 0.2.20](https://img.shields.io/badge/Version-0.2.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.9](https://img.shields.io/badge/AppVersion-0.13.9-informational?style=flat-square)
 
 Helm chart to deploy a langgraph dataplane on kubernetes.
 
@@ -101,6 +101,7 @@ You can find the guide to deploy a LangGraph Dataplane [here](https://langchain-
 | config.enableLGPDeploymentHealthCheck | bool | `true` |  |
 | config.existingSecretName | string | `""` |  |
 | config.hostBackendUrl | string | `"https://api.host.langchain.com"` |  |
+| config.hostQueue | string | `"host"` | SAQ queue name used by the listener. When multiple installs of this chart share one Redis instance (e.g. a managed cache with DB-count limits), set this to a unique value per install to prevent SAQ queue collisions. |
 | config.langgraphListenerId | string | `""` |  |
 | config.langsmithApiKey | string | `""` |  |
 | config.langsmithWorkspaceId | string | `""` |  |

--- a/charts/langgraph-dataplane/templates/_helpers.tpl
+++ b/charts/langgraph-dataplane/templates/_helpers.tpl
@@ -110,7 +110,7 @@ Template containing common environment variables that are used by several servic
       name: {{ include "langgraphDataplane.secretsName" . }}
       key: langsmith_api_key
 - name: HOST_QUEUE
-  value: "host"
+  value: {{ .Values.config.hostQueue | quote }}
 - name: HOST_WORKER_RECONCILIATION_CRON_ENABLED
   value: "true"
 - name: HOST_WORKER_EXTERNAL_ENABLED

--- a/charts/langgraph-dataplane/values.yaml
+++ b/charts/langgraph-dataplane/values.yaml
@@ -89,6 +89,8 @@ config:
   smithBackendUrl: "https://api.smith.langchain.com"
   langsmithWorkspaceId: ""
   langgraphListenerId: ""
+  # -- SAQ queue name used by the listener. When multiple installs of this chart share one Redis instance (e.g. a managed cache with DB-count limits), set this to a unique value per install to prevent SAQ queue collisions.
+  hostQueue: "host"
   watchNamespaces: ""
   enableLGPDeploymentHealthCheck: true
 


### PR DESCRIPTION
## Summary

- Expose `HOST_QUEUE` as a chart value (`config.hostQueue`) so operators running multiple `langgraph-dataplane` installs against a shared Redis can give each listener its own SAQ queue.
- **Default is still `\"host\"`** — zero behavior change for existing deployments, no migration required, dashboards/scripts/runbooks that match the literal `host` keep working.

## Why

Running multiple chart installs against a single Redis instance (e.g. a managed cache where per-install logical-database separation runs into DB-count limits) caused every listener to subscribe to the same SAQ queue named `host`, so installs consumed each other's jobs. The `HOST_QUEUE` env var was hardcoded in `_helpers.tpl` with no override path.

Operators hitting this now set a unique `config.hostQueue` per install. Operators who aren't hitting it don't have to do anything.

## What changed

| File | Change |
|---|---|
| `templates/_helpers.tpl` | `HOST_QUEUE` value now sourced from `.Values.config.hostQueue` |
| `values.yaml` | New `config.hostQueue: \"host\"` with helm-docs description |
| `Chart.yaml` | Version `0.2.19` → `0.2.20` |
| `README.md` | Regenerated (new Configs table row) |

## Test plan

- [x] `helm lint charts/langgraph-dataplane` — passes
- [x] `helm template` default render → `HOST_QUEUE: host` (identical to pre-PR output)
- [x] `helm template --set config.hostQueue=foo` → `HOST_QUEUE: foo`
- [x] Live cluster test: two releases on shared in-cluster Redis, one on default + one with `config.hostQueue=release-b-custom` — verified distinct SAQ keyspaces (`saq:host:*` and `saq:release-b-custom:*`) with no cross-consumption
- [x] Listener log + Redis keys confirm SAQ job enqueue/consume uses the configured queue name end-to-end

## Future work — not in this PR

**Auto-derivation of the queue name from the release name** was considered but intentionally left out. The customer feature request mentioned it as an alternative (\"Alternatively, auto-derive it from the release name\"), but making it the default would break existing deployments on upgrade and require drain-migration planning. For now operators explicitly opt in with a unique value.

A reasonable future addition would be a sentinel like `config.hostQueue: auto` that resolves to the chart fullname at render time, giving users a zero-config path for the per-release case without changing the default. Would be a follow-up PR once we decide it's worth the extra surface area.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)