### PR TITLE
feat: add personalOrgMaxMonthlyTraces config for personal-org trace cap

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -926,6 +926,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | config.observability.tracing.exporter | string | `"http"` |  |
 | config.observability.tracing.useTls | bool | `true` |  |
 | config.orgAdminsInstallationUsageExportEnabled | bool | `false` | When true, any org admin can use the usage backfill export. |
+| config.personalOrgMaxMonthlyTraces | int | `-1` | Deployment-wide cap on monthly traces for every personal org. -1 disables the cap. |
 | config.personalOrgsDisabled | bool | `true` | Disable personal orgs. |
 | config.security | object | `{"cors":{"allowedOrigins":"*","allowedOriginsRegex":"","alwaysAllowPathsRegex":""}}` | Security configuration for CORS, headers, and other security-related settings. These settings control cross-origin access and help protect against common web vulnerabilities. |
 | config.security.cors | object | `{"allowedOrigins":"*","allowedOriginsRegex":"","alwaysAllowPathsRegex":""}` | CORS (Cross-Origin Resource Sharing) configuration. Controls which origins can make requests to the LangSmith API. By default, CORS is permissive. For production deployments, you should restrict this. |

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -351,6 +351,8 @@ Template containing common environment variables that are used by several servic
   value: {{ .Values.config.userOrgCreationDisabled | quote }}
 - name: FF_PERSONAL_ORGS_DISABLED
   value: {{ .Values.config.personalOrgsDisabled | quote }}
+- name: PERSONAL_ORG_MAX_MONTHLY_TRACES
+  value: {{ .Values.config.personalOrgMaxMonthlyTraces | default -1 | quote }}
 {{- if .Values.config.ttl.enabled }}
 - name: FF_TRACE_TIERS_ENABLED
   value: {{ .Values.config.ttl.enabled | quote }}

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -916,6 +916,8 @@ config:
   userOrgCreationDisabled: true
   # -- Disable personal orgs.
   personalOrgsDisabled: true
+  # -- Deployment-wide cap on monthly traces for every personal org. -1 disables the cap.
+  personalOrgMaxMonthlyTraces: -1
   # -- Enable Workspace Admins to invite users to the org and workspace.
   workspaceScopeOrgInvitesEnabled: false
   # -- Require authentication on the GET /info endpoint. When enabled, unauthenticated


### PR DESCRIPTION
- Wires a new chart value, `config.personalOrgMaxMonthlyTraces`, through to the `PERSONAL_ORG_MAX_MONTHLY_TRACES` backend env var added in https://github.com/langchain-ai/langchainplus/pull/26695
- This lets self-hosted admins set a deployment-wide cap on monthly traces across all personal organizations