### PR TITLE
feat(langgraph-cloud): add config.skipValidation flag

### DIFF
--- a/charts/langgraph-cloud/Chart.yaml
+++ b/charts/langgraph-cloud/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the LangGraph Cloud application and all services it depends on.
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "0.2.3"

--- a/charts/langgraph-cloud/README.md
+++ b/charts/langgraph-cloud/README.md
@@ -502,6 +502,7 @@ If you are upgrading from a chart revision that used the old flat MongoDB values
 | config.httpMaxRequestBodyBytes | string | `""` | Set this to override the default limit. Requests exceeding this limit receive HTTP 413. |
 | config.langGraphCloudLicenseKey | string | `""` | Optional LangGraph Cloud license key loaded from the chart secret. |
 | config.numberOfJobsPerWorker | int | `10` |  |
+| config.skipValidation | bool | `false` | Skip chart validation checks (ingress/gateway mutual-exclusion and MongoDB config guards). Used for helm template verification (e.g. AWS Marketplace). |
 
 ## Api Server
 

--- a/charts/langgraph-cloud/templates/_helpers.tpl
+++ b/charts/langgraph-cloud/templates/_helpers.tpl
@@ -152,8 +152,10 @@ MongoDB connection URL used by the chart-managed checkpointer default.
 
 {{/*
 Validates MongoDB provisioning and default-checkpointer settings.
+Set config.skipValidation to true to bypass these checks (e.g. for helm template verification).
 */}}
 {{- define "langGraphCloud.validateMongoConfiguration" -}}
+{{- if not .Values.config.skipValidation -}}
 {{- if and (hasKey .Values.mongo "resources") (not (empty .Values.mongo.resources)) -}}
 {{- fail "mongo.resources has moved to mongo.statefulSet.resources; update your values file to use the new path" -}}
 {{- end -}}
@@ -169,6 +171,7 @@ Validates MongoDB provisioning and default-checkpointer settings.
 {{- if and .Values.mongo.enabled (not .Values.mongo.external.enabled) (empty .Values.mongo.statefulSet.persistence.size) -}}
 {{- fail "mongo.statefulSet.persistence.size must be set when mongo.enabled=true and using the bundled MongoDB instance" -}}
 {{- end -}}
+{{- end -}}{{- /* end skipValidation */ -}}
 {{- end }}
 
 {{/*
@@ -221,8 +224,11 @@ Environment variables used to default agent server checkpointers without overrid
 
 {{/*
 Validates that at most one ingress mechanism is enabled and that required fields are set.
+Set config.skipValidation to true to bypass these checks (e.g. for Ingress + Gateway
+coexistence or helm template verification).
 */}}
 {{- define "langGraphCloud.validateIngress" -}}
+{{- if not .Values.config.skipValidation -}}
 {{- $enabledCount := 0 -}}
 {{- if .Values.ingress.enabled }}{{ $enabledCount = add1 $enabledCount }}{{- end -}}
 {{- if .Values.gateway.enabled }}{{ $enabledCount = add1 $enabledCount }}{{- end -}}
@@ -239,6 +245,7 @@ Validates that at most one ingress mechanism is enabled and that required fields
 {{- if and .Values.ingress.enabled (empty .Values.ingress.hostname) }}
 {{- fail "ingress.hostname must be set when ingress.enabled=true" -}}
 {{- end -}}
+{{- end -}}{{- /* end skipValidation */ -}}
 {{- end -}}
 
 {{/*

--- a/charts/langgraph-cloud/tests/validate_test.yaml
+++ b/charts/langgraph-cloud/tests/validate_test.yaml
@@ -1,0 +1,77 @@
+suite: Validation guards (config.skipValidation)
+templates:
+  - ingress.yaml
+  - api-server/deployment.yaml
+tests:
+  - it: should fail when more than one ingress mechanism is enabled
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.hostname: api.example.com
+      gateway.enabled: true
+      gateway.name: my-gateway
+    asserts:
+      - failedTemplate:
+          errorMessage: "Only one of ingress, gateway, or istioGateway can be enabled at the same time."
+
+  - it: should bypass the ingress mutual-exclusion guard when skipValidation is true
+    template: ingress.yaml
+    set:
+      config.skipValidation: true
+      ingress.enabled: true
+      ingress.hostname: api.example.com
+      gateway.enabled: true
+      gateway.name: my-gateway
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+
+  - it: should fail when ingress is enabled without a hostname
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.hostname must be set when ingress.enabled=true"
+
+  - it: should bypass the ingress hostname guard when skipValidation is true
+    template: ingress.yaml
+    set:
+      config.skipValidation: true
+      ingress.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+
+  - it: should fail when gateway is enabled without a name
+    template: ingress.yaml
+    set:
+      gateway.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.name must be set when gateway.enabled=true"
+
+  - it: should fail when mongo.external.enabled without mongo.enabled
+    template: api-server/deployment.yaml
+    set:
+      mongo.enabled: false
+      mongo.external.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "mongo.external.enabled requires mongo.enabled=true"
+
+  - it: should bypass the MongoDB configuration guard when skipValidation is true
+    template: api-server/deployment.yaml
+    set:
+      config.skipValidation: true
+      mongo.enabled: false
+      mongo.external.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment

--- a/charts/langgraph-cloud/values.yaml
+++ b/charts/langgraph-cloud/values.yaml
@@ -49,6 +49,8 @@ images:
     tag: "7"
 
 config:
+  # -- Skip chart validation checks (ingress/gateway mutual-exclusion and MongoDB config guards). Used for helm template verification (e.g. AWS Marketplace).
+  skipValidation: false
   existingSecretName: ""
   # -- Optional LangGraph Cloud license key loaded from the chart secret.
   langGraphCloudLicenseKey: ""


### PR DESCRIPTION
## Summary

Adds a `config.skipValidation` escape hatch to the langgraph-cloud chart, mirroring the LangSmith chart's flag. When set to `true`, it bypasses both chart validation helpers:

- **`validateIngress`** — the `ingress`/`gateway`/`istioGateway` mutual-exclusion guard plus the required-field checks. This unblocks Ingress + Gateway (HTTPRoute) coexistence — they are separate APIs that can both point at the same backend Service.
- **`validateMongoConfiguration`** — the deprecation and required-field checks, enabling `helm template` verification (e.g. AWS Marketplace).

Defaults to `false`, so existing behavior is unchanged.

## Changes

- `templates/_helpers.tpl`: wrap both validation helpers in `{{- if not .Values.config.skipValidation -}}`.
- `values.yaml`: add documented `config.skipValidation: false`.
- `README.md`: regenerated via `helm-docs`.
- `tests/validate_test.yaml`: new `helm-unittest` suite covering both guard failures and the skipValidation bypass.
- `Chart.yaml`: `0.3.1` → `0.3.2`.

## Testing

- `helm lint charts/langgraph-cloud` — clean.
- `helm unittest charts/langgraph-cloud` — 30 passed (23 existing + 7 new).
- `helm template` matrix: guards still fire with `skipValidation=false`; bypassed with `skipValidation=true`.

Linear: [INF-2263](https://linear.app/langchain/issue/INF-2263/langgraph-cloud-helm-add-skipvalidation-flag-parity-with-langsmith)