### PR TITLE
ci: trigger chart-releaser on push to *-stable branches

### DIFF
--- a/.github/workflows/release_charts.yaml
+++ b/.github/workflows/release_charts.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - '*-stable'
 
 permissions: write-all
 


### PR DESCRIPTION
## Summary
- Adds `*-stable` glob to the `release_charts` workflow's push trigger so pushes to `v14-stable`, `langsmith-0.8-stable`, and future stable branches publish chart releases.
- `CR_SKIP_EXISTING: true` is already set, so previously released versions are skipped.

## Test plan
- [ ] Merge this PR; on the next chart-version-bumping push to a `*-stable` branch, confirm the workflow runs and chart-releaser publishes (or skips if existing).

Companion PR against `v14-stable` will be opened separately.