### PR TITLE
chore(langsmith): bump chart to 0.15.0-rc.15

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.15.0-rc.14
+version: 0.15.0-rc.15
 appVersion: "0.15.7rc1"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.15.0-rc.14](https://img.shields.io/badge/Version-0.15.0--rc.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.7rc1](https://img.shields.io/badge/AppVersion-0.15.7rc1-informational?style=flat-square)
+![Version: 0.15.0-rc.15](https://img.shields.io/badge/Version-0.15.0--rc.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.7rc1](https://img.shields.io/badge/AppVersion-0.15.7rc1-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 


### PR DESCRIPTION
## Summary
- Bump langsmith Helm chart version to `0.15.0-rc.15` to pick up changes from #722.
- `appVersion` retained at `0.15.7rc1`.

## Test plan
- [x] CI passes