### PR TITLE
docs: 0.15.0 bump + FP safety banner + chart-vs-tag

### DIFF
--- a/.github/workflows/security-md-auto-bump.yml
+++ b/.github/workflows/security-md-auto-bump.yml
@@ -1,0 +1,142 @@
+name: Auto-bump SECURITY.md on langsmith GA
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  bump:
+    # Only langsmith-* GA tags. Exclude all RC tags.
+    if: |
+      startsWith(github.event.release.tag_name, 'langsmith-') &&
+      !contains(github.event.release.tag_name, '-rc.')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Extract chart version from release tag
+        id: chart
+        # tag_name is passed via env (never interpolated into the script body)
+        # to avoid shell injection; it is shape-checked before any further use.
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          CHART_VERSION="${TAG#langsmith-}"
+          # Defensive: must be a real semver-shaped string, no spaces, no quotes
+          if ! echo "$CHART_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
+            echo "Refusing to proceed: chart version '${CHART_VERSION}' does not look like a release version" >&2
+            exit 1
+          fi
+          echo "version=${CHART_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Read appVersion from Chart.yaml at the release tag
+        id: app
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          # Validate the tag shape before using it to build a git ref, so a
+          # malformed tag can never expand into an unexpected ref/path.
+          if ! echo "$TAG" | grep -qE '^langsmith-[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
+            echo "Refusing to proceed: tag '${TAG}' is not a langsmith GA tag" >&2
+            exit 1
+          fi
+          APP_VERSION=$(git show "refs/tags/${TAG}:charts/langsmith/Chart.yaml" | awk '/^appVersion:/ {print $2}' | tr -d '"' | tr -d "'")
+          if ! echo "$APP_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
+            echo "Refusing to proceed: appVersion '${APP_VERSION}' does not look like a real version" >&2
+            exit 1
+          fi
+          echo "version=${APP_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Update SECURITY.md between markers only
+        env:
+          CHART_VERSION: ${{ steps.chart.outputs.version }}
+          APP_VERSION: ${{ steps.app.outputs.version }}
+        run: |
+          set -euo pipefail
+          export TODAY=$(date -u +%Y-%m-%d)
+          python3 - <<'PYEOF'
+          import os
+          import re
+
+          chart = os.environ["CHART_VERSION"]
+          app = os.environ["APP_VERSION"]
+          today = os.environ["TODAY"] if "TODAY" in os.environ else __import__("datetime").datetime.utcnow().strftime("%Y-%m-%d")
+
+          with open("SECURITY.md", "r") as f:
+              content = f.read()
+
+          def replace_between(content, marker, new_inner):
+              pattern = re.compile(
+                  rf"(<!-- BEGIN: {re.escape(marker)} -->)(.*?)(<!-- END: {re.escape(marker)} -->)",
+                  re.DOTALL,
+              )
+              if not pattern.search(content):
+                  raise SystemExit(f"Marker block '{marker}' not found in SECURITY.md; refusing to silently no-op")
+              return pattern.sub(lambda m: f"{m.group(1)}\n{new_inner}\n{m.group(3)}", content)
+
+          content = replace_between(
+              content,
+              "current-chart",
+              f"**Latest release covered:** chart `langsmith-{chart}` / images tagged `{app}`",
+          )
+          content = replace_between(
+              content,
+              "last-updated",
+              f"**Last updated:** {today}",
+          )
+          content = replace_between(
+              content,
+              "reporting-example",
+              f"1. The chart and `appVersion` you are deployed on (e.g., chart `langsmith-{chart}` / `appVersion {app}`)",
+          )
+
+          with open("SECURITY.md", "w") as f:
+              f.write(content)
+          PYEOF
+
+      - name: Verify only marker blocks changed
+        run: |
+          set -euo pipefail
+          # Confirm marker counts are still exactly 6
+          MARKER_COUNT=$(grep -cE "^<!-- (BEGIN|END): (current-chart|last-updated|reporting-example) -->$" SECURITY.md || true)
+          if [ "$MARKER_COUNT" -ne 6 ]; then
+            echo "Marker count is ${MARKER_COUNT}, expected 6. Refusing to commit." >&2
+            exit 1
+          fi
+          # Confirm historical worked example is untouched
+          if ! grep -q "langsmith-0.14.6.*langsmith-backend:0.14.9" SECURITY.md; then
+            echo "Historical worked example (0.14.6 -> 0.14.9) is missing — refusing to commit; check whether the workflow accidentally touched it." >&2
+            exit 1
+          fi
+
+      - name: Open PR with changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          BRANCH="auto/security-md-bump-${TAG}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet SECURITY.md; then
+            echo "No changes to SECURITY.md — skipping PR."
+            exit 0
+          fi
+          git checkout -b "${BRANCH}"
+          git add SECURITY.md
+          git commit -m "docs: auto-bump SECURITY.md for ${TAG}"
+          git push origin "${BRANCH}"
+          gh pr create \
+            --title "docs: auto-bump SECURITY.md for ${TAG}" \
+            --body "Automated PR from .github/workflows/security-md-auto-bump.yml. Triggered by release ${TAG}. Only content between BEGIN/END marker comments was modified. Historical worked example (0.14.6 → 0.14.9) is preserved." \
+            --label "automated" \
+            --label "documentation"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,11 @@
 # Security & CVE Transparency
 
-**Latest release covered:** chart `langsmith-0.14.6` / images tagged `0.14.9`
-**Last updated:** 2026-05-19
+<!-- BEGIN: current-chart -->
+**Latest release covered:** chart `langsmith-0.15.0` / images tagged `0.15.8`
+<!-- END: current-chart -->
+<!-- BEGIN: last-updated -->
+**Last updated:** 2026-05-28
+<!-- END: last-updated -->
 **Maintainer contact:** security@langchain.dev
 
 > **Chart version vs. image tag.** The Helm chart and the container images use
@@ -10,6 +14,8 @@
 > is the tag your scanner will report against the running images
 > (`docker.io/langchain/langsmith-backend:0.14.9`, etc.). Both are listed in
 > the heading above so you can match either side to the CVE table below.
+> (The current GA release follows the same pattern: chart `langsmith-0.15.0`
+> ships images tagged `0.15.8`.)
 
 ## Covered images
 
@@ -79,9 +85,20 @@ To consume a patched image, bump the chart version when upgrading the langsmith 
 
 Patched CVEs for each release are tracked as auto-generated security fix bullets in the corresponding release entry of the [self-hosted changelog](https://docs.langchain.com/langsmith/self-hosted-changelog). The changelog is the single source of truth for "what CVEs were fixed in version X." This document covers the standing security posture (image inventory, false-positive registry, SLAs, reporting flow) that is not version-specific.
 
+> **Chart version is not the image tag.** The changelog lists fixes by Helm chart version (e.g., `langsmith-0.14.6`). The image tag containing the fix is the chart's `appVersion`, which is different (e.g., `0.14.9`). To pull a patched image: find the chart version in the changelog, look up that chart's `appVersion` in [`charts/langsmith/Chart.yaml`](https://github.com/langchain-ai/helm/blob/main/charts/langsmith/Chart.yaml) at the matching release tag, then pull `docker.io/langchain/<image>:<appVersion>` — not the chart number.
+>
+> **Verified example:** chart `langsmith-0.14.6` shipped images tagged `0.14.9`. Pulling `langsmith-backend:0.14.6` does not clear these CVEs (Mako and python-multipart still vulnerable in this tag); pulling `langsmith-backend:0.14.9` does.
+
 ---
 
 ## Scanner noise — Chainguard base images
+
+> **Before closing any finding here, check your scanner's `Status` field.**
+>
+> - **`Status: fixed`** with an upgrade version available → NOT a false positive. The patch exists in a newer image; rebuild/pull the patched tag, do not close.
+> - **`Status: will_not_fix`** → eligible for close-with-confidence if a pattern below matches, verified against the [Chainguard advisory feed](https://images.chainguard.dev/security).
+> - **`Status: affected`** (no fix listed) → eligible only if a pattern below cites a specific advisory marking the CVE as not exploitable in the running image.
+> - **Any other status, or no pattern match below** → report to security@langchain.dev.
 
 Several of the images above are built on [Chainguard](https://www.chainguard.dev/)
 Wolfi-based minimal base images. Chainguard maintains its own security advisory
@@ -161,7 +178,9 @@ If you have a finding that is not addressed above, please report it to:
 filing a report — this lets us reproduce your scanner output against the exact
 image you are running:
 
-1. The chart and `appVersion` you are deployed on (e.g., chart `langsmith-0.14.6` / `appVersion 0.14.9`)
+<!-- BEGIN: reporting-example -->
+1. The chart and `appVersion` you are deployed on (e.g., chart `langsmith-0.15.0` / `appVersion 0.15.8`)
+<!-- END: reporting-example -->
 2. The full image reference including digest **if available**, or tag and pull timestamp. Example to retrieve the digest:
    `docker inspect <image> --format '{{.RepoDigests}}'` →
    `langchain/langsmith-backend@sha256:...`


### PR DESCRIPTION
Four small fixes:

1. Version bump for today's 0.15.0 GA (chart 0.15.0 / images 0.15.8).
2. FP registry safety banner — explicit `Status` field check so fixed-with-upgrade findings aren't treated as false positives.
3. Chart-vs-tag callout — explains that customers must pull the appVersion image tag, not the chart number, with empirically-verified worked example (chart 0.14.6 → images 0.14.9).
4. GitHub Action (`security-md-auto-bump.yml`) — auto-opens a follow-up PR to bump the version references in SECURITY.md on each new langsmith-* GA release. Uses HTML comment markers to fence the auto-updatable regions; only marked sections are ever modified. Historical worked example is preserved by design.

Security note on item 4: the release tag value is passed to shell steps via `env:` (not interpolated into `run:` script bodies) to avoid Actions script injection, and is shape-checked before use. Token scope is limited to `contents: write` + `pull-requests: write`; the workflow opens a PR for review rather than committing to main.

No existing FP registry rows rewritten. No content outside the marker blocks is automatable.