### PR TITLE
docs(langgraph-dataplane): mark chart as legacy Hybrid deployment

### DIFF
--- a/charts/langgraph-dataplane/README.md
+++ b/charts/langgraph-dataplane/README.md
@@ -7,7 +7,7 @@ Helm chart to deploy a langgraph dataplane on kubernetes.
 > [!WARNING]
 > **Legacy Hybrid Deployment — No Longer Supported for New Customers**
 >
-> This chart is the legacy version of the Hybrid deployment option. New customers are not supported going forward; existing customers will continue to be supported — see the [legacy Hybrid documentation](https://docs.langchain.com/langsmith/hybrid-legacy) for reference. New Hybrid deployments should use the [`langgraph-cloud`](../langgraph-cloud) chart instead; see the [Hybrid deployment documentation](https://docs.langchain.com/langsmith/hybrid) for more details.
+> This chart is the legacy version of the Hybrid deployment option. New customers are not supported going forward; existing customers will continue to be supported. New Hybrid deployments should use the [`langgraph-cloud`](../langgraph-cloud) chart instead — see the [Hybrid deployment documentation](https://docs.langchain.com/langsmith/hybrid) for more details.
 
 ## Deploying a LangGraph Dataplane
 

--- a/charts/langgraph-dataplane/README.md
+++ b/charts/langgraph-dataplane/README.md
@@ -4,6 +4,11 @@
 
 Helm chart to deploy a langgraph dataplane on kubernetes.
 
+> [!WARNING]
+> **Legacy Hybrid Deployment — No Longer Supported for New Customers**
+>
+> This chart is the legacy version of the Hybrid deployment option. New customers are not supported going forward; existing customers will continue to be supported — see the [legacy Hybrid documentation](https://docs.langchain.com/langsmith/hybrid-legacy) for reference. New Hybrid deployments should use the [`langgraph-cloud`](../langgraph-cloud) chart instead; see the [Hybrid deployment documentation](https://docs.langchain.com/langsmith/hybrid) for more details.
+
 ## Deploying a LangGraph Dataplane
 
 This chart deploys a LangGraph Dataplane, which is a component of the LangGraph Platform. The Dataplane is responsible for executing and managing LangGraph applications.

--- a/charts/langgraph-dataplane/README.md.gotmpl
+++ b/charts/langgraph-dataplane/README.md.gotmpl
@@ -7,7 +7,7 @@
 > [!WARNING]
 > **Legacy Hybrid Deployment — No Longer Supported for New Customers**
 >
-> This chart is the legacy version of the Hybrid deployment option. New customers are not supported going forward; existing customers will continue to be supported — see the [legacy Hybrid documentation](https://docs.langchain.com/langsmith/hybrid-legacy) for reference. New Hybrid deployments should use the [`langgraph-cloud`](../langgraph-cloud) chart instead; see the [Hybrid deployment documentation](https://docs.langchain.com/langsmith/hybrid) for more details.
+> This chart is the legacy version of the Hybrid deployment option. New customers are not supported going forward; existing customers will continue to be supported. New Hybrid deployments should use the [`langgraph-cloud`](../langgraph-cloud) chart instead — see the [Hybrid deployment documentation](https://docs.langchain.com/langsmith/hybrid) for more details.
 
 ## Deploying a LangGraph Dataplane
 

--- a/charts/langgraph-dataplane/README.md.gotmpl
+++ b/charts/langgraph-dataplane/README.md.gotmpl
@@ -4,6 +4,11 @@
 
 {{ template "chart.description" . }}
 
+> [!WARNING]
+> **Legacy Hybrid Deployment — No Longer Supported for New Customers**
+>
+> This chart is the legacy version of the Hybrid deployment option. New customers are not supported going forward; existing customers will continue to be supported — see the [legacy Hybrid documentation](https://docs.langchain.com/langsmith/hybrid-legacy) for reference. New Hybrid deployments should use the [`langgraph-cloud`](../langgraph-cloud) chart instead; see the [Hybrid deployment documentation](https://docs.langchain.com/langsmith/hybrid) for more details.
+
 ## Deploying a LangGraph Dataplane
 
 This chart deploys a LangGraph Dataplane, which is a component of the LangGraph Platform. The Dataplane is responsible for executing and managing LangGraph applications.


### PR DESCRIPTION
## Summary
- Adds a warning callout to the `langgraph-dataplane` chart README noting this is the legacy Hybrid deployment
- Points existing customers to the [legacy Hybrid docs](https://docs.langchain.com/langsmith/hybrid-legacy)
- Points new Hybrid deployments to the `langgraph-cloud` chart and the [current Hybrid docs](https://docs.langchain.com/langsmith/hybrid)

## Test plan
- [x] Render README on GitHub and confirm the warning callout displays correctly