### PR TITLE
docs: remove SECURITY-TEMPLATE.md and fix changelog link

### DIFF
--- a/SECURITY-TEMPLATE.md
+++ b/SECURITY-TEMPLATE.md
@@ -1,5 +1,0 @@
-# SECURITY-TEMPLATE.md (deprecated)
-
-Per-release CVE entries are auto-generated in the [self-hosted changelog](https://docs.smith.langchain.com/self-hosted/changelog) by the helm-changelog-bot. No manual per-release template is needed.
-
-When standing content in SECURITY.md changes (false-positive registry additions, SLA updates, accepted-risk table updates, scope changes), edit SECURITY.md directly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,7 +77,7 @@ To consume a patched image, bump the chart version when upgrading the langsmith 
 
 ## Per-release CVE history
 
-Patched CVEs for each release are tracked in the auto-generated `## Security` section of the [self-hosted changelog](https://docs.smith.langchain.com/self-hosted/changelog). The changelog is the single source of truth for "what CVEs were fixed in version X." This document covers the standing security posture (image inventory, false-positive registry, SLAs, reporting flow) that is not version-specific.
+Patched CVEs for each release are tracked as auto-generated security fix bullets in the corresponding release entry of the [self-hosted changelog](https://docs.langchain.com/langsmith/self-hosted-changelog). The changelog is the single source of truth for "what CVEs were fixed in version X." This document covers the standing security posture (image inventory, false-positive registry, SLAs, reporting flow) that is not version-specific.
 
 ---
 


### PR DESCRIPTION
Follow-up to #725. Two fixes:

1. Removes SECURITY-TEMPLATE.md — it was created and deprecated in the same PR, which is silly. Per-release CVE entries are auto-generated by helm-changelog-bot, no manual template is needed.
2. Fixes the broken self-hosted changelog URL in SECURITY.md.

   - Old: `https://docs.smith.langchain.com/self-hosted/changelog` → 308 redirect chain ending at `/langsmith/home` (not a changelog page)
   - New: `https://docs.langchain.com/langsmith/self-hosted-changelog` → HTTP 200 direct, matches `src/langsmith/self-hosted-changelog.mdx` in the docs repo

Both noted by @romain-priour-lc post-merge.