### PR TITLE
chore(langsmith): bump chart to 0.15.0-rc.16

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.15.0-rc.15
+version: 0.15.0-rc.16
 appVersion: "0.15.7rc1"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.15.0-rc.15](https://img.shields.io/badge/Version-0.15.0--rc.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.7rc1](https://img.shields.io/badge/AppVersion-0.15.7rc1-informational?style=flat-square)
+![Version: 0.15.0-rc.16](https://img.shields.io/badge/Version-0.15.0--rc.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.7rc1](https://img.shields.io/badge/AppVersion-0.15.7rc1-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 


### PR DESCRIPTION
## Summary
- Bumps `charts/langsmith/Chart.yaml` `version` from `0.15.0-rc.15` → `0.15.0-rc.16` so the `/api/v1/fleet/` nginx routes from #729 actually get released. That PR edited `templates/frontend/config-map.yaml` but did not bump `Chart.yaml`, so `0.15.0-rc.15` does not contain the new routes.
- `appVersion` is unchanged (`0.15.7rc1`) — no image/app change.

## Test plan
- [x] CI lints the chart
