### PR TITLE
fix: destroy products

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.15.2
+version: 0.15.3
 appVersion: "0.15.10"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.15.2](https://img.shields.io/badge/Version-0.15.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.10](https://img.shields.io/badge/AppVersion-0.15.10-informational?style=flat-square)
+![Version: 0.15.3](https://img.shields.io/badge/Version-0.15.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.10](https://img.shields.io/badge/AppVersion-0.15.10-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -852,7 +852,8 @@ Extra env vars for polly api-server and queue pods.
 {{- if not .Values.config.agentBuilder.enabled }}
 {{- $destroyProducts = append $destroyProducts "agent_builder" }}
 {{- end }}
-{{- $destroyProducts = append $destroyProducts "insights" "smith_polly" }}
+{{- $destroyProducts = append $destroyProducts "insights" }}
+{{- $destroyProducts = append $destroyProducts "smith_polly" }}
 {{ toYaml $destroyProducts }}
 {{- end -}}
 


### PR DESCRIPTION
fixes:
```
Release "langsmith" does not exist. Installing it now.
install.go:225: 2026-05-29 14:44:13.287547 -0400 EDT m=+0.705484209 [debug] Original chart version: ""
install.go:242: 2026-05-29 14:44:13.89284 -0400 EDT m=+1.310772417 [debug] CHART PATH: /Users/joaquinborggio/Library/Caches/helm/repository/langsmith-0.15.2.tgz

Error: template: langsmith/templates/agent-bootstrap/bootstrap-job.yaml:6:24: executing "langsmith/templates/agent-bootstrap/bootstrap-job.yaml" at <include "agentBootstrap.destroyAgentProducts" .>: error calling include: template: langsmith/templates/_helpers.tpl:855:23: executing "agentBootstrap.destroyAgentProducts" at <append>: wrong number of args for append: want 2 got 3
helm.go:92: 2026-05-29 14:44:14.185445 -0400 EDT m=+1.603375542 [debug] template: langsmith/templates/agent-bootstrap/bootstrap-job.yaml:6:24: executing "langsmith/templates/agent-bootstrap/bootstrap-job.yaml" at <include "agentBootstrap.destroyAgentProducts" .>: error calling include: template: langsmith/templates/_helpers.tpl:855:23: executing "agentBootstrap.destroyAgentProducts" at <append>: wrong number of args for append: want 2 got 3

```