### PR TITLE
Add Fleet minimal LangSmith chart profile

### DIFF
--- a/charts/langsmith/examples/fleet_minimal_langsmith.yaml
+++ b/charts/langsmith/examples/fleet_minimal_langsmith.yaml
@@ -1,0 +1,50 @@
+# Example Fleet/minimal LangSmith profile.
+# Replace all placeholder secrets before using outside a disposable cluster.
+
+config:
+  fleetMinimalLangsmith:
+    enabled: true
+  deployment:
+    enabled: false
+  agentBuilder:
+    enabled: false
+  langsmithLicenseKey: "replace-with-license-key"
+  apiKeySalt: "replace-with-api-key-salt"
+  authType: "mixed"
+  initialOrgAdminEmail: "admin@example.com"
+  hostname: "https://langsmith.example.com"
+  basicAuth:
+    enabled: true
+    initialOrgAdminPassword: "ReplaceThisPassword!123"
+    jwtSecret: "replace-with-jwt-secret"
+
+fleet:
+  enabled: true
+  encryptionKey: "replace-with-fernet-key"
+
+frontend:
+  enabled: true
+
+# Needed while Fleet OAuth provider, callback, token, and integration flows
+# still run through host-backend.
+hostBackend:
+  enabled: true
+
+clickhouse:
+  enabled: false
+
+backend:
+  clickhouseMigrations:
+    enabled: false
+
+aceBackend:
+  enabled: false
+
+playground:
+  enabled: false
+
+queue:
+  enabled: false
+
+ingestQueue:
+  enabled: false

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -242,6 +242,7 @@ Template containing common environment variables that are used by several servic
 - name: REDIS_IAM_AUTH_PROVIDER
   value: {{ .Values.redis.external.iamAuthProvider | quote }}
 {{- end }}
+{{- if ne .Values.clickhouse.enabled false }}
 - name: CLICKHOUSE_HYBRID
   value: {{ .Values.clickhouse.external.hybrid | quote }}
 - name: CLICKHOUSE_DB
@@ -294,6 +295,7 @@ Template containing common environment variables that are used by several servic
 {{- end }}
 - name: CLICKHOUSE_CLUSTER
   value: {{ .Values.clickhouse.external.cluster | quote }}
+{{- end }}
 - name: LOG_LEVEL
   value: {{ .Values.config.logLevel | quote }}
 {{- if .Values.config.oauth.enabled }}
@@ -421,7 +423,7 @@ Template containing common environment variables that are used by several servic
 {{- end }}
 {{- end }}
 - name: FF_CH_SEARCH_ENABLED
-  value: {{ ternary "false" .Values.config.blobStorage.chSearchEnabled .Values.clickhouse.external.hybrid | quote }}
+  value: {{ ternary "false" .Values.config.blobStorage.chSearchEnabled (or .Values.clickhouse.external.hybrid (eq .Values.clickhouse.enabled false)) | quote }}
 {{ include "langsmith.conditionalEnvVarsResolved" . }}
 - name: REDIS_RUNS_EXPIRY_SECONDS
   value: {{ .Values.config.settings.redisRunsExpirySeconds | quote }}
@@ -675,7 +677,7 @@ checksum/redis: {{ include (print $.Template.BasePath "/redis/secrets.yaml") . |
 {{- if not .Values.postgres.external.existingSecretName }}
 checksum/postgres: {{ include (print $.Template.BasePath "/postgres/secrets.yaml") . | sha256sum }}
 {{- end }}
-{{- if not .Values.clickhouse.external.existingSecretName }}
+{{- if and (ne .Values.clickhouse.enabled false) (not .Values.clickhouse.external.existingSecretName) }}
 checksum/clickhouse: {{ include (print $.Template.BasePath "/clickhouse/secrets.yaml") . | sha256sum }}
 {{- end }}
 {{- end }}
@@ -704,7 +706,7 @@ Creates the image reference used for Langsmith deployments. If registry is speci
 {{- if .Values.postgres.external.clientCert.secretName -}}
 {{- $mounts = append $mounts (dict "name" "postgres-client-cert" "mountPath" "/etc/postgres/certs" "readOnly" true) -}}
 {{- end -}}
-{{- if .Values.clickhouse.external.clientCert.secretName -}}
+{{- if and (ne .Values.clickhouse.enabled false) .Values.clickhouse.external.clientCert.secretName -}}
 {{- $mounts = append $mounts (dict "name" "clickhouse-client-cert" "mountPath" "/etc/clickhouse/certs" "readOnly" true) -}}
 {{- end -}}
 {{ $mounts | toYaml }}
@@ -721,7 +723,7 @@ Creates the image reference used for Langsmith deployments. If registry is speci
 {{- if .Values.postgres.external.clientCert.secretName -}}
 {{- $volumes = append $volumes (dict "name" "postgres-client-cert" "secret" (dict "secretName" .Values.postgres.external.clientCert.secretName "items" (list (dict "key" .Values.postgres.external.clientCert.certSecretKey "path" "client.crt" "mode" 0644) (dict "key" .Values.postgres.external.clientCert.keySecretKey "path" "client.key" "mode" 0640)))) -}}
 {{- end -}}
-{{- if .Values.clickhouse.external.clientCert.secretName -}}
+{{- if and (ne .Values.clickhouse.enabled false) .Values.clickhouse.external.clientCert.secretName -}}
 {{- $volumes = append $volumes (dict "name" "clickhouse-client-cert" "secret" (dict "secretName" .Values.clickhouse.external.clientCert.secretName "items" (list (dict "key" .Values.clickhouse.external.clientCert.certSecretKey "path" "client.crt" "mode" 0644) (dict "key" .Values.clickhouse.external.clientCert.keySecretKey "path" "client.key" "mode" 0640)))) -}}
 {{- end -}}
 {{ $volumes | toYaml }}
@@ -826,4 +828,3 @@ Served through the frontend at /mcp (or /<basePath>/mcp).
   value: {{ $slackBotId | quote }}
 {{- end }}
 {{- end -}}
-

--- a/charts/langsmith/templates/ace-backend/deployment.yaml
+++ b/charts/langsmith/templates/ace-backend/deployment.yaml
@@ -4,6 +4,7 @@
 - name: BIND_ADDRESS
   value: {{ .Values.aceBackend.bindAddress | quote }}
 {{- end -}}
+{{- if .Values.aceBackend.enabled }}
 {{- $envVars := concat (include "aceBackendEnvVars" . | fromYamlArray) .Values.aceBackend.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
 {{- if .Values.aceBackend.rollout.enabled }}
@@ -134,4 +135,5 @@ spec:
 {{- if .Values.aceBackend.rollout.enabled }}
   strategy:
     {{- toYaml .Values.aceBackend.rollout.strategy | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/langsmith/templates/ace-backend/hpa.yaml
+++ b/charts/langsmith/templates/ace-backend/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.aceBackend.autoscaling.hpa.enabled }}
+{{- if and .Values.aceBackend.enabled .Values.aceBackend.autoscaling.hpa.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/langsmith/templates/ace-backend/pdb.yaml
+++ b/charts/langsmith/templates/ace-backend/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.aceBackend.pdb.enabled }}
+{{- if and .Values.aceBackend.enabled .Values.aceBackend.pdb.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/langsmith/templates/ace-backend/scaled-object.yaml
+++ b/charts/langsmith/templates/ace-backend/scaled-object.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.aceBackend.autoscaling.keda.enabled }}
+{{- if and .Values.aceBackend.enabled .Values.aceBackend.autoscaling.keda.enabled }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/charts/langsmith/templates/ace-backend/service-account.yaml
+++ b/charts/langsmith/templates/ace-backend/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.aceBackend.serviceAccount.create -}}
+{{- if and .Values.aceBackend.enabled .Values.aceBackend.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/langsmith/templates/ace-backend/service.yaml
+++ b/charts/langsmith/templates/ace-backend/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.aceBackend.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -29,3 +30,4 @@ spec:
   selector:
     {{- include "langsmith.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.aceBackend.name }}
+{{- end }}

--- a/charts/langsmith/templates/backend/deployment.yaml
+++ b/charts/langsmith/templates/backend/deployment.yaml
@@ -13,6 +13,10 @@
 - name: CLIO_LANGGRAPH_URL
   value: "http://{{ include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "insights") }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.insights.apiServer.service.httpPort }}"
 {{- end }}
+{{- if eq .Values.clickhouse.enabled false }}
+- name: SKIP_HEALTH_SERVICES
+  value: '["clickhouse"]'
+{{- end }}
 {{- end -}}
 {{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "backendEnvVars" . | fromYamlArray) .Values.backend.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}

--- a/charts/langsmith/templates/clickhouse/config-map.yaml
+++ b/charts/langsmith/templates/clickhouse/config-map.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.clickhouse.external.enabled }}
+{{- if and (ne .Values.clickhouse.enabled false) (not .Values.clickhouse.external.enabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/langsmith/templates/clickhouse/pdb.yaml
+++ b/charts/langsmith/templates/clickhouse/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clickhouse.pdb.enabled }}
+{{- if and (ne .Values.clickhouse.enabled false) .Values.clickhouse.pdb.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/langsmith/templates/clickhouse/secrets.yaml
+++ b/charts/langsmith/templates/clickhouse/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if not (or .Values.clickhouse.disableSecretCreation .Values.clickhouse.external.existingSecretName) }}
+{{- if and (ne .Values.clickhouse.enabled false) (not (or .Values.clickhouse.disableSecretCreation .Values.clickhouse.external.existingSecretName)) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/langsmith/templates/clickhouse/service-account.yaml
+++ b/charts/langsmith/templates/clickhouse/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.clickhouse.external.enabled) .Values.clickhouse.serviceAccount.create -}}
+{{- if and (ne .Values.clickhouse.enabled false) (not .Values.clickhouse.external.enabled) .Values.clickhouse.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/langsmith/templates/clickhouse/service.yaml
+++ b/charts/langsmith/templates/clickhouse/service.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.clickhouse.external.enabled }}
+{{- if and (ne .Values.clickhouse.enabled false) (not .Values.clickhouse.external.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/langsmith/templates/clickhouse/stateful-set.yaml
+++ b/charts/langsmith/templates/clickhouse/stateful-set.yaml
@@ -18,7 +18,7 @@
       key: clickhouse_password
       optional: {{ .Values.config.disableSecretCreation }}
 {{- end -}}
-{{- if not .Values.clickhouse.external.enabled }}
+{{- if and (ne .Values.clickhouse.enabled false) (not .Values.clickhouse.external.enabled) }}
 {{- $envVars := concat .Values.commonEnv (include "clickhouseEnvVars" . | fromYamlArray) .Values.clickhouse.statefulSet.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
 {{- $volumes := concat .Values.commonVolumes .Values.clickhouse.statefulSet.volumes -}}

--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -35,8 +35,12 @@ data:
   LANGCHAIN_ENV: "local_kubernetes"
   LANGCHAIN_ENDPOINT: "/{{ if .Values.config.basePath }}{{ .Values.config.basePath }}/{{ end }}api/v1"
   GO_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }}"
+  {{- if .Values.aceBackend.enabled }}
   GO_ACE_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.aceBackend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.aceBackend.service.port }}"
+  {{- end }}
+  {{- if .Values.playground.enabled }}
   PLAYGROUND_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.playground.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.playground.service.port }}"
+  {{- end }}
   SMITH_BACKEND_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.backend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.backend.service.port }}"
   HOST_BACKEND_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.hostBackend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.hostBackend.service.port }}"
   {{- if .Values.config.deployment.enabled }}
@@ -65,7 +69,7 @@ data:
   # Self-hosted telemetry
   ENABLE_POSTGRES_METRICS_CRON: {{ ternary "true" "false" .Values.config.telemetry.metrics | quote }}
   ENABLE_REDIS_METRICS_CRON: {{ ternary "true" "false" .Values.config.telemetry.metrics | quote }}
-  ENABLE_CLICKHOUSE_METRICS_CRON: {{ ternary "true" "false" .Values.config.telemetry.metrics | quote }}
+  ENABLE_CLICKHOUSE_METRICS_CRON: {{ ternary "true" "false" (and .Values.config.telemetry.metrics (ne .Values.clickhouse.enabled false)) | quote }}
   BEACON_LOGGING_ENABLED: {{ ternary "true" "false" .Values.config.telemetry.logs | quote }}
   BEACON_METRICS_ENABLED: {{ ternary "true" "false" .Values.config.telemetry.metrics | quote }}
   BEACON_TRACING_ENABLED: {{ ternary "true" "false" .Values.config.telemetry.traces | quote }}

--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -582,12 +582,16 @@ data:
         }
 
         location /api/v1/playground/ {
+            {{- if .Values.playground.enabled }}
             rewrite /api/v1/playground/(.*) /playground/$1  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.playground.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.playground.service.port }};
+            {{- else }}
+            return 404;
+            {{- end }}
         }
 
         # Platform Backend Routes

--- a/charts/langsmith/templates/playground/deployment.yaml
+++ b/charts/langsmith/templates/playground/deployment.yaml
@@ -8,6 +8,7 @@
   value: /etc/ssl/certs/custom-ca-certificates.crt
 {{- end }}
 {{- end -}}
+{{- if .Values.playground.enabled }}
 {{- $envVars := concat (include "playgroundEnvVars" . | fromYamlArray) .Values.playground.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
 {{- $volumes := concat .Values.commonVolumes .Values.playground.deployment.volumes (include "langsmith.tlsVolumes" . | fromYamlArray)  -}}
@@ -140,4 +141,5 @@ spec:
 {{- if .Values.playground.rollout.enabled }}
   strategy:
     {{- toYaml .Values.playground.rollout.strategy | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/langsmith/templates/playground/hpa.yaml
+++ b/charts/langsmith/templates/playground/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.playground.autoscaling.hpa.enabled }}
+{{- if and .Values.playground.enabled .Values.playground.autoscaling.hpa.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/langsmith/templates/playground/pdb.yaml
+++ b/charts/langsmith/templates/playground/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.playground.pdb.enabled }}
+{{- if and .Values.playground.enabled .Values.playground.pdb.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/langsmith/templates/playground/scaled-object.yaml
+++ b/charts/langsmith/templates/playground/scaled-object.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.playground.autoscaling.keda.enabled }}
+{{- if and .Values.playground.enabled .Values.playground.autoscaling.keda.enabled }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/charts/langsmith/templates/playground/service-account.yaml
+++ b/charts/langsmith/templates/playground/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.playground.serviceAccount.create -}}
+{{- if and .Values.playground.enabled .Values.playground.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/langsmith/templates/playground/service.yaml
+++ b/charts/langsmith/templates/playground/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.playground.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -29,3 +30,4 @@ spec:
   selector:
     {{- include "langsmith.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.playground.name }}
+{{- end }}

--- a/charts/langsmith/templates/queue/deployment.yaml
+++ b/charts/langsmith/templates/queue/deployment.yaml
@@ -10,6 +10,7 @@
   value: "http://{{ include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "insights") }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.insights.apiServer.service.httpPort }}"
 {{- end }}
 {{- end -}}
+{{- if .Values.queue.enabled }}
 {{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "queueEnvVars" . | fromYamlArray) .Values.queue.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
 {{- $volumes := concat .Values.commonVolumes .Values.queue.deployment.volumes (include "langsmith.tlsVolumes" . | fromYamlArray)  -}}
@@ -148,4 +149,5 @@ spec:
 {{- if .Values.queue.rollout.enabled }}
   strategy:
     {{- toYaml .Values.queue.rollout.strategy | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/langsmith/templates/queue/hpa.yaml
+++ b/charts/langsmith/templates/queue/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.queue.autoscaling.hpa.enabled }}
+{{- if and .Values.queue.enabled .Values.queue.autoscaling.hpa.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/langsmith/templates/queue/pdb.yaml
+++ b/charts/langsmith/templates/queue/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.queue.pdb.enabled }}
+{{- if and .Values.queue.enabled .Values.queue.pdb.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/langsmith/templates/queue/scaled-object.yaml
+++ b/charts/langsmith/templates/queue/scaled-object.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.queue.autoscaling.keda.enabled }}
+{{- if and .Values.queue.enabled .Values.queue.autoscaling.keda.enabled }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/charts/langsmith/templates/queue/service-account.yaml
+++ b/charts/langsmith/templates/queue/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.queue.serviceAccount.create -}}
+{{- if and .Values.queue.enabled .Values.queue.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -18,6 +18,38 @@ AWS Marketplace Helm template verification).
 
 {{- if not .Values.config.skipValidation -}}
 
+{{- /* Validate Fleet/minimal LangSmith profile configuration */ -}}
+{{- $fleetMinimalLangsmith := .Values.config.fleetMinimalLangsmith | default dict -}}
+{{- if ($fleetMinimalLangsmith.enabled | default false) -}}
+{{- if not .Values.frontend.enabled -}}
+{{- fail "frontend.enabled must be true when config.fleetMinimalLangsmith.enabled is true. Fleet/minimal LangSmith uses the frontend nginx router for API, MCP, and trigger paths." -}}
+{{- end -}}
+{{- if not .Values.fleet.enabled -}}
+{{- fail "fleet.enabled must be true when config.fleetMinimalLangsmith.enabled is true." -}}
+{{- end -}}
+{{- if .Values.config.deployment.enabled -}}
+{{- fail "config.deployment.enabled must be false when config.fleetMinimalLangsmith.enabled is true. Standalone LangGraph/LSD must be deployed as sibling infrastructure for this profile." -}}
+{{- end -}}
+{{- if .Values.config.agentBuilder.enabled -}}
+{{- fail "config.agentBuilder.enabled must be false when config.fleetMinimalLangsmith.enabled is true. Use fleet.enabled and the Fleet services instead of LangSmith-managed Agent Builder deployments." -}}
+{{- end -}}
+{{- if .Values.config.insights.enabled -}}
+{{- fail "config.insights.enabled must be false when config.fleetMinimalLangsmith.enabled is true." -}}
+{{- end -}}
+{{- if .Values.config.polly.enabled -}}
+{{- fail "config.polly.enabled must be false when config.fleetMinimalLangsmith.enabled is true." -}}
+{{- end -}}
+{{- if .Values.insights.enabled -}}
+{{- fail "insights.enabled must be false when config.fleetMinimalLangsmith.enabled is true." -}}
+{{- end -}}
+{{- if .Values.polly.enabled -}}
+{{- fail "polly.enabled must be false when config.fleetMinimalLangsmith.enabled is true." -}}
+{{- end -}}
+{{- if and .Values.agentBuilderTriggerServer.enabled (not .Values.hostBackend.enabled) -}}
+{{- fail "hostBackend.enabled must be true when config.fleetMinimalLangsmith.enabled is true and agentBuilderTriggerServer.enabled is true. Trigger OAuth/provider flows still depend on host-backend in this profile." -}}
+{{- end -}}
+{{- end -}}
+
 {{- /* Validate ingress configuration */ -}}
 # Fail if none of ingress, gateway, or istioGateway are enabled and LangSmith Deployment is enabled with the chart-managed frontend
 {{- if and .Values.frontend.enabled (not .Values.ingress.enabled) (not .Values.gateway.enabled) (not .Values.istioGateway.enabled) .Values.config.deployment.enabled }}
@@ -181,8 +213,17 @@ AWS Marketplace Helm template verification).
 {{- end -}}
 
 {{- /* Validate clickhouse mTLS configuration */ -}}
+{{- if eq .Values.clickhouse.enabled false -}}
+{{- if .Values.clickhouse.external.enabled -}}
+{{- fail "clickhouse.external.enabled must be false when clickhouse.enabled is false." -}}
+{{- end -}}
+{{- if .Values.backend.clickhouseMigrations.enabled -}}
+{{- fail "backend.clickhouseMigrations.enabled must be false when clickhouse.enabled is false." -}}
+{{- end -}}
+{{- else -}}
 {{- if and .Values.clickhouse.external.clientCert.secretName (not .Values.clickhouse.external.existingSecretName) (not .Values.clickhouse.external.tls) -}}
 {{- fail "clickhouse.external.tls must be true when clickhouse.external.clientCert.secretName is set and the value is not being fetched from an existing secret." -}}
+{{- end -}}
 {{- end -}}
 
 {{- /* Validate agent builder configuration */ -}}

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -831,6 +831,11 @@ polly:
 config:
   # -- Skip validation checks in validate.yaml. Used by AWS Marketplace for helm template verification.
   skipValidation: false
+  # -- Enables the reduced Fleet/minimal LangSmith deployment profile. This profile
+  # -- keeps LangSmith auth/user/org state and Fleet services, while requiring
+  # -- LangSmith Deployments and Agent Builder deployment management to stay off.
+  fleetMinimalLangsmith:
+    enabled: false
   existingSecretName: ""
   disableSecretCreation: false
   langsmithLicenseKey: ""
@@ -1074,6 +1079,7 @@ config:
       alwaysAllowPathsRegex: ""
 
 aceBackend:
+  enabled: true
   name: "ace-backend"
   containerPort: 1987
   bindAddress: "0.0.0.0"
@@ -1434,6 +1440,7 @@ backend:
     ttlSecondsAfterFinished: 600
 
 clickhouse:
+  enabled: true
   name: "clickhouse"
   disableSecretCreation: false
   config:
@@ -2204,6 +2211,7 @@ operator:
                 storage: "${storage_gi}Gi"
 
 playground:
+  enabled: true
   name: "playground"
   containerPort: 1988
   # -- ArgoCD Rollouts configuration. If enabled, will create a Rollout resource instead of a Deployment. See https://argo-rollouts.readthedocs.io/
@@ -2419,6 +2427,7 @@ postgres:
     automountServiceAccountToken: true
 
 queue:
+  enabled: true
   name: "queue"
   containerPort: 8080
   # -- ArgoCD Rollouts configuration. If enabled, will create a Rollout resource instead of a Deployment. See https://argo-rollouts.readthedocs.io/


### PR DESCRIPTION
## Summary

- add a disabled-by-default Fleet/minimal LangSmith profile marker and validation
- add explicit component switches for ace-backend, playground, queue, and ClickHouse
- add a Fleet/minimal example values file that disables ClickHouse and eval/observability-adjacent services

## Validation

- `helm lint charts/langsmith -f charts/langsmith/examples/fleet_minimal_langsmith.yaml`
- `helm lint charts/langsmith`
- `git diff --check`
- rendered the Fleet/minimal example and confirmed ClickHouse, ace-backend, playground, and queue resources are omitted
