### PR TITLE
fix(fleet): inject LANGGRAPH_DEPLOYMENT_URL into platform-backend whe…

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.15.0-rc.16
+version: 0.15.0-rc.17
 appVersion: "0.15.7rc1"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1681,9 +1681,9 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | presidioAnalyzer.deployment.readinessProbe.timeoutSeconds | int | `3` |  |
 | presidioAnalyzer.deployment.replicas | int | `1` |  |
 | presidioAnalyzer.deployment.resources.limits.cpu | int | `1` |  |
-| presidioAnalyzer.deployment.resources.limits.memory | string | `"2Gi"` |  |
+| presidioAnalyzer.deployment.resources.limits.memory | string | `"4Gi"` |  |
 | presidioAnalyzer.deployment.resources.requests.cpu | string | `"250m"` |  |
-| presidioAnalyzer.deployment.resources.requests.memory | string | `"1Gi"` |  |
+| presidioAnalyzer.deployment.resources.requests.memory | string | `"2Gi"` |  |
 | presidioAnalyzer.deployment.securityContext | object | `{}` |  |
 | presidioAnalyzer.deployment.sidecars | list | `[]` |  |
 | presidioAnalyzer.deployment.startupProbe.failureThreshold | int | `6` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.15.0-rc.16](https://img.shields.io/badge/Version-0.15.0--rc.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.7rc1](https://img.shields.io/badge/AppVersion-0.15.7rc1-informational?style=flat-square)
+![Version: 0.15.0-rc.17](https://img.shields.io/badge/Version-0.15.0--rc.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.7rc1](https://img.shields.io/badge/AppVersion-0.15.7rc1-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -201,6 +201,13 @@ Template containing common environment variables that are used by several servic
 - name: HOST_BACKEND_ENDPOINT_PUBLIC
   value: {{ .Values.config.hostname }}/api-host
 {{- end }}
+{{- if .Values.fleet.enabled }}
+{{- $ns := .Values.namespace | default .Release.Namespace -}}
+{{- $cd := .Values.clusterDomain -}}
+{{- $fleetApi := printf "http://%s.%s.svc.%s:%v" (include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "fleet")) $ns $cd .Values.fleet.apiServer.service.httpPort }}
+- name: LANGGRAPH_DEPLOYMENT_URL
+  value: {{ $fleetApi | quote }}
+{{- end }}
 - name: REDIS_CLUSTER_ENABLED
   value: {{ .Values.redis.external.cluster.enabled | quote }}
 {{- if .Values.redis.external.cluster.enabled }}

--- a/charts/langsmith/templates/platform-backend/deployment.yaml
+++ b/charts/langsmith/templates/platform-backend/deployment.yaml
@@ -5,6 +5,13 @@
 - name: DOCS_PREFIX
   value: /{{ . }}/api
 {{- end }}
+{{- if .Values.fleet.enabled }}
+{{- $ns := .Values.namespace | default .Release.Namespace -}}
+{{- $cd := .Values.clusterDomain -}}
+{{- $fleetApi := printf "http://%s.%s.svc.%s:%v" (include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "fleet")) $ns $cd .Values.fleet.apiServer.service.httpPort }}
+- name: LANGGRAPH_DEPLOYMENT_URL
+  value: {{ $fleetApi | quote }}
+{{- end }}
 {{- end -}}
 {{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "platformBackendEnvVars" . | fromYamlArray) .Values.platformBackend.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}

--- a/charts/langsmith/templates/platform-backend/deployment.yaml
+++ b/charts/langsmith/templates/platform-backend/deployment.yaml
@@ -5,13 +5,6 @@
 - name: DOCS_PREFIX
   value: /{{ . }}/api
 {{- end }}
-{{- if .Values.fleet.enabled }}
-{{- $ns := .Values.namespace | default .Release.Namespace -}}
-{{- $cd := .Values.clusterDomain -}}
-{{- $fleetApi := printf "http://%s.%s.svc.%s:%v" (include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "fleet")) $ns $cd .Values.fleet.apiServer.service.httpPort }}
-- name: LANGGRAPH_DEPLOYMENT_URL
-  value: {{ $fleetApi | quote }}
-{{- end }}
 {{- end -}}
 {{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "platformBackendEnvVars" . | fromYamlArray) .Values.platformBackend.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}

--- a/charts/mission-control/README.md
+++ b/charts/mission-control/README.md
@@ -118,11 +118,11 @@ helm install mission-control langchain/mission-control \
 | config.features.chat | bool | `true` | Chat assistant: floating widget that proxies to chat.langchain.com. Egress: outbound HTTPS to chat.langchain.com and *.us.langgraph.app. |
 | config.features.configSave | bool | `true` | Persists working configuration to the draft Kubernetes Secret. Grants write access to the mission-control-draft secret. |
 | config.features.dbTools | bool | `true` | Database detection, preflight checks, and support query execution. Adds no extra RBAC verbs; gates the /db/* endpoints at the application layer. |
-| config.features.deploy | bool | `true` | In-UI `helm upgrade --install` for LangSmith and sibling charts. Grants broad write RBAC on secrets/configmaps cluster-wide (required for Helm). Set to `false` in compliance-sensitive installs to revert to read-mostly mode. |
-| config.features.valuesOverride | bool | `false` | Server-side values override layer applied on top of every deploy. When enabled, operators can lock specific Helm values that users cannot override from the UI. |
+| config.features.deploy | bool | `true` |  |
 | config.features.diagnostics | bool | `true` | Diagnostic bundle download (pod logs + resource manifests packaged as a zip). |
 | config.features.discover | bool | `true` | Namespace-scoped infrastructure discovery via the /api/discover endpoint. Adds no extra RBAC verbs; gates the endpoint at the application layer. |
 | config.features.fixIssue | bool | `true` | Fix Issue button: deletes pods stuck in CreateContainerConfigError. Grants pods:delete. |
+| config.features.valuesOverride | bool | `true` | Operator-uploaded values.yaml overrides per product (airgapped support). Adds the settings pill in the topbar and grants update/delete on the `mission-control-values-overrides` Secret. Set to false to remove the pill and 403 the /api/values-overrides/* endpoints. |
 | diagnostics.persistence.accessMode | string | `"ReadWriteOnce"` |  |
 | diagnostics.persistence.enabled | bool | `false` |  |
 | diagnostics.persistence.size | string | `"1Gi"` |  |
@@ -140,10 +140,10 @@ helm install mission-control langchain/mission-control \
 | fullnameOverride | string | `""` | String to fully override the chart's full name |
 | images.backendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.backendImage.repository | string | `"langchain/mission-control-backend"` |  |
-| images.backendImage.tag | string | `"latest"` | Backend image tag. Defaults to `latest`; pin to a specific release like `1.0.0` for reproducible deploys. Versioned tags are published alongside `latest` on every release. |
+| images.backendImage.tag | string | `"latest"` | Backend image tag. Defaults to `latest`; pin to a specific release like `1.2.0` for reproducible deploys. Versioned tags are published alongside `latest` on every release. |
 | images.frontendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.frontendImage.repository | string | `"langchain/mission-control-frontend"` |  |
-| images.frontendImage.tag | string | `"latest"` | Frontend image tag. Defaults to `latest`; pin to a specific release like `1.0.0` for reproducible deploys. Versioned tags are published alongside `latest` on every release. |
+| images.frontendImage.tag | string | `"latest"` | Frontend image tag. Defaults to `latest`; pin to a specific release like `1.2.0` for reproducible deploys. Versioned tags are published alongside `latest` on every release. |
 | images.imagePullSecrets | list | `[{"name":"regcred"}]` | Image pull secrets used by all components. |
 | images.registry | string | `""` | If supplied, all child <image>.repository values will be prepended with this registry name + `/` |
 | ingress.enabled | bool | `false` |  |


### PR DESCRIPTION
…n fleet enabled

When fleet.enabled=true, smith-go (platform-backend) needs LANGGRAPH_DEPLOYMENT_URL to locate the standalone fleet LangGraph API server for agent CRUD operations. The trigger-server already receives this URL via agentBuilderTriggerServerEnvVars but platform-backend was missing it, causing POST /v1/fleet/agents to fail with "agent runtime is not configured on this deployment".