### PR TITLE
feat(langsmith): add preInstallManifests for pre-install hook ordering

### DIFF
--- a/charts/langsmith/templates/extra-manifests.yaml
+++ b/charts/langsmith/templates/extra-manifests.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.extraManifests }}
+---
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
+{{ tpl (toYaml .) $ }}
+{{- end }}
+{{- end }}

--- a/charts/langsmith/templates/extra-manifests.yaml
+++ b/charts/langsmith/templates/extra-manifests.yaml
@@ -1,8 +1,0 @@
-{{- range .Values.extraManifests }}
----
-{{- if typeIs "string" . }}
-{{ tpl . $ }}
-{{- else }}
-{{ tpl (toYaml .) $ }}
-{{- end }}
-{{- end }}

--- a/charts/langsmith/templates/pre-install-manifests.yaml
+++ b/charts/langsmith/templates/pre-install-manifests.yaml
@@ -1,18 +1,35 @@
 {{- /*
-Renders each entry in .Values.preInstallManifests as a Helm pre-install / pre-upgrade
-hook so the resource is applied before the rest of the chart's manifests. Useful for
-prerequisites the chart consumes during install/upgrade (for example, an
-ExternalSecret whose materialized Secret is referenced by the chart's pods).
+Renders each entry in .Values.preInstallManifests as a Helm pre-install /
+pre-upgrade hook so the resource is applied before the rest of the chart's
+manifests. Intended for prerequisites the chart consumes during install/upgrade
+-- for example, an ExternalSecret (External Secrets Operator) whose
+materialized Kubernetes Secret is referenced via `config.existingSecretName`
+or the per-datastore `*.external.existingSecretName` values.
 
-Each entry can be a YAML object or a multi-line YAML string. Both are rendered
-through `tpl` so template expressions work. Each entry must be a single resource
-(no `---` separators inside one string).
+Entry forms
+-----------
+Each entry may be a YAML object or a multi-line YAML string. Both are rendered
+through `tpl` so template expressions like `{{ .Release.Name }}` work. Each
+entry must be a single resource (no `---` separators inside one string).
 
-The following annotations are injected automatically; user-provided annotations
-on the same keys win, so they can be overridden per entry:
+Annotation handling
+-------------------
+The following annotations are injected automatically. User-provided values for
+the same keys take precedence, so the template is idempotent for manifests
+that already carry hook annotations -- partial overrides are merged
+(any default the user did not set is still applied).
+
   helm.sh/hook: pre-install,pre-upgrade
   helm.sh/hook-weight: "-5"
   helm.sh/hook-delete-policy: before-hook-creation
+
+Caveats
+-------
+Hook resources are not tracked as part of the Helm release and are recreated
+on every upgrade. For ExternalSecret entries, prefer
+`target.creationPolicy: Orphan` (or `target.deletionPolicy: Retain` on newer
+ESO versions) so the materialized Secret survives upgrades and pods consuming
+it don't restart.
 */ -}}
 {{- range .Values.preInstallManifests }}
 {{- $manifest := . }}

--- a/charts/langsmith/templates/pre-install-manifests.yaml
+++ b/charts/langsmith/templates/pre-install-manifests.yaml
@@ -1,0 +1,33 @@
+{{- /*
+Renders each entry in .Values.preInstallManifests as a Helm pre-install / pre-upgrade
+hook so the resource is applied before the rest of the chart's manifests. Useful for
+prerequisites the chart consumes during install/upgrade (for example, an
+ExternalSecret whose materialized Secret is referenced by the chart's pods).
+
+Each entry can be a YAML object or a multi-line YAML string. Both are rendered
+through `tpl` so template expressions work. Each entry must be a single resource
+(no `---` separators inside one string).
+
+The following annotations are injected automatically; user-provided annotations
+on the same keys win, so they can be overridden per entry:
+  helm.sh/hook: pre-install,pre-upgrade
+  helm.sh/hook-weight: "-5"
+  helm.sh/hook-delete-policy: before-hook-creation
+*/ -}}
+{{- range .Values.preInstallManifests }}
+{{- $manifest := . }}
+{{- if typeIs "string" $manifest }}
+{{-   $manifest = tpl . $ | fromYaml }}
+{{- else }}
+{{-   $manifest = tpl (toYaml .) $ | fromYaml }}
+{{- end }}
+{{- $_ := set $manifest "metadata" (default (dict) $manifest.metadata) }}
+{{- $hookAnnotations := dict
+      "helm.sh/hook" "pre-install,pre-upgrade"
+      "helm.sh/hook-weight" "-5"
+      "helm.sh/hook-delete-policy" "before-hook-creation" }}
+{{- $userAnnotations := default (dict) $manifest.metadata.annotations }}
+{{- $_ := set $manifest.metadata "annotations" (merge $userAnnotations $hookAnnotations) }}
+---
+{{ toYaml $manifest }}
+{{- end }}

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -26,6 +26,46 @@ namespace: ""
 #     stringData:
 #       token: changeme
 extraManifests: []
+# -- Pre-requisite manifests rendered as Helm pre-install / pre-upgrade hooks so they
+# -- are applied before the rest of the chart's resources. Each entry can be a YAML
+# -- string (rendered through `tpl`) or a YAML object. Each entry must be a single
+# -- resource (no `---` separators inside one string).
+# --
+# -- Use this for resources the chart consumes during install/upgrade, e.g. an
+# -- ExternalSecret (External Secrets Operator) whose materialized Kubernetes Secret
+# -- is referenced via `config.existingSecretName` or the per-datastore
+# -- `*.external.existingSecretName` values.
+# --
+# -- These annotations are injected automatically; user-provided values on the same
+# -- keys take precedence so behavior can be overridden per entry:
+# --   helm.sh/hook: pre-install,pre-upgrade
+# --   helm.sh/hook-weight: "-5"
+# --   helm.sh/hook-delete-policy: before-hook-creation
+# --
+# -- Caveat: hook resources are not tracked as part of the Helm release and are
+# -- recreated on every upgrade. For ExternalSecret entries, prefer
+# -- `target.creationPolicy: Orphan` (or `target.deletionPolicy: Retain` on newer
+# -- ESO versions) so the materialized Secret survives upgrades.
+# Example:
+# preInstallManifests:
+#   - apiVersion: external-secrets.io/v1beta1
+#     kind: ExternalSecret
+#     metadata:
+#       name: langsmith-app
+#     spec:
+#       refreshInterval: 1h
+#       secretStoreRef:
+#         name: vault-backend
+#         kind: ClusterSecretStore
+#       target:
+#         name: langsmith-app-secret
+#         creationPolicy: Orphan
+#       data:
+#         - secretKey: langsmith_license_key
+#           remoteRef:
+#             key: secret/langsmith/app
+#             property: langsmith_license_key
+preInstallManifests: []
 # -- Annotations that will be applied to all resources created by the chart
 commonAnnotations: {}
 # -- Annotations that will be applied to all pods created by the chart

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -6,46 +6,11 @@ nameOverride: ""
 fullnameOverride: ""
 # -- Namespace to install the chart into. If not set, will use the namespace of the current context.
 namespace: ""
-# -- Extra manifests to deploy alongside the chart. Each entry can be either a YAML string
-# -- (rendered through `tpl`, so you can use `{{ .Release.Name }}` etc.) or a YAML object.
-# -- Useful for shipping ConfigMaps, Secrets, NetworkPolicies, ServiceMonitors, or any other
-# -- resource the chart doesn't natively support.
-# Example:
-# extraManifests:
-#   - apiVersion: v1
-#     kind: ConfigMap
-#     metadata:
-#       name: my-extra-config
-#     data:
-#       key: value
-#   - |
-#     apiVersion: v1
-#     kind: Secret
-#     metadata:
-#       name: {{ .Release.Name }}-extra-secret
-#     stringData:
-#       token: changeme
-extraManifests: []
-# -- Pre-requisite manifests rendered as Helm pre-install / pre-upgrade hooks so they
-# -- are applied before the rest of the chart's resources. Each entry can be a YAML
-# -- string (rendered through `tpl`) or a YAML object. Each entry must be a single
-# -- resource (no `---` separators inside one string).
-# --
-# -- Use this for resources the chart consumes during install/upgrade, e.g. an
-# -- ExternalSecret (External Secrets Operator) whose materialized Kubernetes Secret
-# -- is referenced via `config.existingSecretName` or the per-datastore
-# -- `*.external.existingSecretName` values.
-# --
-# -- These annotations are injected automatically; user-provided values on the same
-# -- keys take precedence so behavior can be overridden per entry:
-# --   helm.sh/hook: pre-install,pre-upgrade
-# --   helm.sh/hook-weight: "-5"
-# --   helm.sh/hook-delete-policy: before-hook-creation
-# --
-# -- Caveat: hook resources are not tracked as part of the Helm release and are
-# -- recreated on every upgrade. For ExternalSecret entries, prefer
-# -- `target.creationPolicy: Orphan` (or `target.deletionPolicy: Retain` on newer
-# -- ESO versions) so the materialized Secret survives upgrades.
+# -- Prerequisite manifests rendered as Helm pre-install / pre-upgrade hooks so they
+# -- are applied before the rest of the chart's resources. Typical use case is an
+# -- ExternalSecret that produces a Secret consumed via `config.existingSecretName`.
+# -- See `templates/pre-install-manifests.yaml` for entry forms, injected
+# -- annotations, idempotency rules, and caveats.
 # Example:
 # preInstallManifests:
 #   - apiVersion: external-secrets.io/v1beta1

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -6,6 +6,26 @@ nameOverride: ""
 fullnameOverride: ""
 # -- Namespace to install the chart into. If not set, will use the namespace of the current context.
 namespace: ""
+# -- Extra manifests to deploy alongside the chart. Each entry can be either a YAML string
+# -- (rendered through `tpl`, so you can use `{{ .Release.Name }}` etc.) or a YAML object.
+# -- Useful for shipping ConfigMaps, Secrets, NetworkPolicies, ServiceMonitors, or any other
+# -- resource the chart doesn't natively support.
+# Example:
+# extraManifests:
+#   - apiVersion: v1
+#     kind: ConfigMap
+#     metadata:
+#       name: my-extra-config
+#     data:
+#       key: value
+#   - |
+#     apiVersion: v1
+#     kind: Secret
+#     metadata:
+#       name: {{ .Release.Name }}-extra-secret
+#     stringData:
+#       token: changeme
+extraManifests: []
 # -- Annotations that will be applied to all resources created by the chart
 commonAnnotations: {}
 # -- Annotations that will be applied to all pods created by the chart


### PR DESCRIPTION
## Summary

Adds a top-level `preInstallManifests` list to the `langsmith` chart. Each entry is rendered as a Helm `pre-install` / `pre-upgrade` hook so the resource is applied **before** the rest of the chart's manifests.

Intended for prerequisites the chart consumes during install/upgrade — most commonly an `ExternalSecret` (External Secrets Operator) whose materialized Kubernetes Secret is referenced via `config.existingSecretName` or the per-datastore `*.external.existingSecretName` values.

This is scoped intentionally narrow: arbitrary side-car manifests are not covered here — those are better handled by Helm composition (parent chart with `langsmith` as a dependency). The gap composition does **not** cover is ordering: subchart and parent manifests render into a single release manifest list and Helm sorts by `kind`, not by chart, so an ExternalSecret declared in a parent chart is not guaranteed to be applied before the `langsmith` Deployments that consume it.

## Usage

```yaml
preInstallManifests:
  - apiVersion: external-secrets.io/v1beta1
    kind: ExternalSecret
    metadata:
      name: langsmith-app
    spec:
      refreshInterval: 1h
      secretStoreRef:
        name: vault-backend
        kind: ClusterSecretStore
      target:
        name: langsmith-app-secret      # matches config.existingSecretName
        creationPolicy: Orphan          # so the materialized Secret survives upgrades
      data:
        - secretKey: langsmith_license_key
          remoteRef:
            key: secret/langsmith/app
            property: langsmith_license_key
```

The chart then consumes the materialized Secret via the existing knobs:

```yaml
config:
  disableSecretCreation: true
  existingSecretName: langsmith-app-secret
```

Entries can also be multi-line YAML strings; both forms run through `tpl`, so `{{ .Release.Name }}` etc. works.

## Annotation handling (idempotent)

The following annotations are injected automatically:

```
helm.sh/hook: pre-install,pre-upgrade
helm.sh/hook-weight: "-5"
helm.sh/hook-delete-policy: before-hook-creation
```

User-provided values on the same keys take precedence, so manifests that already carry hook annotations are handled correctly — partial overrides are merged (any default the user did not set is still applied). Example: a user setting `helm.sh/hook-weight: "-50"` keeps that weight while still receiving the default `hook` and `hook-delete-policy` values.

## Implementation

- `templates/pre-install-manifests.yaml` — iterates `.Values.preInstallManifests`, renders each entry through `tpl`, then `merge`s user annotations over the default hook annotations (user wins). Header comment documents entry forms, annotation semantics, idempotency, and the ExternalSecret `creationPolicy: Orphan` caveat in detail.
- `values.yaml` — short comment + simple `ExternalSecret` example; defers to the template file for full details.

Default is `[]`, so behavior is unchanged for existing users.

## Caveats

Hook resources are not tracked as part of the Helm release and are recreated on every upgrade. For `ExternalSecret` entries, prefer `target.creationPolicy: Orphan` (or `target.deletionPolicy: Retain` on newer ESO versions) so the materialized Secret survives upgrades and pods consuming it don't restart.

Each entry must be a single resource (no `---` separators inside one string).

---

Scoped down from the original PR per review feedback in #714. `extraManifests` was dropped — composition via subchart is the recommended pattern for arbitrary side-car resources.