### PR TITLE
feat: add nginx routes for /api/v1/fleet/ to platformBackend

### DIFF
--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -173,6 +173,15 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
 
+        location /{{ .Values.config.basePath }}/api/v1/fleet/ {
+            rewrite /{{ .Values.config.basePath }}/api/v1/fleet/(.*) /v1/fleet/$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
         location = /{{ .Values.config.basePath }}/api/v1/runs/multipart {
             rewrite /{{ .Values.config.basePath }}/api/v1/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
@@ -662,6 +671,15 @@ data:
 
         location /api/v1/agent-builder/ {
             rewrite /api/v1/agent-builder/(.*) /v1/agent-builder/$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        location /api/v1/fleet/ {
+            rewrite /api/v1/fleet/(.*) /v1/fleet/$1  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
             proxy_buffering off;


### PR DESCRIPTION
## Summary
- Adds `/api/v1/fleet/` nginx `location` blocks (basePath and non-basePath variants) to the frontend ConfigMap, rewriting to `/v1/fleet/...` and proxying to `platformBackend`.
- Mirrors the existing `/api/v1/agent-builder/` blocks added in #671 — without this, browser calls to `/api/v1/fleet/*` fall through to a 404 from the frontend nginx.

## Test plan
- [x] `helm template` renders cleanly for both `config.basePath` set and unset.