### PR TITLE
ci: use FIPS image variants in langsmith readonly test

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -168,7 +168,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | images.insightsAgentImage.tag | string | `"0.15.1rc1"` |  |
 | images.operatorImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.operatorImage.repository | string | `"docker.io/langchain/langgraph-operator"` |  |
-| images.operatorImage.tag | string | `"0.1.47"` |  |
+| images.operatorImage.tag | string | `"0.1.50"` |  |
 | images.platformBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.platformBackendImage.repository | string | `"docker.io/langchain/langsmith-go-backend"` |  |
 | images.platformBackendImage.tag | string | `"0.15.1rc1"` |  |

--- a/charts/langsmith/ci/readonly-config-values.yaml
+++ b/charts/langsmith/ci/readonly-config-values.yaml
@@ -1,4 +1,20 @@
 # Read-Only configuration. Use this if you are running in an environment where containers must run as read-only.
+images:
+  aceBackendImage:
+    repository: "docker.io/langchain/langsmith-ace-backend-fips"
+  backendImage:
+    repository: "docker.io/langchain/langsmith-backend-fips"
+  frontendImage:
+    repository: "docker.io/langchain/langsmith-frontend-fips"
+  hostBackendImage:
+    repository: "docker.io/langchain/hosted-langserve-backend-fips"
+  operatorImage:
+    repository: "docker.io/langchain/langgraph-operator-fips"
+  platformBackendImage:
+    repository: "docker.io/langchain/langsmith-go-backend-fips"
+  playgroundImage:
+    repository: "docker.io/langchain/langsmith-playground-fips"
+
 config:
   langsmithLicenseKey: "YOUR_LICENSE_KEY"
   apiKeySalt: "YOUR_API_KEY_SALT"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -60,7 +60,7 @@ images:
   operatorImage:
     repository: "docker.io/langchain/langgraph-operator"
     pullPolicy: IfNotPresent
-    tag: "0.1.47"
+    tag: "0.1.50"
   platformBackendImage:
     repository: "docker.io/langchain/langsmith-go-backend"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary
- Overrides the 7 LangChain-authored image repositories in `charts/langsmith/ci/readonly-config-values.yaml` to their `-fips` counterparts so the readonly CI job exercises FIPS images alongside the `readOnlyRootFilesystem: true` configuration.
- Only `repository` is overridden — `tag` and `pullPolicy` continue to flow from the chart's default `values.yaml`, so each release automatically pulls the matching FIPS build.
- Follows the image mapping documented in langchain-ai/docs#3712. Third-party images (postgres/redis/clickhouse) and LangChain images without a published FIPS variant (clio, agent-builder-*, polly) are untouched.

## Test plan
- [x] `helm lint charts/langsmith -f charts/langsmith/ci/readonly-config-values.yaml`
- [x] `helm template charts/langsmith -f charts/langsmith/ci/readonly-config-values.yaml` shows the 7 overridden repositories and default tag
- [x] CI readonly workflow pulls and runs the FIPS images successfully