### PR TITLE
release(langgraph-cloud): 0.3.1

### DIFF
--- a/charts/langgraph-cloud/Chart.yaml
+++ b/charts/langgraph-cloud/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the LangGraph Cloud application and all services it depends on.
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "0.2.3"

--- a/charts/langgraph-cloud/README.md
+++ b/charts/langgraph-cloud/README.md
@@ -1,6 +1,6 @@
 # langgraph-cloud
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.3](https://img.shields.io/badge/AppVersion-0.2.3-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.3](https://img.shields.io/badge/AppVersion-0.2.3-informational?style=flat-square)
 
 Helm chart to deploy the LangGraph Cloud application and all services it depends on.
 
@@ -391,6 +391,7 @@ If you are upgrading from a chart revision that used the old flat MongoDB values
 | queue.deployment.annotations | object | `{}` |  |
 | queue.deployment.envFrom | list | `[]` |  |
 | queue.deployment.extraEnv | list | `[]` |  |
+| queue.deployment.extraPorts | list | `[]` |  |
 | queue.deployment.labels | object | `{}` |  |
 | queue.deployment.lifecycle | object | `{}` |  |
 | queue.deployment.livenessProbe.failureThreshold | int | `6` |  |


### PR DESCRIPTION
## Summary
- Bump `langgraph-cloud` chart version `0.3.0` → `0.3.1` (patch).
- Regenerate `README.md` via `helm-docs` — picks up the new `queue.deployment.extraPorts` row added in #717.
- `appVersion` unchanged at `0.2.3` (no underlying app change since last release).

## Test plan
- [x] `helm lint charts/langgraph-cloud`
- [x] `helm template charts/langgraph-cloud` renders without error