### PR TITLE
docs(langsmith): mirror readonly example with CI (agent apps)

### DIFF
--- a/charts/langsmith/ci/readonly-config-values.yaml
+++ b/charts/langsmith/ci/readonly-config-values.yaml
@@ -533,6 +533,60 @@ operator:
         type: RuntimeDefault
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
+  templates:
+    deployment: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ${name}
+        namespace: ${namespace}
+      spec:
+        replicas: ${replicas}
+        selector:
+          matchLabels:
+            app: ${name}
+        template:
+          metadata:
+            labels:
+              app: ${name}
+          spec:
+            enableServiceLinks: false
+            # Pod-level security context:
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1000
+              runAsGroup: 1000
+              fsGroup: 1000
+            containers:
+              - name: api-server
+                image: ${image}
+                ports:
+                  - name: api-server
+                    containerPort: 8000
+                    protocol: TCP
+                # Container-level security context:
+                securityContext:
+                  capabilities:
+                    drop:
+                      - ALL
+                  seccompProfile:
+                    type: RuntimeDefault
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+                livenessProbe:
+                  httpGet:
+                    path: /lgp/${name}/ok?check_db=1
+                    port: 8000
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+                readinessProbe:
+                  httpGet:
+                    path: /lgp/${name}/ok
+                    port: 8000
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 6
 
 frontend:
   deployment:

--- a/charts/langsmith/examples/read_only_config.yaml
+++ b/charts/langsmith/examples/read_only_config.yaml
@@ -9,6 +9,312 @@ config:
     initialOrgAdminPassword: "TestLangSmith123!"
     jwtSecret: "YOUR_JWT_SECRET"
 
+# Agent applications (fleet, insights, polly) are enabled by default and must
+# also be configured for a read-only root filesystem.
+fleet:
+  enabled: true
+  encryptionKey: "YOUR_ENCRYPTION_KEY"
+  apiServer:
+    deployment:
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+  queue:
+    deployment:
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+  postgres:
+    statefulSet:
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: postgres
+          emptyDir: {}
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: postgres
+          mountPath: /run/postgresql
+  redis:
+    statefulSet:
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+
+insights:
+  enabled: true
+  encryptionKey: "YOUR_ENCRYPTION_KEY"
+  apiServer:
+    deployment:
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+  queue:
+    deployment:
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+  postgres:
+    statefulSet:
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: postgres
+          emptyDir: {}
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: postgres
+          mountPath: /run/postgresql
+  redis:
+    statefulSet:
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+
+polly:
+  enabled: true
+  encryptionKey: "YOUR_ENCRYPTION_KEY"
+  apiServer:
+    deployment:
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+  queue:
+    deployment:
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+  postgres:
+    statefulSet:
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: postgres
+          emptyDir: {}
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: postgres
+          mountPath: /run/postgresql
+  redis:
+    statefulSet:
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+
+fleetToolServer:
+  enabled: true
+  deployment:
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    securityContext:
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+    volumes:
+      - name: tmp
+        emptyDir: {}
+    volumeMounts:
+      - name: tmp
+        mountPath: /tmp
+
+fleetTriggerServer:
+  enabled: true
+  deployment:
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    securityContext:
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+    volumes:
+      - name: tmp
+        emptyDir: {}
+    volumeMounts:
+      - name: tmp
+        mountPath: /tmp
+
 aceBackend:
   deployment:
     podSecurityContext:
@@ -130,155 +436,6 @@ listener:
         type: RuntimeDefault
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
-  templates:
-      db: |
-        apiVersion: apps/v1
-        kind: StatefulSet
-        metadata:
-          name: ${service_name}
-        spec:
-          serviceName: ${service_name}
-          replicas: ${replicas}
-          selector:
-            matchLabels:
-              app: ${service_name}
-          persistentVolumeClaimRetentionPolicy:
-            whenDeleted: Delete
-            whenScaled: Retain
-          template:
-            metadata:
-              labels:
-                app: ${service_name}
-            spec:
-              # Pod-level security context (applies to all containers)
-              securityContext:
-                runAsNonRoot: true
-                runAsUser: 1000
-                runAsGroup: 1000
-                fsGroup: 1000
-              # Declare additional volumes
-              volumes:
-              - name: tmp
-                emptyDir: {}
-              - name: postgres
-                emptyDir: {}
-              containers:
-              - name: postgres
-                image: pgvector/pgvector:pg15
-                ports:
-                  - containerPort: 5432
-                command: ["docker-entrypoint.sh"]
-                args:
-                  - postgres
-                  - -c
-                  - max_connections=${max_connections}
-                env:
-                  - name: POSTGRES_PASSWORD
-                    valueFrom:
-                      secretKeyRef:
-                        name: ${secret_name}
-                        key: POSTGRES_PASSWORD
-                  - name: POSTGRES_USER
-                    value: ${postgres_user}
-                  - name: POSTGRES_DB
-                    value: ${postgres_db}
-                  - name: PGDATA
-                    value: /var/lib/postgresql/data/pgdata
-                # Mount the PVC volume (postgres-data), plus the tmp/postgres volumes
-                volumeMounts:
-                  - name: postgres-data
-                    mountPath: /var/lib/postgresql/data
-                  - name: tmp
-                    mountPath: /tmp
-                  - name: postgres
-                    mountPath: /run/postgresql
-                # Container-level security context (applies only to "postgres" container)
-                securityContext:
-                  capabilities:
-                    drop:
-                      - ALL
-                  seccompProfile:
-                    type: RuntimeDefault
-                  allowPrivilegeEscalation: false
-                  readOnlyRootFilesystem: true
-                resources:
-                  requests:
-                    cpu: "${cpu}"
-                    memory: "${memory_mb}Mi"
-                  limits:
-                    cpu: "${cpu_limit}"
-                    memory: "${memory_limit}Mi"
-              enableServiceLinks: false
-          volumeClaimTemplates:
-          - metadata:
-              name: postgres-data
-            spec:
-              storageClassName: "gp2"
-              accessModes: ["ReadWriteOnce"]
-              resources:
-                requests:
-                  storage: "${storage_gi}Gi"
-      redis: |
-        apiVersion: apps/v1
-        kind: Deployment
-        metadata:
-          name: ${service_name}
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              app: ${service_name}
-          template:
-            metadata:
-              labels:
-                app: ${service_name}
-            spec:
-              # Pod-level security context
-              securityContext:
-                runAsNonRoot: true
-                runAsUser: 1000
-                runAsGroup: 1000
-                fsGroup: 1000
-              volumes:
-              - name: data
-                emptyDir: {}
-              containers:
-                - name: redis
-                  image: redis:6
-                  ports:
-                    - containerPort: 6379
-                  livenessProbe:
-                    exec:
-                      command:
-                      - redis-cli
-                      - ping
-                    initialDelaySeconds: 30
-                    periodSeconds: 10
-                  readinessProbe:
-                    tcpSocket:
-                      port: 6379
-                    initialDelaySeconds: 10
-                    periodSeconds: 5
-                  # Container-level security context
-                  securityContext:
-                    capabilities:
-                      drop:
-                        - ALL
-                    seccompProfile:
-                      type: RuntimeDefault
-                    allowPrivilegeEscalation: false
-                    readOnlyRootFilesystem: true
-                  resources:
-                    requests:
-                      cpu: "1"
-                      memory: "2048Mi"
-                    limits:
-                      cpu: "1"
-                      memory: "2048Mi"
-                  volumeMounts:
-                    - name: data
-                      mountPath: /data
-              enableServiceLinks: false
 
 operator:
   deployment:


### PR DESCRIPTION
## Summary

Brings `examples/read_only_config.yaml` in line with `ci/readonly-config-values.yaml` for the agent applications, which are now enabled by default and would otherwise fail to start under a read-only root filesystem.

- **Add agent apps to the example:** `fleet`, `insights`, `polly`, `fleetToolServer`, `fleetTriggerServer` — each with read-only `securityContext`/`podSecurityContext` and the required `tmp` (and `postgres`) volume mounts. Uses placeholder `encryptionKey: "YOUR_ENCRYPTION_KEY"` to match the example's `YOUR_*` style. CI-only bits (resources, hostname, ingress, replicas) are intentionally **not** added, to keep the example consistent with its existing style.
- **Remove obsolete `listener.templates`** (inline db/redis) from the example — no longer needed.
- **Add `operator.templates` deployment block to the CI values** so CI exercises it (the example already had it).

No chart version bump — consistent with how prior `ci/`/`examples/`-only changes were merged in this repo (e.g. #664, #558). `helm lint` and `helm template` pass against both files.