### PR TITLE
fix: route pairwise annotation queues to platform backend in self-hosted

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.15.7
+version: 0.15.8
 appVersion: "0.15.13"

--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -182,6 +182,15 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
 
+        location /{{ .Values.config.basePath }}/api/v1/annotation-queues/pairwise {
+            rewrite /{{ .Values.config.basePath }}/api/v1/(.*) /$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
         location = /{{ .Values.config.basePath }}/api/v1/runs/multipart {
             rewrite /{{ .Values.config.basePath }}/api/v1/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
@@ -689,6 +698,15 @@ data:
 
         location /api/v1/fleet/ {
             rewrite /api/v1/fleet/(.*) /v1/fleet/$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        location /api/v1/annotation-queues/pairwise {
+            rewrite /api/v1/(.*) /$1  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
             proxy_buffering off;


### PR DESCRIPTION
## Description
Pairwise annotation queues are served only by the Go platform backend, but `charts/langsmith/templates/frontend/config-map.yaml` had no `annotation-queues` location block, so `/api/v1/annotation-queues/pairwise` fell through the generic `location /api/v1` catch-all to the Python backend and 405'd. This adds a more-specific `location /api/v1/annotation-queues/pairwise` block (in both `config.basePath` variants) that strips the `/api/v1` prefix to a bare path and proxies to the platform backend upstream, matching the bare-path Go routes (e.g. oauth). Companion to langchainplus PR #26852.

## Release Note
Fix 405 on pairwise annotation queue creation in self-hosted Kubernetes deployments by routing `/api/v1/annotation-queues/pairwise` to the Go platform backend.

## Test Plan
- [x] `helm template` both basePath variants render a valid `location /api/v1/annotation-queues/pairwise` block proxying to the platform backend (verified locally).

Made by [Open SWE](https://openswe.vercel.app)