### PR TITLE
feat: add extraPorts support to queue deployment

### DIFF
--- a/charts/langgraph-cloud/templates/queue/deployment.yaml
+++ b/charts/langgraph-cloud/templates/queue/deployment.yaml
@@ -109,6 +109,9 @@ spec:
             - name: queue
               containerPort: {{ .Values.queue.containerPort }}
               protocol: TCP
+            {{- with .Values.queue.deployment.extraPorts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           startupProbe:
             {{- toYaml .Values.queue.deployment.startupProbe | nindent 12 }}
           readinessProbe:

--- a/charts/langgraph-cloud/values.yaml
+++ b/charts/langgraph-cloud/values.yaml
@@ -211,6 +211,7 @@ queue:
     extraEnv: []
     envFrom: []  # List of ConfigMap or Secret references to load environment variables from
     sidecars: []
+    extraPorts: []
     nodeSelector: {}
     tolerations: []
     affinity: {}


### PR DESCRIPTION
## Summary

- Adds `queue.deployment.extraPorts: []` to `values.yaml`
- Adds a `{{- with .Values.queue.deployment.extraPorts }}` block to the queue deployment template, appending any extra ports after the primary health/metrics port

## Context

The queue deployment currently exposes a single named container port (the internal health+metrics server on `containerPort`). Customers who run custom metrics endpoints inside their graph code need to expose an additional named port so that Prometheus Operator's PodMonitor can scrape it — `targetPort` is deprecated in PodMonitors in favor of named ports.

## Usage

```yaml
queue:
  deployment:
    extraPorts:
      - name: custom-metrics
        containerPort: 9090
        protocol: TCP
```

## Test plan

- [ ] `helm template` renders the extra port when `extraPorts` is set
- [ ] `helm template` renders cleanly (no extra ports block) when `extraPorts` is empty