### PR TITLE
feat(langsmith): strip internal Envoy response headers (INF-2025)

### DIFF
--- a/charts/langsmith/templates/envoy-filter-strip-response-headers.yaml
+++ b/charts/langsmith/templates/envoy-filter-strip-response-headers.yaml
@@ -1,3 +1,41 @@
 {{- if and .Values.istioGateway.enabled .Values.istioGateway.stripResponseHeaders.enabled }}
-{{- /* body filled in by Task 3 */ -}}
+{{- $s := .Values.istioGateway.stripResponseHeaders }}
+{{- if $s.headers }}
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: {{ include "langsmith.fullname" . }}-strip-response-headers
+  namespace: {{ .Values.istioGateway.namespace }}
+  annotations:
+    {{- include "langsmith.annotations" . | nindent 4 }}
+    {{- with .Values.istioGateway.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "langsmith.labels" . | nindent 4 }}
+    {{- with .Values.istioGateway.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  workloadSelector:
+    labels:
+      {{- toYaml $s.workloadSelector | nindent 6 }}
+  configPatches:
+    - applyTo: NETWORK_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: envoy.filters.network.http_connection_manager
+      patch:
+        operation: MERGE
+        value:
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+            response_headers_to_remove:
+              {{- range $s.headers }}
+              - {{ . | quote }}
+              {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/langsmith/templates/envoy-filter-strip-response-headers.yaml
+++ b/charts/langsmith/templates/envoy-filter-strip-response-headers.yaml
@@ -1,0 +1,3 @@
+{{- if and .Values.istioGateway.enabled .Values.istioGateway.stripResponseHeaders.enabled }}
+{{- /* body filled in by Task 3 */ -}}
+{{- end }}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -44,6 +44,11 @@ AWS Marketplace Helm template verification).
 {{- fail "istioGateway.stripResponseHeaders.enabled requires istioGateway.enabled to be true." -}}
 {{- end -}}
 
+{{- /* Validate workloadSelector is non-empty (empty selector attaches to ALL pods in the gateway namespace) */ -}}
+{{- if and .Values.istioGateway.stripResponseHeaders.enabled (empty .Values.istioGateway.stripResponseHeaders.workloadSelector) -}}
+{{- fail "istioGateway.stripResponseHeaders.workloadSelector must not be empty - an empty selector would attach the EnvoyFilter to every pod in the gateway namespace." -}}
+{{- end -}}
+
 # Fail if hostname is missing when deployment is enabled
 {{- if and .Values.config.deployment.enabled (not .Values.config.hostname) }}
 {{- fail "config.hostname is required when LangSmith Deployments is enabled." -}}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -49,6 +49,11 @@ AWS Marketplace Helm template verification).
 {{- fail "istioGateway.stripResponseHeaders.workloadSelector must not be empty - an empty selector would attach the EnvoyFilter to every pod in the gateway namespace." -}}
 {{- end -}}
 
+{{- /* Validate headers list is non-empty */ -}}
+{{- if and .Values.istioGateway.stripResponseHeaders.enabled (empty .Values.istioGateway.stripResponseHeaders.headers) -}}
+{{- fail "istioGateway.stripResponseHeaders.headers must contain at least one header to strip." -}}
+{{- end -}}
+
 # Fail if hostname is missing when deployment is enabled
 {{- if and .Values.config.deployment.enabled (not .Values.config.hostname) }}
 {{- fail "config.hostname is required when LangSmith Deployments is enabled." -}}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -39,6 +39,11 @@ AWS Marketplace Helm template verification).
   {{- end -}}
 {{- end -}}
 
+{{- /* Validate stripResponseHeaders requires istioGateway.enabled */ -}}
+{{- if and .Values.istioGateway.stripResponseHeaders.enabled (not .Values.istioGateway.enabled) -}}
+{{- fail "istioGateway.stripResponseHeaders.enabled requires istioGateway.enabled to be true." -}}
+{{- end -}}
+
 # Fail if hostname is missing when deployment is enabled
 {{- if and .Values.config.deployment.enabled (not .Values.config.hostname) }}
 {{- fail "config.hostname is required when LangSmith Deployments is enabled." -}}

--- a/charts/langsmith/tests/strip_response_headers_test.yaml
+++ b/charts/langsmith/tests/strip_response_headers_test.yaml
@@ -1,0 +1,17 @@
+suite: test envoy filter for stripping response headers
+templates:
+  - envoy-filter-strip-response-headers.yaml
+tests:
+  - it: should not render when istioGateway.enabled is false (default)
+    template: envoy-filter-strip-response-headers.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when istioGateway.enabled is true but stripResponseHeaders.enabled is false (default)
+    template: envoy-filter-strip-response-headers.yaml
+    set:
+      istioGateway.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/langsmith/tests/strip_response_headers_test.yaml
+++ b/charts/langsmith/tests/strip_response_headers_test.yaml
@@ -59,3 +59,40 @@ tests:
       - equal:
           path: spec.configPatches[0].patch.value.typed_config["@type"]
           value: type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+
+  - it: should render the configured custom headers list
+    template: envoy-filter-strip-response-headers.yaml
+    set:
+      istioGateway.enabled: true
+      istioGateway.stripResponseHeaders.enabled: true
+      istioGateway.stripResponseHeaders.headers:
+        - server
+        - x-powered-by
+        - x-custom-header
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.configPatches[0].patch.value.typed_config.response_headers_to_remove
+          value:
+            - server
+            - x-powered-by
+            - x-custom-header
+
+  - it: should render the configured custom workloadSelector
+    template: envoy-filter-strip-response-headers.yaml
+    set:
+      istioGateway.enabled: true
+      istioGateway.stripResponseHeaders.enabled: true
+      istioGateway.stripResponseHeaders.workloadSelector:
+        app: my-custom-gateway
+        tier: edge
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.workloadSelector.labels.app
+          value: my-custom-gateway
+      - equal:
+          path: spec.workloadSelector.labels.tier
+          value: edge

--- a/charts/langsmith/tests/strip_response_headers_test.yaml
+++ b/charts/langsmith/tests/strip_response_headers_test.yaml
@@ -15,3 +15,47 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should render EnvoyFilter with defaults when both toggles enabled
+    template: envoy-filter-strip-response-headers.yaml
+    set:
+      istioGateway.enabled: true
+      istioGateway.stripResponseHeaders.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: EnvoyFilter
+      - equal:
+          path: apiVersion
+          value: networking.istio.io/v1alpha3
+      - equal:
+          path: metadata.namespace
+          value: istio-system
+      - equal:
+          path: spec.workloadSelector.labels.istio
+          value: ingressgateway
+      - equal:
+          path: spec.configPatches[0].patch.value.typed_config.response_headers_to_remove
+          value:
+            - x-envoy-upstream-service-time
+            - x-envoy-decorator-operation
+      - equal:
+          path: spec.configPatches[0].applyTo
+          value: NETWORK_FILTER
+      - equal:
+          path: spec.configPatches[0].match.context
+          value: GATEWAY
+      - equal:
+          path: spec.configPatches[0].match.listener.filterChain.filter.name
+          value: envoy.filters.network.http_connection_manager
+      - equal:
+          path: spec.configPatches[0].patch.operation
+          value: MERGE
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-langsmith-strip-response-headers
+      - equal:
+          path: spec.configPatches[0].patch.value.typed_config["@type"]
+          value: type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager

--- a/charts/langsmith/tests/strip_response_headers_validation_test.yaml
+++ b/charts/langsmith/tests/strip_response_headers_validation_test.yaml
@@ -19,3 +19,12 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "istioGateway.stripResponseHeaders.enabled requires istioGateway.enabled to be true."
+
+  - it: should fail when stripResponseHeaders.workloadSelector is empty
+    set:
+      istioGateway.enabled: true
+      istioGateway.stripResponseHeaders.enabled: true
+      istioGateway.stripResponseHeaders.workloadSelector: null
+    asserts:
+      - failedTemplate:
+          errorMessage: "istioGateway.stripResponseHeaders.workloadSelector must not be empty - an empty selector would attach the EnvoyFilter to every pod in the gateway namespace."

--- a/charts/langsmith/tests/strip_response_headers_validation_test.yaml
+++ b/charts/langsmith/tests/strip_response_headers_validation_test.yaml
@@ -1,0 +1,21 @@
+suite: test stripResponseHeaders validation
+templates:
+  - validate.yaml
+# Suite-level set provides minimum config to bypass UNRELATED validate.yaml checks
+# (apiKeySalt, license, basicAuth, authType, password complexity, frontend.enabled).
+# Per-test `set:` overrides what's needed to trigger the SPECIFIC validation under test.
+set:
+  config.apiKeySalt: "test-salt-1234567890"
+  config.langsmithLicenseKey: "test-license-key"
+  config.authType: "mixed"
+  config.basicAuth.enabled: true
+  config.basicAuth.initialOrgAdminEmail: "test@example.com"
+  config.basicAuth.initialOrgAdminPassword: "TestPass1234!"
+tests:
+  - it: should fail when stripResponseHeaders.enabled but istioGateway.enabled is false
+    set:
+      istioGateway.enabled: false
+      istioGateway.stripResponseHeaders.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "istioGateway.stripResponseHeaders.enabled requires istioGateway.enabled to be true."

--- a/charts/langsmith/tests/strip_response_headers_validation_test.yaml
+++ b/charts/langsmith/tests/strip_response_headers_validation_test.yaml
@@ -28,3 +28,12 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "istioGateway.stripResponseHeaders.workloadSelector must not be empty - an empty selector would attach the EnvoyFilter to every pod in the gateway namespace."
+
+  - it: should fail when stripResponseHeaders.headers is empty
+    set:
+      istioGateway.enabled: true
+      istioGateway.stripResponseHeaders.enabled: true
+      istioGateway.stripResponseHeaders.headers: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "istioGateway.stripResponseHeaders.headers must contain at least one header to strip."

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -125,6 +125,21 @@ istioGateway:
   namespace: "istio-system"
   annotations: {}
   labels: {}
+  # -- Optional: deploy an EnvoyFilter to the istio-gateway pods that
+  # -- strips internal Envoy observability headers from all responses
+  # -- leaving the gateway. Useful for closing pentest findings about
+  # -- HTTP response header information disclosure.
+  stripResponseHeaders:
+    enabled: false
+    # -- Label selector matching the Istio gateway pods to attach the
+    # -- filter to. Default matches the standard Istio ingress gateway.
+    workloadSelector:
+      istio: ingressgateway
+    # -- List of response headers to strip. The defaults cover known
+    # -- Envoy/Istio observability headers flagged by external pentests.
+    headers:
+      - x-envoy-upstream-service-time
+      - x-envoy-decorator-operation
 
 
 fleet:


### PR DESCRIPTION
## Summary

- Adds opt-in `EnvoyFilter` to strip internal Envoy observability headers (`x-envoy-upstream-service-time`, `x-envoy-decorator-operation`) from gateway responses for self-hosted customers running Istio.
- New values: `istioGateway.stripResponseHeaders.{enabled,workloadSelector,headers}`. Default: disabled. The default `headers` list closes the pentest finding without further configuration.
- Validation in `validate.yaml` rejects misconfiguration (toggle without `istioGateway.enabled`, empty `workloadSelector`, empty `headers`).

## Test plan

- [x] `helm unittest charts/langsmith` — 18/18 pass across 3 suites (existing + 5 new EnvoyFilter rendering tests + 3 new validation tests)
- [x] `helm template` with `istioGateway.stripResponseHeaders.enabled=true` renders a structurally correct EnvoyFilter (NETWORK_FILTER MERGE patch on http_connection_manager, `response_headers_to_remove` populated)
- [x] `helm template` with toggle on but `istioGateway.enabled=false` fails with the validation error
- [x] After deploy: `curl -i` against any path shows neither `x-envoy-upstream-service-time` nor `x-envoy-decorator-operation` in the response