### PR TITLE
feat(langsmith): expose clickhouse.statefulSet.updateStrategy

### DIFF
--- a/charts/langgraph-cloud/README.md
+++ b/charts/langgraph-cloud/README.md
@@ -376,6 +376,7 @@ If you are upgrading from a chart revision that used the old flat MongoDB values
 | mongo.external.existingSecretName | string | `""` | Existing secret name containing the MongoDB connection URL. |
 | mongo.statefulSet.persistence.size | string | `"8Gi"` | Persistent volume size for the bundled MongoDB instance. |
 | mongo.statefulSet.resources | object | `{"limits":{"cpu":"2000m","memory":"4Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}` | Resource requests and limits for the bundled MongoDB pod. |
+| mongo.statefulSet.updateStrategy | object | `{}` | Optional StatefulSet update strategy for the in-chart MongoDB instance. Leave unset to keep the Kubernetes default RollingUpdate behavior. |
 | nameOverride | string | `""` | Provide a name in place of `langgraph-cloud` for the chart |
 | namespace | string | `""` | Namespace to install the chart into. If not set, will use the namespace of the current context. |
 | queue.autoscaling.enabled | bool | `false` |  |
@@ -620,6 +621,7 @@ If you are upgrading from a chart revision that used the old flat MongoDB values
 | postgres.statefulSet.sidecars | list | `[]` |  |
 | postgres.statefulSet.terminationGracePeriodSeconds | int | `30` |  |
 | postgres.statefulSet.tolerations | list | `[]` |  |
+| postgres.statefulSet.updateStrategy | object | `{}` | Optional StatefulSet update strategy for the in-chart PostgreSQL instance. Leave unset to keep the Kubernetes default RollingUpdate behavior. |
 | postgres.statefulSet.volumeMounts | list | `[]` |  |
 | postgres.statefulSet.volumes | list | `[]` |  |
 

--- a/charts/langgraph-cloud/templates/mongo/stateful-set.yaml
+++ b/charts/langgraph-cloud/templates/mongo/stateful-set.yaml
@@ -10,6 +10,10 @@ metadata:
 spec:
   serviceName: {{ include "langGraphCloud.mongoServiceName" . }}
   replicas: 1
+  {{- with .Values.mongo.statefulSet.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "langGraphCloud.selectorLabels" . | nindent 6 }}

--- a/charts/langgraph-cloud/templates/postgres/stateful-set.yaml
+++ b/charts/langgraph-cloud/templates/postgres/stateful-set.yaml
@@ -19,6 +19,10 @@ metadata:
 spec:
   serviceName: {{ include "langGraphCloud.fullname" . }}-{{ .Values.postgres.name }}
   replicas: 1
+  {{- with .Values.postgres.statefulSet.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "langGraphCloud.selectorLabels" . | nindent 6 }}

--- a/charts/langgraph-cloud/tests/statefulset_update_strategy_test.yaml
+++ b/charts/langgraph-cloud/tests/statefulset_update_strategy_test.yaml
@@ -1,0 +1,37 @@
+suite: StatefulSet updateStrategy rendering
+templates:
+  - postgres/stateful-set.yaml
+  - mongo/stateful-set.yaml
+tests:
+  # --- postgres ---
+  - it: postgres does not render updateStrategy by default
+    template: postgres/stateful-set.yaml
+    asserts:
+      - notExists:
+          path: spec.updateStrategy
+  - it: postgres renders a configured updateStrategy
+    template: postgres/stateful-set.yaml
+    set:
+      postgres.statefulSet.updateStrategy.type: OnDelete
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: OnDelete
+
+  # --- mongo ---
+  - it: mongo does not render updateStrategy by default
+    template: mongo/stateful-set.yaml
+    set:
+      mongo.enabled: true
+    asserts:
+      - notExists:
+          path: spec.updateStrategy
+  - it: mongo renders a configured updateStrategy
+    template: mongo/stateful-set.yaml
+    set:
+      mongo.enabled: true
+      mongo.statefulSet.updateStrategy.type: OnDelete
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: OnDelete

--- a/charts/langgraph-cloud/values.yaml
+++ b/charts/langgraph-cloud/values.yaml
@@ -274,6 +274,9 @@ postgres:
     existingSecretName: ""
   containerPort: 5432
   statefulSet:
+    # -- Optional StatefulSet update strategy for the in-chart PostgreSQL instance.
+    # Leave unset to keep the Kubernetes default RollingUpdate behavior.
+    updateStrategy: {}
     labels: {}
     annotations: {}
     podSecurityContext: {}
@@ -407,6 +410,9 @@ mongo:
     # -- Existing secret name containing the MongoDB connection URL.
     existingSecretName: ""
   statefulSet:
+    # -- Optional StatefulSet update strategy for the in-chart MongoDB instance.
+    # Leave unset to keep the Kubernetes default RollingUpdate behavior.
+    updateStrategy: {}
     # -- Resource requests and limits for the bundled MongoDB pod.
     resources:
       limits:

--- a/charts/langgraph-dataplane/README.md
+++ b/charts/langgraph-dataplane/README.md
@@ -287,6 +287,7 @@ You can find the guide to deploy a LangGraph Dataplane [here](https://langchain-
 | redis.statefulSet.terminationGracePeriodSeconds | int | `30` |  |
 | redis.statefulSet.tolerations | list | `[]` |  |
 | redis.statefulSet.topologySpreadConstraints | list | `[]` |  |
+| redis.statefulSet.updateStrategy | object | `{}` | Optional StatefulSet update strategy for the in-chart Redis instance. Leave unset to keep the Kubernetes default RollingUpdate behavior. |
 | redis.statefulSet.volumeMounts | list | `[]` |  |
 | redis.statefulSet.volumes | list | `[]` |  |
 

--- a/charts/langgraph-dataplane/templates/redis/stateful-set.yaml
+++ b/charts/langgraph-dataplane/templates/redis/stateful-set.yaml
@@ -21,6 +21,10 @@ metadata:
 spec:
   serviceName: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.redis.name }}
   replicas: 1
+  {{- with .Values.redis.statefulSet.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "langgraphDataplane.selectorLabels" . | nindent 6 }}

--- a/charts/langgraph-dataplane/values.yaml
+++ b/charts/langgraph-dataplane/values.yaml
@@ -389,6 +389,9 @@ redis:
     existingSecretName: ""
   containerPort: 6379
   statefulSet:
+    # -- Optional StatefulSet update strategy for the in-chart Redis instance.
+    # Leave unset to keep the Kubernetes default RollingUpdate behavior.
+    updateStrategy: {}
     labels: {}
     annotations: {}
     podSecurityContext: {}

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -130,6 +130,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | fleet.postgres.statefulSet.sidecars | list | `[]` |  |
 | fleet.postgres.statefulSet.terminationGracePeriodSeconds | int | `30` |  |
 | fleet.postgres.statefulSet.tolerations | list | `[]` |  |
+| fleet.postgres.statefulSet.updateStrategy | object | `{}` | Optional StatefulSet update strategy for the in-chart Fleet PostgreSQL instance. Leave unset to keep the Kubernetes default RollingUpdate behavior. |
 | fleet.postgres.statefulSet.volumeMounts | list | `[]` |  |
 | fleet.postgres.statefulSet.volumes | list | `[]` |  |
 | fleet.queue.autoscaling.enabled | bool | `false` |  |
@@ -218,6 +219,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | fleet.redis.statefulSet.sidecars | list | `[]` |  |
 | fleet.redis.statefulSet.terminationGracePeriodSeconds | int | `30` |  |
 | fleet.redis.statefulSet.tolerations | list | `[]` |  |
+| fleet.redis.statefulSet.updateStrategy | object | `{}` | Optional StatefulSet update strategy for the in-chart Fleet Redis instance. Leave unset to keep the Kubernetes default RollingUpdate behavior. |
 | fleet.redis.statefulSet.volumeMounts | list | `[]` |  |
 | fleet.redis.statefulSet.volumes | list | `[]` |  |
 | fleetToolServer.autoscaling.createHpa | bool | `true` |  |
@@ -566,6 +568,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | insights.postgres.statefulSet.sidecars | list | `[]` |  |
 | insights.postgres.statefulSet.terminationGracePeriodSeconds | int | `30` |  |
 | insights.postgres.statefulSet.tolerations | list | `[]` |  |
+| insights.postgres.statefulSet.updateStrategy | object | `{}` | Optional StatefulSet update strategy for the in-chart Insights PostgreSQL instance. Leave unset to keep the Kubernetes default RollingUpdate behavior. |
 | insights.postgres.statefulSet.volumeMounts | list | `[]` |  |
 | insights.postgres.statefulSet.volumes | list | `[]` |  |
 | insights.queue.autoscaling.enabled | bool | `false` |  |
@@ -654,6 +657,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | insights.redis.statefulSet.sidecars | list | `[]` |  |
 | insights.redis.statefulSet.terminationGracePeriodSeconds | int | `30` |  |
 | insights.redis.statefulSet.tolerations | list | `[]` |  |
+| insights.redis.statefulSet.updateStrategy | object | `{}` | Optional StatefulSet update strategy for the in-chart Insights Redis instance. Leave unset to keep the Kubernetes default RollingUpdate behavior. |
 | insights.redis.statefulSet.volumeMounts | list | `[]` |  |
 | insights.redis.statefulSet.volumes | list | `[]` |  |
 | istioGateway.annotations | object | `{}` |  |
@@ -762,6 +766,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | polly.postgres.statefulSet.sidecars | list | `[]` |  |
 | polly.postgres.statefulSet.terminationGracePeriodSeconds | int | `30` |  |
 | polly.postgres.statefulSet.tolerations | list | `[]` |  |
+| polly.postgres.statefulSet.updateStrategy | object | `{}` | Optional StatefulSet update strategy for the in-chart Polly PostgreSQL instance. Leave unset to keep the Kubernetes default RollingUpdate behavior. |
 | polly.postgres.statefulSet.volumeMounts | list | `[]` |  |
 | polly.postgres.statefulSet.volumes | list | `[]` |  |
 | polly.queue.autoscaling.enabled | bool | `false` |  |
@@ -850,6 +855,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | polly.redis.statefulSet.sidecars | list | `[]` |  |
 | polly.redis.statefulSet.terminationGracePeriodSeconds | int | `30` |  |
 | polly.redis.statefulSet.tolerations | list | `[]` |  |
+| polly.redis.statefulSet.updateStrategy | object | `{}` | Optional StatefulSet update strategy for the in-chart Polly Redis instance. Leave unset to keep the Kubernetes default RollingUpdate behavior. |
 | polly.redis.statefulSet.volumeMounts | list | `[]` |  |
 | polly.redis.statefulSet.volumes | list | `[]` |  |
 
@@ -1982,6 +1988,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | postgres.statefulSet.terminationGracePeriodSeconds | int | `30` |  |
 | postgres.statefulSet.tolerations | list | `[]` |  |
 | postgres.statefulSet.topologySpreadConstraints | list | `[]` |  |
+| postgres.statefulSet.updateStrategy | object | `{}` | Optional StatefulSet update strategy for the in-chart PostgreSQL instance. Leave unset to keep the Kubernetes default RollingUpdate behavior. |
 | postgres.statefulSet.volumeMounts | list | `[]` |  |
 | postgres.statefulSet.volumes | list | `[]` |  |
 
@@ -2142,6 +2149,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | redis.statefulSet.terminationGracePeriodSeconds | int | `30` |  |
 | redis.statefulSet.tolerations | list | `[]` |  |
 | redis.statefulSet.topologySpreadConstraints | list | `[]` |  |
+| redis.statefulSet.updateStrategy | object | `{}` | Optional StatefulSet update strategy for the in-chart Redis instance. Leave unset to keep the Kubernetes default RollingUpdate behavior. |
 | redis.statefulSet.volumeMounts | list | `[]` |  |
 | redis.statefulSet.volumes | list | `[]` |  |
 

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1304,6 +1304,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | clickhouse.statefulSet.startupProbe.periodSeconds | int | `10` |  |
 | clickhouse.statefulSet.startupProbe.timeoutSeconds | int | `1` |  |
 | clickhouse.statefulSet.terminationGracePeriodSeconds | int | `30` |  |
+| clickhouse.statefulSet.updateStrategy | object | `{}` | Optional StatefulSet update strategy for the in-chart ClickHouse instance. Leave unset to keep the Kubernetes default RollingUpdate behavior. |
 | clickhouse.statefulSet.tolerations | list | `[]` |  |
 | clickhouse.statefulSet.topologySpreadConstraints | list | `[]` |  |
 | clickhouse.statefulSet.volumeMounts | list | `[]` |  |

--- a/charts/langsmith/templates/agent-features/fleet/postgres/statefulset.yaml
+++ b/charts/langsmith/templates/agent-features/fleet/postgres/statefulset.yaml
@@ -21,6 +21,10 @@ metadata:
 spec:
   serviceName: {{ $componentName }}
   replicas: 1
+  {{- with .Values.fleet.postgres.statefulSet.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "langsmith.selectorLabels" . | nindent 6 }}

--- a/charts/langsmith/templates/agent-features/fleet/redis/statefulset.yaml
+++ b/charts/langsmith/templates/agent-features/fleet/redis/statefulset.yaml
@@ -21,6 +21,10 @@ metadata:
 spec:
   serviceName: {{ $componentName }}
   replicas: 1
+  {{- with .Values.fleet.redis.statefulSet.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "langsmith.selectorLabels" . | nindent 6 }}

--- a/charts/langsmith/templates/agent-features/insights/postgres/statefulset.yaml
+++ b/charts/langsmith/templates/agent-features/insights/postgres/statefulset.yaml
@@ -21,6 +21,10 @@ metadata:
 spec:
   serviceName: {{ $componentName }}
   replicas: 1
+  {{- with .Values.insights.postgres.statefulSet.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "langsmith.selectorLabels" . | nindent 6 }}

--- a/charts/langsmith/templates/agent-features/insights/redis/statefulset.yaml
+++ b/charts/langsmith/templates/agent-features/insights/redis/statefulset.yaml
@@ -21,6 +21,10 @@ metadata:
 spec:
   serviceName: {{ $componentName }}
   replicas: 1
+  {{- with .Values.insights.redis.statefulSet.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "langsmith.selectorLabels" . | nindent 6 }}

--- a/charts/langsmith/templates/agent-features/polly/postgres/statefulset.yaml
+++ b/charts/langsmith/templates/agent-features/polly/postgres/statefulset.yaml
@@ -21,6 +21,10 @@ metadata:
 spec:
   serviceName: {{ $componentName }}
   replicas: 1
+  {{- with .Values.polly.postgres.statefulSet.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "langsmith.selectorLabels" . | nindent 6 }}

--- a/charts/langsmith/templates/agent-features/polly/redis/statefulset.yaml
+++ b/charts/langsmith/templates/agent-features/polly/redis/statefulset.yaml
@@ -21,6 +21,10 @@ metadata:
 spec:
   serviceName: {{ $componentName }}
   replicas: 1
+  {{- with .Values.polly.redis.statefulSet.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "langsmith.selectorLabels" . | nindent 6 }}

--- a/charts/langsmith/templates/clickhouse/stateful-set.yaml
+++ b/charts/langsmith/templates/clickhouse/stateful-set.yaml
@@ -42,6 +42,10 @@ metadata:
 spec:
   serviceName: {{ include "langsmith.fullname" . }}-{{ .Values.clickhouse.name }}
   replicas: 1
+  {{- with .Values.clickhouse.statefulSet.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "langsmith.selectorLabels" . | nindent 6 }}

--- a/charts/langsmith/templates/postgres/stateful-set.yaml
+++ b/charts/langsmith/templates/postgres/stateful-set.yaml
@@ -44,6 +44,10 @@ metadata:
 spec:
   serviceName: {{ include "langsmith.fullname" . }}-{{ .Values.postgres.name }}
   replicas: 1
+  {{- with .Values.postgres.statefulSet.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "langsmith.selectorLabels" . | nindent 6 }}

--- a/charts/langsmith/templates/redis/stateful-set.yaml
+++ b/charts/langsmith/templates/redis/stateful-set.yaml
@@ -22,6 +22,10 @@ metadata:
 spec:
   serviceName: {{ include "langsmith.fullname" . }}-{{ .Values.redis.name }}
   replicas: 1
+  {{- with .Values.redis.statefulSet.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "langsmith.selectorLabels" . | nindent 6 }}

--- a/charts/langsmith/tests/clickhouse_statefulset_test.yaml
+++ b/charts/langsmith/tests/clickhouse_statefulset_test.yaml
@@ -1,0 +1,16 @@
+suite: ClickHouse StatefulSet rendering
+templates:
+  - clickhouse/stateful-set.yaml
+tests:
+  - it: does not render updateStrategy by default
+    asserts:
+      - notExists:
+          path: spec.updateStrategy
+
+  - it: renders a configured ClickHouse updateStrategy
+    set:
+      clickhouse.statefulSet.updateStrategy.type: OnDelete
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: OnDelete

--- a/charts/langsmith/tests/clickhouse_statefulset_test.yaml
+++ b/charts/langsmith/tests/clickhouse_statefulset_test.yaml
@@ -1,13 +1,17 @@
 suite: ClickHouse StatefulSet rendering
 templates:
   - clickhouse/stateful-set.yaml
+  # config-map.yaml is loaded so the StatefulSet's checksum/config `include` resolves.
+  - clickhouse/config-map.yaml
 tests:
   - it: does not render updateStrategy by default
+    template: clickhouse/stateful-set.yaml
     asserts:
       - notExists:
           path: spec.updateStrategy
 
   - it: renders a configured ClickHouse updateStrategy
+    template: clickhouse/stateful-set.yaml
     set:
       clickhouse.statefulSet.updateStrategy.type: OnDelete
     asserts:

--- a/charts/langsmith/tests/statefulset_update_strategy_test.yaml
+++ b/charts/langsmith/tests/statefulset_update_strategy_test.yaml
@@ -1,0 +1,148 @@
+suite: StatefulSet updateStrategy rendering
+templates:
+  - redis/stateful-set.yaml
+  - postgres/stateful-set.yaml
+  - agent-features/insights/redis/statefulset.yaml
+  - agent-features/insights/postgres/statefulset.yaml
+  - agent-features/fleet/redis/statefulset.yaml
+  - agent-features/fleet/postgres/statefulset.yaml
+  - agent-features/polly/redis/statefulset.yaml
+  - agent-features/polly/postgres/statefulset.yaml
+tests:
+  # --- redis ---
+  - it: redis does not render updateStrategy by default
+    template: redis/stateful-set.yaml
+    asserts:
+      - notExists:
+          path: spec.updateStrategy
+  - it: redis renders a configured updateStrategy
+    template: redis/stateful-set.yaml
+    set:
+      redis.statefulSet.updateStrategy.type: OnDelete
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: OnDelete
+
+  # --- postgres ---
+  - it: postgres does not render updateStrategy by default
+    template: postgres/stateful-set.yaml
+    asserts:
+      - notExists:
+          path: spec.updateStrategy
+  - it: postgres renders a configured updateStrategy
+    template: postgres/stateful-set.yaml
+    set:
+      postgres.statefulSet.updateStrategy.type: OnDelete
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: OnDelete
+
+  # --- insights redis ---
+  - it: insights redis does not render updateStrategy by default
+    template: agent-features/insights/redis/statefulset.yaml
+    set:
+      insights.enabled: true
+    asserts:
+      - notExists:
+          path: spec.updateStrategy
+  - it: insights redis renders a configured updateStrategy
+    template: agent-features/insights/redis/statefulset.yaml
+    set:
+      insights.enabled: true
+      insights.redis.statefulSet.updateStrategy.type: OnDelete
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: OnDelete
+
+  # --- insights postgres ---
+  - it: insights postgres does not render updateStrategy by default
+    template: agent-features/insights/postgres/statefulset.yaml
+    set:
+      insights.enabled: true
+    asserts:
+      - notExists:
+          path: spec.updateStrategy
+  - it: insights postgres renders a configured updateStrategy
+    template: agent-features/insights/postgres/statefulset.yaml
+    set:
+      insights.enabled: true
+      insights.postgres.statefulSet.updateStrategy.type: OnDelete
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: OnDelete
+
+  # --- fleet redis ---
+  - it: fleet redis does not render updateStrategy by default
+    template: agent-features/fleet/redis/statefulset.yaml
+    set:
+      fleet.enabled: true
+    asserts:
+      - notExists:
+          path: spec.updateStrategy
+  - it: fleet redis renders a configured updateStrategy
+    template: agent-features/fleet/redis/statefulset.yaml
+    set:
+      fleet.enabled: true
+      fleet.redis.statefulSet.updateStrategy.type: OnDelete
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: OnDelete
+
+  # --- fleet postgres ---
+  - it: fleet postgres does not render updateStrategy by default
+    template: agent-features/fleet/postgres/statefulset.yaml
+    set:
+      fleet.enabled: true
+    asserts:
+      - notExists:
+          path: spec.updateStrategy
+  - it: fleet postgres renders a configured updateStrategy
+    template: agent-features/fleet/postgres/statefulset.yaml
+    set:
+      fleet.enabled: true
+      fleet.postgres.statefulSet.updateStrategy.type: OnDelete
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: OnDelete
+
+  # --- polly redis ---
+  - it: polly redis does not render updateStrategy by default
+    template: agent-features/polly/redis/statefulset.yaml
+    set:
+      polly.enabled: true
+    asserts:
+      - notExists:
+          path: spec.updateStrategy
+  - it: polly redis renders a configured updateStrategy
+    template: agent-features/polly/redis/statefulset.yaml
+    set:
+      polly.enabled: true
+      polly.redis.statefulSet.updateStrategy.type: OnDelete
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: OnDelete
+
+  # --- polly postgres ---
+  - it: polly postgres does not render updateStrategy by default
+    template: agent-features/polly/postgres/statefulset.yaml
+    set:
+      polly.enabled: true
+    asserts:
+      - notExists:
+          path: spec.updateStrategy
+  - it: polly postgres renders a configured updateStrategy
+    template: agent-features/polly/postgres/statefulset.yaml
+    set:
+      polly.enabled: true
+      polly.postgres.statefulSet.updateStrategy.type: OnDelete
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: OnDelete

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1454,6 +1454,9 @@ clickhouse:
   statefulSet:
     labels: {}
     annotations: {}
+    # -- Optional StatefulSet update strategy for the in-chart ClickHouse instance.
+    # -- Leave unset to keep the Kubernetes default RollingUpdate behavior.
+    updateStrategy: {}
     podSecurityContext: {}
     securityContext: {}
     lifecycle: {}

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -291,6 +291,9 @@ fleet:
       connectionUrl: ""
       existingSecretName: ""
     statefulSet:
+      # -- Optional StatefulSet update strategy for the in-chart Fleet PostgreSQL instance.
+      # Leave unset to keep the Kubernetes default RollingUpdate behavior.
+      updateStrategy: {}
       labels: {}
       annotations: {}
       podSecurityContext: {}
@@ -335,6 +338,9 @@ fleet:
       connectionUrl: ""
       existingSecretName: ""
     statefulSet:
+      # -- Optional StatefulSet update strategy for the in-chart Fleet Redis instance.
+      # Leave unset to keep the Kubernetes default RollingUpdate behavior.
+      updateStrategy: {}
       labels: {}
       annotations: {}
       podSecurityContext: {}
@@ -522,6 +528,9 @@ insights:
       connectionUrl: ""
       existingSecretName: ""
     statefulSet:
+      # -- Optional StatefulSet update strategy for the in-chart Insights PostgreSQL instance.
+      # Leave unset to keep the Kubernetes default RollingUpdate behavior.
+      updateStrategy: {}
       labels: {}
       annotations: {}
       podSecurityContext: {}
@@ -566,6 +575,9 @@ insights:
       connectionUrl: ""
       existingSecretName: ""
     statefulSet:
+      # -- Optional StatefulSet update strategy for the in-chart Insights Redis instance.
+      # Leave unset to keep the Kubernetes default RollingUpdate behavior.
+      updateStrategy: {}
       labels: {}
       annotations: {}
       podSecurityContext: {}
@@ -752,6 +764,9 @@ polly:
       connectionUrl: ""
       existingSecretName: ""
     statefulSet:
+      # -- Optional StatefulSet update strategy for the in-chart Polly PostgreSQL instance.
+      # Leave unset to keep the Kubernetes default RollingUpdate behavior.
+      updateStrategy: {}
       labels: {}
       annotations: {}
       podSecurityContext: {}
@@ -796,6 +811,9 @@ polly:
       connectionUrl: ""
       existingSecretName: ""
     statefulSet:
+      # -- Optional StatefulSet update strategy for the in-chart Polly Redis instance.
+      # Leave unset to keep the Kubernetes default RollingUpdate behavior.
+      updateStrategy: {}
       labels: {}
       annotations: {}
       podSecurityContext: {}
@@ -2327,6 +2345,9 @@ postgres:
       keySecretKey: "tls.key"
   containerPort: 5432
   statefulSet:
+    # -- Optional StatefulSet update strategy for the in-chart PostgreSQL instance.
+    # Leave unset to keep the Kubernetes default RollingUpdate behavior.
+    updateStrategy: {}
     labels: {}
     annotations: {}
     podSecurityContext: {}
@@ -2646,6 +2667,9 @@ redis:
       tlsEnabled: true
   containerPort: 6379
   statefulSet:
+    # -- Optional StatefulSet update strategy for the in-chart Redis instance.
+    # Leave unset to keep the Kubernetes default RollingUpdate behavior.
+    updateStrategy: {}
     labels: {}
     annotations: {}
     podSecurityContext: {}


### PR DESCRIPTION
## Summary

Expose `clickhouse.statefulSet.updateStrategy` in the LangSmith chart so self-hosted users can opt into StatefulSet update strategies such as `OnDelete` for the in-chart ClickHouse instance.

## Changes

- add `clickhouse.statefulSet.updateStrategy` to `values.yaml`
- render `spec.updateStrategy` in the ClickHouse StatefulSet only when explicitly configured
- add a chart unittest covering default and configured rendering
- document the new value in the generated chart README

## Validation

- rendered the chart with a minimal self-hosted values file and confirmed the ClickHouse StatefulSet does not include `spec.updateStrategy` by default
- rendered the chart with `clickhouse.statefulSet.updateStrategy.type=OnDelete` and confirmed the ClickHouse StatefulSet includes `spec.updateStrategy.type=OnDelete`

## Motivation

This helps self-hosted users who want to keep using the chart-managed ClickHouse instance, while avoiding automatic ClickHouse pod restarts during Helm upgrades that only change the StatefulSet template.

For single-replica ClickHouse deployments, making `updateStrategy` configurable allows operators to opt into `OnDelete` and control pod rollover explicitly when needed.

Closes #753