### PR TITLE
chart(langsmith): release 0.15.1 — drop insights/polly bootstrap, enable by default

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.15.0
+version: 0.15.1
 appVersion: "0.15.8"

--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
 version: 0.15.1
-appVersion: "0.15.8"
+appVersion: "0.15.9"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -912,15 +912,6 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | config.infoEndpointAuthRequired | bool | `false` | Require authentication on the GET /info endpoint. When enabled, unauthenticated requests to /info will receive a 401 and must supply a valid API key. The LangSmith SDK handles this automatically by retrying with credentials. Useful for deployments that must not expose instance configuration (version, feature flags, batch ingest config) to unauthenticated callers. |
 | config.initialOrgAdminEmail | string | `""` |  |
 | config.initialOrgName | string | `"Default"` | Initial org name to be provisioned. |
-| config.insights.agent.extraEnv | object | `{}` |  |
-| config.insights.agent.resources.cpu | int | `2` |  |
-| config.insights.agent.resources.cpuLimit | int | `4` |  |
-| config.insights.agent.resources.maxScale | int | `5` |  |
-| config.insights.agent.resources.memoryLimitMb | int | `8192` |  |
-| config.insights.agent.resources.memoryMb | int | `4096` |  |
-| config.insights.agent.resources.minScale | int | `1` |  |
-| config.insights.enabled | bool | `false` |  |
-| config.insights.encryptionKey | string | `""` |  |
 | config.langsmithLicenseKey | string | `""` |  |
 | config.logLevel | string | `"info"` |  |
 | config.oauth.enabled | bool | `false` |  |
@@ -936,15 +927,6 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | config.observability.tracing.useTls | bool | `true` |  |
 | config.orgAdminsInstallationUsageExportEnabled | bool | `false` | When true, any org admin can use the usage backfill export. |
 | config.personalOrgsDisabled | bool | `true` | Disable personal orgs. |
-| config.polly.agent.extraEnv | object | `{}` |  |
-| config.polly.agent.resources.cpu | int | `2` |  |
-| config.polly.agent.resources.cpuLimit | int | `4` |  |
-| config.polly.agent.resources.maxScale | int | `5` |  |
-| config.polly.agent.resources.memoryLimitMb | int | `8192` |  |
-| config.polly.agent.resources.memoryMb | int | `4096` |  |
-| config.polly.agent.resources.minScale | int | `1` |  |
-| config.polly.enabled | bool | `false` |  |
-| config.polly.encryptionKey | string | `""` |  |
 | config.security | object | `{"cors":{"allowedOrigins":"*","allowedOriginsRegex":"","alwaysAllowPathsRegex":""}}` | Security configuration for CORS, headers, and other security-related settings. These settings control cross-origin access and help protect against common web vulnerabilities. |
 | config.security.cors | object | `{"allowedOrigins":"*","allowedOriginsRegex":"","alwaysAllowPathsRegex":""}` | CORS (Cross-Origin Resource Sharing) configuration. Controls which origins can make requests to the LangSmith API. By default, CORS is permissive. For production deployments, you should restrict this. |
 | config.security.cors.allowedOrigins | string | `"*"` | Comma-separated list of allowed origins. Use "*" to allow all origins (not recommended for production). Example: "https://app.example.com,https://admin.example.com" If allowedOriginsRegex is set, this value is ignored. |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.8](https://img.shields.io/badge/AppVersion-0.15.8-informational?style=flat-square)
+![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.8](https://img.shields.io/badge/AppVersion-0.15.8-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -522,7 +522,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | insights.apiServer.serviceAccount.create | bool | `true` |  |
 | insights.apiServer.serviceAccount.labels | object | `{}` |  |
 | insights.apiServer.serviceAccount.name | string | `""` |  |
-| insights.enabled | bool | `false` |  |
+| insights.enabled | bool | `true` |  |
 | insights.encryptionKey | string | `""` |  |
 | insights.namePrefix | string | `"standalone-insights"` |  |
 | insights.postgres.containerPort | int | `5432` |  |
@@ -718,7 +718,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | polly.apiServer.serviceAccount.labels | object | `{}` |  |
 | polly.apiServer.serviceAccount.name | string | `""` |  |
 | polly.enableTracing | bool | `true` |  |
-| polly.enabled | bool | `false` |  |
+| polly.enabled | bool | `true` |  |
 | polly.encryptionKey | string | `""` |  |
 | polly.namePrefix | string | `"standalone-polly"` |  |
 | polly.postgres.containerPort | int | `5432` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.8](https://img.shields.io/badge/AppVersion-0.15.8-informational?style=flat-square)
+![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.9](https://img.shields.io/badge/AppVersion-0.15.9-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -338,44 +338,44 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | gateway.sectionName | string | `""` |  |
 | images.aceBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.aceBackendImage.repository | string | `"docker.io/langchain/langsmith-ace-backend"` |  |
-| images.aceBackendImage.tag | string | `"0.15.8"` |  |
+| images.aceBackendImage.tag | string | `"0.15.9"` |  |
 | images.agentBuilderImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.agentBuilderImage.repository | string | `"docker.io/langchain/agent-builder-deep-agent"` |  |
-| images.agentBuilderImage.tag | string | `"0.15.8"` |  |
+| images.agentBuilderImage.tag | string | `"0.15.9"` |  |
 | images.fleetToolServerImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.fleetToolServerImage.repository | string | `"docker.io/langchain/agent-builder-tool-server"` |  |
-| images.fleetToolServerImage.tag | string | `"0.15.8"` |  |
+| images.fleetToolServerImage.tag | string | `"0.15.9"` |  |
 | images.fleetTriggerServerImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.fleetTriggerServerImage.repository | string | `"docker.io/langchain/agent-builder-trigger-server"` |  |
-| images.fleetTriggerServerImage.tag | string | `"0.15.8"` |  |
+| images.fleetTriggerServerImage.tag | string | `"0.15.9"` |  |
 | images.backendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.backendImage.repository | string | `"docker.io/langchain/langsmith-backend"` |  |
-| images.backendImage.tag | string | `"0.15.8"` |  |
+| images.backendImage.tag | string | `"0.15.9"` |  |
 | images.clickhouseImage.pullPolicy | string | `"Always"` |  |
 | images.clickhouseImage.repository | string | `"docker.io/clickhouse/clickhouse-server"` |  |
 | images.clickhouseImage.tag | string | `"25.12"` |  |
 | images.frontendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.frontendImage.repository | string | `"docker.io/langchain/langsmith-frontend"` |  |
-| images.frontendImage.tag | string | `"0.15.8"` |  |
+| images.frontendImage.tag | string | `"0.15.9"` |  |
 | images.hostBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.hostBackendImage.repository | string | `"docker.io/langchain/hosted-langserve-backend"` |  |
-| images.hostBackendImage.tag | string | `"0.15.8"` |  |
+| images.hostBackendImage.tag | string | `"0.15.9"` |  |
 | images.imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Specified as name: value. |
 | images.insightsAgentImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.insightsAgentImage.repository | string | `"docker.io/langchain/langsmith-clio"` |  |
-| images.insightsAgentImage.tag | string | `"0.15.8"` |  |
+| images.insightsAgentImage.tag | string | `"0.15.9"` |  |
 | images.operatorImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.operatorImage.repository | string | `"docker.io/langchain/langgraph-operator"` |  |
 | images.operatorImage.tag | string | `"0.1.47"` |  |
 | images.platformBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.platformBackendImage.repository | string | `"docker.io/langchain/langsmith-go-backend"` |  |
-| images.platformBackendImage.tag | string | `"0.15.8"` |  |
+| images.platformBackendImage.tag | string | `"0.15.9"` |  |
 | images.playgroundImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.playgroundImage.repository | string | `"docker.io/langchain/langsmith-playground"` |  |
-| images.playgroundImage.tag | string | `"0.15.8"` |  |
+| images.playgroundImage.tag | string | `"0.15.9"` |  |
 | images.pollyAgentImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.pollyAgentImage.repository | string | `"docker.io/langchain/langsmith-polly"` |  |
-| images.pollyAgentImage.tag | string | `"0.15.8"` |  |
+| images.pollyAgentImage.tag | string | `"0.15.9"` |  |
 | images.postgresImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.postgresImage.repository | string | `"docker.io/postgres"` |  |
 | images.postgresImage.tag | string | `"14.7"` |  |

--- a/charts/langsmith/ci/custom-ca-external-redis-values.yaml
+++ b/charts/langsmith/ci/custom-ca-external-redis-values.yaml
@@ -82,3 +82,11 @@ clickhouse:
       requests:
         cpu: 200m
         memory: 500Mi
+
+# Insights and Polly default to enabled in chart 0.15.1, but this CI fixture
+# focuses on the custom-CA + external-Redis path; disable both to keep the
+# kind cluster lean and avoid requiring encryption keys.
+insights:
+  enabled: false
+polly:
+  enabled: false

--- a/charts/langsmith/ci/subdomain.yaml
+++ b/charts/langsmith/ci/subdomain.yaml
@@ -73,3 +73,11 @@ clickhouse:
       requests:
         cpu: 200m
         memory: 500Mi
+
+# Insights and Polly default to enabled in chart 0.15.1, but this CI fixture
+# focuses on the subdomain/ingress path; disable both to keep the kind
+# cluster lean and avoid requiring encryption keys.
+insights:
+  enabled: false
+polly:
+  enabled: false

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -844,12 +844,6 @@ Extra env vars for polly api-server and queue pods.
 {{- if .Values.config.agentBuilder.enabled }}
 {{- $createProducts = append $createProducts "agent_builder" }}
 {{- end }}
-{{- if .Values.config.insights.enabled }}
-{{- $createProducts = append $createProducts "insights" }}
-{{- end }}
-{{- if .Values.config.polly.enabled }}
-{{- $createProducts = append $createProducts "smith_polly" }}
-{{- end }}
 {{ toYaml $createProducts }}
 {{- end -}}
 
@@ -858,12 +852,7 @@ Extra env vars for polly api-server and queue pods.
 {{- if not .Values.config.agentBuilder.enabled }}
 {{- $destroyProducts = append $destroyProducts "agent_builder" }}
 {{- end }}
-{{- if not .Values.config.insights.enabled }}
-{{- $destroyProducts = append $destroyProducts "insights" }}
-{{- end }}
-{{- if not .Values.config.polly.enabled }}
-{{- $destroyProducts = append $destroyProducts "smith_polly" }}
-{{- end }}
+{{- $destroyProducts = append $destroyProducts "insights" "smith_polly" }}
 {{ toYaml $destroyProducts }}
 {{- end -}}
 

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -469,7 +469,7 @@ Template containing common environment variables that are used by several servic
       name: {{ include "langsmith.secretsName" . }}
       key: agent_builder_encryption_key
 {{- end }}
-{{- if or .Values.config.insights.enabled .Values.insights.enabled }}
+{{- if .Values.insights.enabled }}
 - name: CLIO_ENCRYPTION_KEY
   valueFrom:
     secretKeyRef:
@@ -477,7 +477,7 @@ Template containing common environment variables that are used by several servic
       key: insights_encryption_key
       optional: false
 {{- end }}
-{{- if or .Values.config.polly.enabled .Values.polly.enabled }}
+{{- if .Values.polly.enabled }}
 - name: POLLY_ENCRYPTION_KEY
   valueFrom:
     secretKeyRef:

--- a/charts/langsmith/templates/agent-bootstrap/bootstrap-job.yaml
+++ b/charts/langsmith/templates/agent-bootstrap/bootstrap-job.yaml
@@ -103,36 +103,6 @@ spec:
                   "min_scale": {{ .Values.config.agentBuilder.agent.resources.minScale }},
                   "max_scale": {{ .Values.config.agentBuilder.agent.resources.maxScale }},
                   "extra_env": {{ (.Values.config.agentBuilder.agent.extraEnv | default (dict)) | toJson }}
-                }{{- if .Values.config.insights.enabled }},{{- end }}
-              {{- end }}
-              {{- if .Values.config.insights.enabled }}
-                "clio": {
-                  "image": "{{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "insightsAgentImage") }}",
-                  "configmap_name": "{{ include "langsmith.fullname" . }}-insights-config",
-                  "k8s_namespace": "{{ .Values.namespace | default .Release.Namespace }}",
-                  "restart_deployments": ["{{ include "langsmith.fullname" . }}-{{ .Values.frontend.name }}", "{{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}", "{{ include "langsmith.fullname" . }}-{{ .Values.queue.name }}"],
-                  "cpu": {{ .Values.config.insights.agent.resources.cpu }},
-                  "cpu_limit": {{ .Values.config.insights.agent.resources.cpuLimit }},
-                  "memory_mb": {{ .Values.config.insights.agent.resources.memoryMb }},
-                  "memory_limit_mb": {{ .Values.config.insights.agent.resources.memoryLimitMb }},
-                  "min_scale": {{ .Values.config.insights.agent.resources.minScale }},
-                  "max_scale": {{ .Values.config.insights.agent.resources.maxScale }},
-                  "extra_env": {{ (.Values.config.insights.agent.extraEnv | default (dict)) | toJson }}
-                }{{- if .Values.config.polly.enabled }},{{- end }}
-              {{- end }}
-              {{- if .Values.config.polly.enabled }}
-                "smith-polly": {
-                  "image": "{{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "pollyAgentImage") }}",
-                  "configmap_name": "{{ include "langsmith.fullname" . }}-polly-config",
-                  "k8s_namespace": "{{ .Values.namespace | default .Release.Namespace }}",
-                  "restart_deployments": ["{{ include "langsmith.fullname" . }}-{{ .Values.frontend.name }}"],
-                  "cpu": {{ .Values.config.polly.agent.resources.cpu }},
-                  "cpu_limit": {{ .Values.config.polly.agent.resources.cpuLimit }},
-                  "memory_mb": {{ .Values.config.polly.agent.resources.memoryMb }},
-                  "memory_limit_mb": {{ .Values.config.polly.agent.resources.memoryLimitMb }},
-                  "min_scale": {{ .Values.config.polly.agent.resources.minScale }},
-                  "max_scale": {{ .Values.config.polly.agent.resources.maxScale }},
-                  "extra_env": {{ (.Values.config.polly.agent.extraEnv | default (dict)) | toJson }}
                 }
               {{- end }}
               }

--- a/charts/langsmith/templates/agent-bootstrap/rbac.yaml
+++ b/charts/langsmith/templates/agent-bootstrap/rbac.yaml
@@ -20,7 +20,7 @@ automountServiceAccountToken: {{ .Values.backend.agentBootstrap.serviceAccount.a
 {{- end }}
 ---
 # Role + RoleBinding: only when at least one product is enabled (create path patches ConfigMaps and restarts deployments)
-{{- if and .Values.backend.agentBootstrap.enabled .Values.config.deployment.enabled (or .Values.config.agentBuilder.enabled .Values.config.insights.enabled .Values.config.polly.enabled) }}
+{{- if and .Values.backend.agentBootstrap.enabled .Values.config.deployment.enabled .Values.config.agentBuilder.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -44,12 +44,6 @@ rules:
       {{- if .Values.config.agentBuilder.enabled }}
       - {{ include "langsmith.fullname" . }}-agent-builder-config
       {{- end }}
-      {{- if .Values.config.insights.enabled }}
-      - {{ include "langsmith.fullname" . }}-insights-config
-      {{- end }}
-      {{- if .Values.config.polly.enabled }}
-      - {{ include "langsmith.fullname" . }}-polly-config
-      {{- end }}
   # Permission to restart deployments after ConfigMap updates
   - apiGroups: ["apps"]
     resources: ["deployments"]
@@ -59,10 +53,6 @@ rules:
       {{- if .Values.config.agentBuilder.enabled }}
       - {{ include "langsmith.fullname" . }}-agent-builder-trigger-server
       - {{ include "langsmith.fullname" . }}-{{ .Values.ingestQueue.name }}
-      {{- end }}
-      {{- if .Values.config.insights.enabled }}
-      - {{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}
-      - {{ include "langsmith.fullname" . }}-{{ .Values.queue.name }}
       {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/langsmith/templates/backend/deployment.yaml
+++ b/charts/langsmith/templates/backend/deployment.yaml
@@ -87,11 +87,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "langsmith.fullname" . }}-config
-            {{- if .Values.config.insights.enabled }}
-            - configMapRef:
-                name: {{ include "langsmith.fullname" . }}-insights-config
-                optional: true
-            {{- end }}
           image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "backendImage") | quote }}
           imagePullPolicy: {{ .Values.images.backendImage.pullPolicy }}
           ports:

--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -78,7 +78,7 @@ data:
   FF_USE_PG_FOR_FEEDBACK_CONFIGS_FETCH_ENABLED_ALL: "true"
   FF_USE_PG_FOR_FEEDBACK_FETCH_ENABLED_ALL: "true"
   IS_SELF_HOSTED: "true"
-  {{- if or .Values.config.polly.enabled .Values.polly.enabled }}
+  {{- if .Values.polly.enabled }}
   SELF_HOSTED_POLLY_ENABLED: "true"
   {{- end }}
   {{- if .Values.agentGateway.enabled }}

--- a/charts/langsmith/templates/frontend/deployment.yaml
+++ b/charts/langsmith/templates/frontend/deployment.yaml
@@ -1,8 +1,8 @@
 {{- define "frontendEnvVars" -}}
 - name: VITE_SELF_HOSTED_CLIO_ENABLED
-  value: {{ (or .Values.config.insights.enabled .Values.insights.enabled) | quote }}
+  value: {{ .Values.insights.enabled | quote }}
 - name: VITE_SELF_HOSTED_POLLY_ENABLED
-  value: {{ (or .Values.config.polly.enabled .Values.polly.enabled) | quote }}
+  value: {{ .Values.polly.enabled | quote }}
 {{- /* Agent Builder OAuth provider IDs for frontend */ -}}
 {{- $googleOAuth := .Values.config.agentBuilder.oauth.googleOAuthProvider | default .Values.fleet.oauth.googleOAuthProvider }}
 {{- $slackOAuth := .Values.config.agentBuilder.oauth.slackOAuthProvider | default .Values.fleet.oauth.slackOAuthProvider }}
@@ -176,11 +176,6 @@ spec:
             {{- if and .Values.backend.agentBootstrap.enabled .Values.config.agentBuilder.enabled }}
             - configMapRef:
                 name: {{ include "langsmith.fullname" . }}-agent-builder-config
-                optional: true
-            {{- end }}
-            {{- if .Values.config.polly.enabled }}
-            - configMapRef:
-                name: {{ include "langsmith.fullname" . }}-polly-config
                 optional: true
             {{- end }}
           image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "frontendImage") | quote }}

--- a/charts/langsmith/templates/queue/deployment.yaml
+++ b/charts/langsmith/templates/queue/deployment.yaml
@@ -84,11 +84,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "langsmith.fullname" . }}-config
-            {{- if .Values.config.insights.enabled }}
-            - configMapRef:
-                name: {{ include "langsmith.fullname" . }}-insights-config
-                optional: true
-            {{- end }}
           image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "backendImage") | quote }}
           imagePullPolicy: {{ .Values.images.backendImage.pullPolicy }}
           ports:

--- a/charts/langsmith/templates/secrets.yaml
+++ b/charts/langsmith/templates/secrets.yaml
@@ -22,6 +22,6 @@ data:
   azure_storage_account_key: {{ .Values.config.blobStorage.azureStorageAccountKey | b64enc | quote }}
   azure_storage_connection_string: {{ .Values.config.blobStorage.azureStorageConnectionString | b64enc | quote }}
   agent_builder_encryption_key: {{ (.Values.fleet.encryptionKey | default .Values.config.agentBuilder.encryptionKey) | b64enc | quote }}
-  insights_encryption_key: {{ (.Values.insights.encryptionKey | default .Values.config.insights.encryptionKey) | b64enc | quote }}
-  polly_encryption_key: {{ (.Values.polly.encryptionKey | default .Values.config.polly.encryptionKey) | b64enc | quote }}
+  insights_encryption_key: {{ .Values.insights.encryptionKey | b64enc | quote }}
+  polly_encryption_key: {{ .Values.polly.encryptionKey | b64enc | quote }}
 {{- end }}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -209,20 +209,14 @@ AWS Marketplace Helm template verification).
 {{- end -}}
 {{- end -}}
 
-{{- /* Validate insights configuration */ -}}
-{{- if and .Values.config.insights.enabled (not .Values.config.deployment.enabled) -}}
-{{- fail "config.deployment.enabled must be true when Insights is enabled. Insights requires LangSmith Deployments." -}}
+{{- /* The bundled-agent bootstrap path was removed for Insights and Polly.
+       Reject any attempt to use config.insights.enabled / config.polly.enabled
+       and direct users at the top-level insights / polly blocks. */ -}}
+{{- if .Values.config.insights.enabled -}}
+{{- fail "config.insights.enabled is no longer supported (the bundled-agent bootstrap path was removed in chart 0.15.1). Use the top-level insights block: insights.enabled, insights.encryptionKey, etc." -}}
 {{- end -}}
-{{- if and .Values.config.insights.enabled (not .Values.config.insights.encryptionKey) (not .Values.config.existingSecretName) -}}
-{{- fail "config.insights.encryptionKey is required when Insights is enabled. Generate one with: python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\"" -}}
-{{- end -}}
-
-{{- /* Validate polly configuration */ -}}
-{{- if and .Values.config.polly.enabled (not .Values.config.deployment.enabled) -}}
-{{- fail "config.deployment.enabled must be true when Polly is enabled. Polly requires LangSmith Deployments." -}}
-{{- end -}}
-{{- if and .Values.config.polly.enabled (not .Values.config.polly.encryptionKey) (not .Values.config.existingSecretName) -}}
-{{- fail "config.polly.encryptionKey is required when Polly is enabled. Generate one with: python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\"" -}}
+{{- if .Values.config.polly.enabled -}}
+{{- fail "config.polly.enabled is no longer supported (the bundled-agent bootstrap path was removed in chart 0.15.1). Use the top-level polly block: polly.enabled, polly.encryptionKey, etc." -}}
 {{- end -}}
 
 {{- /* Validate autoscaling configuration for all services */ -}}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -210,13 +210,13 @@ AWS Marketplace Helm template verification).
 {{- end -}}
 
 {{- /* The bundled-agent bootstrap path was removed for Insights and Polly.
-       Reject any attempt to use config.insights.enabled / config.polly.enabled
-       and direct users at the top-level insights / polly blocks. */ -}}
-{{- if .Values.config.insights.enabled -}}
-{{- fail "config.insights.enabled is no longer supported (the bundled-agent bootstrap path was removed in chart 0.15.1). Use the top-level insights block: insights.enabled, insights.encryptionKey, etc." -}}
+       Reject any presence of config.insights / config.polly and direct
+       users at the top-level insights / polly blocks. */ -}}
+{{- if hasKey .Values.config "insights" -}}
+{{- fail "config.insights is no longer supported (the bundled-agent bootstrap path was removed in chart 0.15.1). Use the top-level insights block: insights.enabled, insights.encryptionKey, etc." -}}
 {{- end -}}
-{{- if .Values.config.polly.enabled -}}
-{{- fail "config.polly.enabled is no longer supported (the bundled-agent bootstrap path was removed in chart 0.15.1). Use the top-level polly block: polly.enabled, polly.encryptionKey, etc." -}}
+{{- if hasKey .Values.config "polly" -}}
+{{- fail "config.polly is no longer supported (the bundled-agent bootstrap path was removed in chart 0.15.1). Use the top-level polly block: polly.enabled, polly.encryptionKey, etc." -}}
 {{- end -}}
 
 {{- /* Validate autoscaling configuration for all services */ -}}

--- a/charts/langsmith/tests/bundled_agent_bootstrap_test.yaml
+++ b/charts/langsmith/tests/bundled_agent_bootstrap_test.yaml
@@ -1,0 +1,23 @@
+suite: removed bundled-agent bootstrap keys validation
+templates:
+  - validate.yaml
+tests:
+  - it: should fail when deprecated config.insights.enabled is set
+    set:
+      config.existingSecretName: "langsmith-secrets"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.insights.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "config.insights.enabled is no longer supported (the bundled-agent bootstrap path was removed in chart 0.15.1). Use the top-level insights block: insights.enabled, insights.encryptionKey, etc."
+
+  - it: should fail when deprecated config.polly.enabled is set
+    set:
+      config.existingSecretName: "langsmith-secrets"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.polly.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "config.polly.enabled is no longer supported (the bundled-agent bootstrap path was removed in chart 0.15.1). Use the top-level polly block: polly.enabled, polly.encryptionKey, etc."

--- a/charts/langsmith/tests/bundled_agent_bootstrap_test.yaml
+++ b/charts/langsmith/tests/bundled_agent_bootstrap_test.yaml
@@ -2,7 +2,7 @@ suite: removed bundled-agent bootstrap keys validation
 templates:
   - validate.yaml
 tests:
-  - it: should fail when deprecated config.insights.enabled is set
+  - it: should fail when deprecated config.insights is set
     set:
       config.existingSecretName: "langsmith-secrets"
       config.oauth.enabled: true
@@ -10,9 +10,9 @@ tests:
       config.insights.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: "config.insights.enabled is no longer supported (the bundled-agent bootstrap path was removed in chart 0.15.1). Use the top-level insights block: insights.enabled, insights.encryptionKey, etc."
+          errorMessage: "config.insights is no longer supported (the bundled-agent bootstrap path was removed in chart 0.15.1). Use the top-level insights block: insights.enabled, insights.encryptionKey, etc."
 
-  - it: should fail when deprecated config.polly.enabled is set
+  - it: should fail when deprecated config.polly is set
     set:
       config.existingSecretName: "langsmith-secrets"
       config.oauth.enabled: true
@@ -20,4 +20,4 @@ tests:
       config.polly.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: "config.polly.enabled is no longer supported (the bundled-agent bootstrap path was removed in chart 0.15.1). Use the top-level polly block: polly.enabled, polly.encryptionKey, etc."
+          errorMessage: "config.polly is no longer supported (the bundled-agent bootstrap path was removed in chart 0.15.1). Use the top-level polly block: polly.enabled, polly.encryptionKey, etc."

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -849,37 +849,6 @@ config:
     # Disable this if there is restricted access to the external facing ingress endpoint for your agent(s) from inside of your kubernetes cluster.
     ingressHealthCheckEnabled: true
 
-  # Insights (Clio) configuration - AI-powered insights agent
-  # Requires config.deployment.enabled to be true
-  insights:
-    enabled: false
-    # Fernet encryption key for Insights. Required when enabled.
-    # Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
-    encryptionKey: ""
-    agent:
-      resources:
-        cpu: 2
-        cpuLimit: 4
-        memoryMb: 4096
-        memoryLimitMb: 8192
-        minScale: 1
-        maxScale: 5
-      extraEnv: {}
-
-  # Polly configuration
-  polly:
-    enabled: false
-    encryptionKey: ""
-    agent:
-      resources:
-        cpu: 2
-        cpuLimit: 4
-        memoryMb: 4096
-        memoryLimitMb: 8192
-        minScale: 1
-        maxScale: 5
-      extraEnv: {}
-
   # DEPRECATED: use the top-level fleet block (fleet/fleetToolServer/
   # fleetTriggerServer) instead. This bundled-agent path is managed by
   # backend.agentBootstrap and is being phased out.

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -40,23 +40,23 @@ images:
   aceBackendImage:
     repository: "docker.io/langchain/langsmith-ace-backend"
     pullPolicy: IfNotPresent
-    tag: "0.15.8"
+    tag: "0.15.9"
   backendImage:
     repository: "docker.io/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
-    tag: "0.15.8"
+    tag: "0.15.9"
   insightsAgentImage:
     repository: "docker.io/langchain/langsmith-clio"
     pullPolicy: IfNotPresent
-    tag: "0.15.8"
+    tag: "0.15.9"
   frontendImage:
     repository: "docker.io/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
-    tag: "0.15.8"
+    tag: "0.15.9"
   hostBackendImage:
     repository: "docker.io/langchain/hosted-langserve-backend"
     pullPolicy: IfNotPresent
-    tag: "0.15.8"
+    tag: "0.15.9"
   operatorImage:
     repository: "docker.io/langchain/langgraph-operator"
     pullPolicy: IfNotPresent
@@ -64,11 +64,11 @@ images:
   platformBackendImage:
     repository: "docker.io/langchain/langsmith-go-backend"
     pullPolicy: IfNotPresent
-    tag: "0.15.8"
+    tag: "0.15.9"
   playgroundImage:
     repository: "docker.io/langchain/langsmith-playground"
     pullPolicy: IfNotPresent
-    tag: "0.15.8"
+    tag: "0.15.9"
   # For production environments, we strongly recommend connecting to a managed PostgreSQL instance instead of using the one provided by the chart.
   # Docs: https://docs.langchain.com/langsmith/self-host-external-postgres
   postgresImage:
@@ -88,19 +88,19 @@ images:
   fleetToolServerImage:
     repository: "docker.io/langchain/agent-builder-tool-server"
     pullPolicy: IfNotPresent
-    tag: "0.15.8"
+    tag: "0.15.9"
   fleetTriggerServerImage:
     repository: "docker.io/langchain/agent-builder-trigger-server"
     pullPolicy: IfNotPresent
-    tag: "0.15.8"
+    tag: "0.15.9"
   agentBuilderImage:
     repository: "docker.io/langchain/agent-builder-deep-agent"
     pullPolicy: IfNotPresent
-    tag: "0.15.8"
+    tag: "0.15.9"
   pollyAgentImage:
     repository: "docker.io/langchain/langsmith-polly"
     pullPolicy: IfNotPresent
-    tag: "0.15.8"
+    tag: "0.15.9"
   # Optional: only mirror/pull when presidioAnalyzer.enabled is true
   presidioAnalyzerImage:
     repository: "mcr.microsoft.com/presidio-analyzer"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -372,7 +372,7 @@ fleet:
       enabled: false
       minAvailable: 1
 insights:
-  enabled: false
+  enabled: true
   namePrefix: "standalone-insights"
   encryptionKey: ""
   apiServer:
@@ -604,7 +604,7 @@ insights:
       minAvailable: 1
 
 polly:
-  enabled: false
+  enabled: true
   namePrefix: "standalone-polly"
   enableTracing: true
   encryptionKey: ""
@@ -849,8 +849,6 @@ config:
     # Disable this if there is restricted access to the external facing ingress endpoint for your agent(s) from inside of your kubernetes cluster.
     ingressHealthCheckEnabled: true
 
-  # DEPRECATED: use the top-level insights block instead. This bundled-agent
-  # path is managed by backend.agentBootstrap and is being phased out.
   # Insights (Clio) configuration - AI-powered insights agent
   # Requires config.deployment.enabled to be true
   insights:
@@ -868,8 +866,6 @@ config:
         maxScale: 5
       extraEnv: {}
 
-  # DEPRECATED: use the top-level polly block instead. This bundled-agent
-  # path is managed by backend.agentBootstrap and is being phased out.
   # Polly configuration
   polly:
     enabled: false


### PR DESCRIPTION
## Summary

Removes the bundled-agent bootstrap path for Insights and Polly. Both now run as standard Helm-managed Deployments via the top-level \`insights\` / \`polly\` value blocks (same shape as \`fleet\`).

- \`insights.enabled\` and \`polly.enabled\` default to \`true\` — fresh installs get the standalone stacks (api-server, queue, bundled Postgres + Redis) out of the box.
- \`config.insights.enabled\` and \`config.polly.enabled\` are no longer supported; templating hard-fails with a message pointing at the top-level blocks.

Chart version: \`0.15.0\` → \`0.15.1\`. appVersion stays at \`0.15.8\`.

## Heads-up

Fresh installs without an \`existingSecretName\` now need to supply \`insights.encryptionKey\` and \`polly.encryptionKey\` (or set the respective \`.enabled: false\`).

## Test plan

- [ ] \`helm unittest charts/langsmith\` passes
- [ ] \`helm lint charts/langsmith\` passes
- [ ] Default \`helm template\` renders both standalone insights and polly stacks
- [ ] \`helm template --set insights.enabled=false --set polly.enabled=false\` cleanly skips both
- [ ] \`helm template --set config.insights.enabled=true\` fails with the deprecation error
- [ ] \`helm upgrade\` against a release that previously used \`config.insights.enabled=true\` / \`config.polly.enabled=true\` tears down the bundled-agent Deployments and brings up the new standalone ones