### PR TITLE
chore: bump operator image to 0.1.50

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -168,7 +168,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | images.insightsAgentImage.tag | string | `"0.15.1rc2"` |  |
 | images.operatorImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.operatorImage.repository | string | `"docker.io/langchain/langgraph-operator"` |  |
-| images.operatorImage.tag | string | `"0.1.47"` |  |
+| images.operatorImage.tag | string | `"0.1.50"` |  |
 | images.platformBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.platformBackendImage.repository | string | `"docker.io/langchain/langsmith-go-backend"` |  |
 | images.platformBackendImage.tag | string | `"0.15.1rc2"` |  |

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -60,7 +60,7 @@ images:
   operatorImage:
     repository: "docker.io/langchain/langgraph-operator"
     pullPolicy: IfNotPresent
-    tag: "0.1.47"
+    tag: "0.1.50"
   platformBackendImage:
     repository: "docker.io/langchain/langsmith-go-backend"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary
- Bumps `langgraph-operator` image tag from `0.1.47` to `0.1.50` in the `langsmith` chart (`values.yaml` + `README.md` tag table).
- `langgraph-dataplane` chart still pins `0.1.36` and is intentionally untouched here — its operator version is tracked separately, see #567.

## Test plan
- [ ] `helm lint charts/langsmith`
- [ ] `helm template charts/langsmith` shows the operator image at `0.1.50`
- [ ] Operator pod comes up cleanly with the new tag in a dev cluster