### PR TITLE
Enable context hub feature flag in LangSmith chart

### DIFF
--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -55,6 +55,7 @@ data:
   {{- end }}
   {{- end }}
   FF_RUN_STATS_GROUP_BY_ENABLED_ALL: "true"
+  FF_CONTEXT_HUB_ENABLED_ALL: "true"
   SEPARATE_QUEUES_WITH_SINGLE_WORKER: '["host"]'
   {{- if .Values.config.observability.tracing.enabled }}
   OTEL_TRACING_ENABLED: "{{ .Values.config.observability.tracing.enabled }}"


### PR DESCRIPTION
## Summary
- set FF_CONTEXT_HUB_ENABLED_ALL to "true" in the LangSmith config map template

## Testing
- not run (config-only change)