### PR TITLE
fix: cherry-pick pairwise annotation queue routing into v15-stable

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.15.2
+version: 0.15.3
 appVersion: "0.15.9"

--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -182,6 +182,15 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
 
+        location /{{ .Values.config.basePath }}/api/v1/annotation-queues/pairwise {
+            rewrite /{{ .Values.config.basePath }}/api/v1/(.*) /$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
         location = /{{ .Values.config.basePath }}/api/v1/runs/multipart {
             rewrite /{{ .Values.config.basePath }}/api/v1/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
@@ -680,6 +689,15 @@ data:
 
         location /api/v1/fleet/ {
             rewrite /api/v1/fleet/(.*) /v1/fleet/$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        location /api/v1/annotation-queues/pairwise {
+            rewrite /api/v1/(.*) /$1  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
             proxy_buffering off;


### PR DESCRIPTION
## Description
Cherry-picks the fix from #758 onto `v15-stable`, adding the `/api/v1/annotation-queues/pairwise` location block that proxies pairwise annotation queue requests to the Go platform backend. The chart version is bumped to 0.15.3 (next patch on the v15-stable line, since this branch was at 0.15.2 rather than main's version).

## Release Note
Route pairwise annotation queues to the platform backend in self-hosted deployments.

## Test Plan
- [ ] Render the langsmith chart and confirm the new `/api/v1/annotation-queues/pairwise` nginx location proxies to the platform backend.

Made by [Open SWE](https://openswe.vercel.app)