### PR TITLE
fix(langsmith): allow migration hook annotation overrides

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.8.30
+version: 0.8.31
 appVersion: "0.8.92"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.8.28](https://img.shields.io/badge/Version-0.8.28-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.92](https://img.shields.io/badge/AppVersion-0.8.92-informational?style=flat-square)
+![Version: 0.8.31](https://img.shields.io/badge/Version-0.8.31-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.92](https://img.shields.io/badge/AppVersion-0.8.92-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 

--- a/charts/langsmith/templates/backend/clickhouse-migrations.yaml
+++ b/charts/langsmith/templates/backend/clickhouse-migrations.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.backend.clickhouseMigrations.enabled }}
 {{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) .Values.backend.clickhouseMigrations.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
+{{- $annotations := .Values.backend.clickhouseMigrations.annotations | default dict -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -13,9 +14,11 @@ metadata:
   annotations:
     "helm.sh/hook": post-install, pre-upgrade
     "helm.sh/hook-weight": "-1"
+    {{- if not (hasKey $annotations "argocd.argoproj.io/hook") }}
     "argocd.argoproj.io/hook": "PreSync"
+    {{- end }}
     {{- include "langsmith.annotations" . | nindent 4 }}
-    {{- with.Values.backend.clickhouseMigrations.annotations }}
+    {{- with $annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:

--- a/charts/langsmith/templates/backend/postgres-migrations.yaml
+++ b/charts/langsmith/templates/backend/postgres-migrations.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.backend.migrations.enabled }}
 {{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) .Values.backend.migrations.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
+{{- $annotations := .Values.backend.migrations.annotations | default dict -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -13,9 +14,11 @@ metadata:
   annotations:
     "helm.sh/hook": post-install, pre-upgrade
     "helm.sh/hook-weight": "-1"
+    {{- if not (hasKey $annotations "argocd.argoproj.io/hook") }}
     "argocd.argoproj.io/hook": "PreSync"
+    {{- end }}
     {{- include "langsmith.annotations" . | nindent 4 }}
-    {{- with.Values.backend.migrations.annotations }}
+    {{- with $annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:

--- a/charts/langsmith/tests/migration_hook_annotations_test.yaml
+++ b/charts/langsmith/tests/migration_hook_annotations_test.yaml
@@ -1,0 +1,34 @@
+suite: test migration hook annotations
+templates:
+  - backend/clickhouse-migrations.yaml
+  - backend/postgres-migrations.yaml
+tests:
+  - it: should default migration hooks to PreSync
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: PreSync
+        template: backend/postgres-migrations.yaml
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: PreSync
+        template: backend/clickhouse-migrations.yaml
+
+  - it: should allow overriding migration hook annotations
+    set:
+      backend:
+        migrations:
+          annotations:
+            argocd.argoproj.io/hook: PostSync
+        clickhouseMigrations:
+          annotations:
+            argocd.argoproj.io/hook: PostSync
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: PostSync
+        template: backend/postgres-migrations.yaml
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: PostSync
+        template: backend/clickhouse-migrations.yaml


### PR DESCRIPTION
Allows v0.8 chart consumers to override the Argo CD hook annotation for Postgres and ClickHouse migration Jobs through the existing migration annotations maps. The default remains `PreSync`, preserving current behavior unless an environment opts into a different hook phase.

Bumps the LangSmith chart to 0.8.31 so the stable chart release can publish.

## Release Note
none

## Test Plan
- [x] `helm lint charts/langsmith`
- [x] `helm unittest charts/langsmith`
- [x] `helm template` default migration hooks render `PreSync`
- [x] `helm template` with migration hook annotation overrides renders `PostSync` without a duplicate top-level hook annotation