### PR TITLE
Cherry-pick #729 + #733 into v15-release

### DIFF
--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -201,6 +201,13 @@ Template containing common environment variables that are used by several servic
 - name: HOST_BACKEND_ENDPOINT_PUBLIC
   value: {{ .Values.config.hostname }}/api-host
 {{- end }}
+{{- if .Values.fleet.enabled }}
+{{- $ns := .Values.namespace | default .Release.Namespace -}}
+{{- $cd := .Values.clusterDomain -}}
+{{- $fleetApi := printf "http://%s.%s.svc.%s:%v" (include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "fleet")) $ns $cd .Values.fleet.apiServer.service.httpPort }}
+- name: LANGGRAPH_DEPLOYMENT_URL
+  value: {{ $fleetApi | quote }}
+{{- end }}
 - name: REDIS_CLUSTER_ENABLED
   value: {{ .Values.redis.external.cluster.enabled | quote }}
 {{- if .Values.redis.external.cluster.enabled }}

--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -159,6 +159,15 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
 
+        location /{{ .Values.config.basePath }}/api/v1/fleet/ {
+            rewrite /{{ .Values.config.basePath }}/api/v1/fleet/(.*) /v1/fleet/$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
         location = /{{ .Values.config.basePath }}/api/v1/runs/multipart {
             rewrite /{{ .Values.config.basePath }}/api/v1/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
@@ -620,6 +629,15 @@ data:
 
         location /api/v1/agent-builder/ {
             rewrite /api/v1/agent-builder/(.*) /v1/agent-builder/$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        location /api/v1/fleet/ {
+            rewrite /api/v1/fleet/(.*) /v1/fleet/$1  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
             proxy_buffering off;


### PR DESCRIPTION
## Summary
Cherry-picks the following PRs from `main` into `v15-release`:

- **#729** — `feat: add nginx routes for /api/v1/fleet/ to platformBackend` (clean apply)
- **#733** — `fix(fleet): inject LANGGRAPH_DEPLOYMENT_URL into platform-backend when …` (took only the `_helpers.tpl` change; dropped the incidental Chart.yaml version bump and helm-docs README regeneration that conflicted with this branch's release line)

**#730** (`chore(langsmith): bump chart to 0.15.0-rc.16`) was intentionally skipped — `v15-release` is on its own version line (`0.15.0-rc.15` / appVersion `0.15.8rc1`) and #730 would have regressed `appVersion` from `0.15.8rc1` to `0.15.7rc1`.

Net diff vs `v15-release`:
- `charts/langsmith/templates/_helpers.tpl` (+7)
- `charts/langsmith/templates/frontend/config-map.yaml` (+18)

## Test plan
- [ ] Verify nginx routes for `/api/v1/fleet/` resolve in a v15 deploy
- [ ] Verify `LANGGRAPH_DEPLOYMENT_URL` is injected into platform-backend when fleet is enabled
- [ ] Confirm chart version (`0.15.0-rc.15`) and appVersion (`0.15.8rc1`) are unchanged on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)