### PR TITLE
release_charts: Trivy CVE diff + send fixed_cves payload to changelog bot

### DIFF
--- a/.github/workflows/release_charts.yaml
+++ b/.github/workflows/release_charts.yaml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
       - '*-stable'
+  workflow_dispatch:
+    inputs:
+      dry_run_cve_diff:
+        description: 'Compute the CVE diff but do not include it in the bot trigger payload'
+        type: boolean
+        default: false
 
 permissions: write-all
 
@@ -39,9 +45,116 @@ jobs:
           CR_SKIP_EXISTING: true
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Trigger self-hosted changelog bot
+      # CVE diff: scan langsmith-backend at the previous and new appVersion
+      # tags, then send the fixed-CVE delta to the changelog bot. Public images
+      # on Docker Hub, so no docker login required. Trivy errors do not fail
+      # the release (continue-on-error). Scope is langsmith-backend only for
+      # v1; siblings (langsmith-go-backend, langsmith-frontend, ...) can be
+      # added as additional matrix entries once this lands.
+      - name: Determine appVersions for CVE diff
+        id: versions
         run: |
+          set -euo pipefail
+          chart=charts/langsmith/Chart.yaml
+          new=$(awk '/^appVersion:/ {gsub(/"/,"",$2); print $2}' "$chart")
+          prev=$(git show HEAD~1:"$chart" 2>/dev/null | awk '/^appVersion:/ {gsub(/"/,"",$2); print $2}' || true)
+          echo "prev=$prev" >> "$GITHUB_OUTPUT"
+          echo "new=$new"  >> "$GITHUB_OUTPUT"
+          if [ -z "$prev" ] || [ -z "$new" ] || [ "$prev" = "$new" ]; then
+            echo "[INFO] Skipping CVE diff (prev='$prev' new='$new')"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "[INFO] Will diff langsmith-backend $prev -> $new"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Scan previous langsmith-backend image
+        if: steps.versions.outputs.skip == 'false'
+        uses: aquasecurity/trivy-action@0.28.0
+        continue-on-error: true
+        with:
+          image-ref: docker.io/langchain/langsmith-backend:${{ steps.versions.outputs.prev }}
+          severity: HIGH,CRITICAL
+          format: json
+          output: before.json
+          exit-code: '0'
+          ignore-unfixed: false
+          vuln-type: 'os,library'
+
+      - name: Scan new langsmith-backend image
+        if: steps.versions.outputs.skip == 'false'
+        uses: aquasecurity/trivy-action@0.28.0
+        continue-on-error: true
+        with:
+          image-ref: docker.io/langchain/langsmith-backend:${{ steps.versions.outputs.new }}
+          severity: HIGH,CRITICAL
+          format: json
+          output: after.json
+          exit-code: '0'
+          ignore-unfixed: false
+          vuln-type: 'os,library'
+
+      - name: Compute fixed CVEs
+        if: steps.versions.outputs.skip == 'false'
+        id: diff
+        run: |
+          set -euo pipefail
+          if [ ! -s before.json ] || [ ! -s after.json ]; then
+            echo "[WARN] One or both Trivy scans produced no output; emitting empty fixed_cves.json"
+            echo "[]" > fixed_cves.json
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python3 - <<'PY'
+          import json, pathlib
+          def collect(p):
+              try:
+                  data = json.loads(pathlib.Path(p).read_text())
+              except Exception as exc:
+                  print(f"[WARN] could not parse {p}: {exc.__class__.__name__}")
+                  return {}
+              seen = {}
+              for r in data.get('Results') or []:
+                  for v in r.get('Vulnerabilities') or []:
+                      vid = v.get('VulnerabilityID')
+                      if vid and vid not in seen:
+                          seen[vid] = {
+                              'id': vid,
+                              'severity': v.get('Severity', '') or '',
+                              'package': v.get('PkgName', '') or '',
+                          }
+              return seen
+          before = collect('before.json')
+          after  = collect('after.json')
+          fixed = [before[k] for k in before if k not in after]
+          pathlib.Path('fixed_cves.json').write_text(json.dumps(fixed, indent=2))
+          print(f"[INFO] Fixed CVEs (HIGH+CRITICAL): {len(fixed)}")
+          PY
+          cat fixed_cves.json
+          echo "count=$(jq 'length' fixed_cves.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger self-hosted changelog bot
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run_cve_diff || 'false' }}
+          NEW_APP_VERSION: ${{ steps.versions.outputs.new }}
+          DIFF_RAN: ${{ steps.diff.outcome == 'success' }}
+          FIXED_COUNT: ${{ steps.diff.outputs.count || '0' }}
+        run: |
+          set -euo pipefail
+          payload=$(mktemp)
+          echo '{}' > "$payload"
+          if [ "$DIFF_RAN" = "true" ] && [ "$FIXED_COUNT" -gt 0 ]; then
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[INFO] dry_run_cve_diff=true; skipping CVE payload (would have included $FIXED_COUNT CVE(s))"
+              cat fixed_cves.json
+            else
+              jq -n --arg v "$NEW_APP_VERSION" --slurpfile cves fixed_cves.json \
+                '{fixed_cves_by_app_version: {($v): $cves[0]}}' > "$payload"
+              echo "[INFO] Posting fixed_cves payload for app_version=$NEW_APP_VERSION ($FIXED_COUNT CVE(s))"
+            fi
+          fi
           curl -X POST "${{ secrets.HELM_CHANGELOG_BOT_URL }}/trigger" \
             -H "X-Api-Key: ${{ secrets.LANGSMITH_API_KEY }}" \
             -H "Content-Type: application/json" \
+            --data-binary "@$payload" \
             --fail --silent --show-error


### PR DESCRIPTION
Requested by: @ashwinamardeep-ashwin

Companion PR: [helm-changelog-bot#28](https://github.com/langchain-ai/helm-changelog-bot/pull/28). Both should land together; the bot side is backwards-compatible so order does not matter for safety.

## Summary
At release time, scan \`docker.io/langchain/langsmith-backend\` at the previous and new \`appVersion\` tags, compute the set difference of HIGH+CRITICAL CVEs (before − after), and post that delta as JSON to the changelog bot's \`/trigger\`. The bot renders a per-version \`## Security\` block from the payload (or falls back to regex over release notes if no payload).

New steps inserted after \`Run chart-releaser\`, before \`Trigger self-hosted changelog bot\`:
1. **Determine appVersions** — \`awk\` on \`charts/langsmith/Chart.yaml\` (current + \`HEAD~1\`); skips the diff when prev == new or either is missing. \`fetch-depth: 0\` is already set on checkout.
2. **Scan previous image** — \`aquasecurity/trivy-action@0.28.0\`, \`severity: HIGH,CRITICAL\`, \`continue-on-error: true\`. No docker login needed (image is public on Docker Hub).
3. **Scan new image** — same.
4. **Compute fixed CVEs** — inline \`python3\` parses Trivy JSON, set-diffs by \`VulnerabilityID\`, writes \`fixed_cves.json\` as \`[{id, severity, package}]\`.
5. **Trigger** — builds payload via \`jq -n --slurpfile\`, posts with \`--data-binary @file\`. Existing curl, headers, and \`X-Api-Key\` auth are unchanged.

## Workflow_dispatch
Adds \`dry_run_cve_diff: boolean\` input. When \`true\`, the diff still runs and is logged, but the payload sent to the bot is \`{}\` — useful for end-to-end testing on a stable branch without affecting customer-facing changelog output.

## Why scoped to one image for v1
The chart references 7+ service images (\`langsmith-backend\`, \`langsmith-go-backend\`, \`langsmith-frontend\`, \`langsmith-playground\`, \`langsmith-ace-backend\`, \`langsmith-clio\`, \`hosted-langserve-backend\`). Scanning all of them is straightforward to add as a matrix once this lands and we have signal that the rendered output looks right. Starting with backend keeps the failure surface small and the diff easy to validate.

## Failure modes handled
- Image tag missing in registry → Trivy errors, \`continue-on-error\` keeps pipeline alive, diff produces \`[]\`, bot receives \`{}\`, falls back to regex.
- \`Chart.yaml\` unchanged this push → \`prev == new\`, all four scan/diff steps are skipped, bot receives \`{}\` (today's behaviour).
- Bot URL/secret unchanged. No new secrets introduced.

## Test plan
- [ ] Run via \`workflow_dispatch\` with \`dry_run_cve_diff=true\` on a \`*-stable\` branch (or a throwaway branch); confirm Trivy scans run, diff is logged, bot receives \`{}\`.
- [ ] Run via \`workflow_dispatch\` with \`dry_run_cve_diff=false\` on a branch where the previous appVersion has known fixed CVEs vs the new one; confirm bot receives a non-empty \`fixed_cves_by_app_version\` and renders \`## Security\` with severity + package.
- [ ] Confirm a normal push that does not bump \`appVersion\` skips the scans and triggers the bot identically to today.
- [ ] Confirm a push with a non-existent image tag (e.g. \`appVersion\` typo) does not fail the workflow — Trivy errors, payload becomes \`{}\`, bot falls back to regex.