### PR TITLE
feat(langsmith): expose remote MCP server + OAuth AS under /api

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.15.3
+version: 0.15.4
 appVersion: "0.15.9"

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -974,6 +974,18 @@ which default to http:// for local development.
 {{- end -}}
 
 {{/*
+OAuth issuer URL advertised by the remote MCP server / OAuth Authorization Server.
+Defaults to <hostnameWithProtocol>[/basePath]/api; overridable via config.remoteMcp.issuer.
+*/}}
+{{- define "langsmith.remoteMcpIssuer" -}}
+{{- if .Values.config.remoteMcp.issuer -}}
+{{- .Values.config.remoteMcp.issuer -}}
+{{- else -}}
+{{- include "langsmith.hostnameWithProtocol" . }}{{- with .Values.config.basePath }}/{{ . }}{{- end }}/api
+{{- end -}}
+{{- end -}}
+
+{{/*
 Public URL for the default Agent Builder MCP server.
 Served through the frontend at /mcp (or /<basePath>/mcp).
 */}}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -974,12 +974,12 @@ which default to http:// for local development.
 {{- end -}}
 
 {{/*
-OAuth issuer URL advertised by the remote MCP server / OAuth Authorization Server.
-Defaults to <hostnameWithProtocol>[/basePath]/api; overridable via config.remoteMcp.issuer.
+OAuth Authorization Server issuer URL advertised to remote MCP clients.
+Defaults to <hostnameWithProtocol>[/basePath]/api; overridable via config.oauthAsIssuer.
 */}}
-{{- define "langsmith.remoteMcpIssuer" -}}
-{{- if .Values.config.remoteMcp.issuer -}}
-{{- .Values.config.remoteMcp.issuer -}}
+{{- define "langsmith.oauthAsIssuer" -}}
+{{- if .Values.config.oauthAsIssuer -}}
+{{- .Values.config.oauthAsIssuer -}}
 {{- else -}}
 {{- include "langsmith.hostnameWithProtocol" . }}{{- with .Values.config.basePath }}/{{ . }}{{- end }}/api
 {{- end -}}

--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -47,6 +47,9 @@ data:
   OAUTH_AS_ENABLED: "true"
   OAUTH_AS_ISSUER: {{ include "langsmith.oauthAsIssuer" . | quote }}
   {{- end }}
+  {{- if .Values.config.llmAuthProxyIssuer }}
+  LLM_AUTH_PROXY_ISSUER: {{ .Values.config.llmAuthProxyIssuer | quote }}
+  {{- end }}
   {{- if and .Values.fleet.enabled .Values.fleetTriggerServer.enabled }}
   MCP_SERVER_URL: "http://{{ include "langsmith.fullname" . }}-{{ .Values.fleetToolServer.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.fleetToolServer.service.port }}"
   {{- end }}

--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -40,9 +40,10 @@ data:
   SMITH_BACKEND_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.backend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.backend.service.port }}"
   HOST_BACKEND_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.hostBackend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.hostBackend.service.port }}"
   LANGSMITH_AUTH_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }}"
-  {{- if .Values.config.signingJwks }}
-  # Remote MCP server / OAuth Authorization Server (served under /api). Enabled when
-  # config.signingJwks is set; routes are added in the frontend nginx config.
+  {{- if .Values.config.hostname }}
+  # Remote MCP server / OAuth Authorization Server (served under /api). The AS only
+  # activates when a signing JWKS is present (langsmith_signing_jwks in the secret);
+  # without it these are inert. Routes are added in the frontend nginx config.
   OAUTH_AS_ENABLED: "true"
   OAUTH_AS_ISSUER: {{ include "langsmith.oauthAsIssuer" . | quote }}
   {{- end }}

--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -40,6 +40,12 @@ data:
   SMITH_BACKEND_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.backend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.backend.service.port }}"
   HOST_BACKEND_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.hostBackend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.hostBackend.service.port }}"
   LANGSMITH_AUTH_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }}"
+  {{- if .Values.config.remoteMcp.signingJwks }}
+  # Remote MCP server / OAuth Authorization Server (served under /api). Enabled when
+  # config.remoteMcp.signingJwks is set; routes are added in the frontend nginx config.
+  OAUTH_AS_ENABLED: "true"
+  OAUTH_AS_ISSUER: {{ include "langsmith.remoteMcpIssuer" . | quote }}
+  {{- end }}
   {{- if and .Values.fleet.enabled .Values.fleetTriggerServer.enabled }}
   MCP_SERVER_URL: "http://{{ include "langsmith.fullname" . }}-{{ .Values.fleetToolServer.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.fleetToolServer.service.port }}"
   {{- end }}

--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -40,11 +40,11 @@ data:
   SMITH_BACKEND_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.backend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.backend.service.port }}"
   HOST_BACKEND_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.hostBackend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.hostBackend.service.port }}"
   LANGSMITH_AUTH_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }}"
-  {{- if .Values.config.remoteMcp.signingJwks }}
+  {{- if .Values.config.signingJwks }}
   # Remote MCP server / OAuth Authorization Server (served under /api). Enabled when
-  # config.remoteMcp.signingJwks is set; routes are added in the frontend nginx config.
+  # config.signingJwks is set; routes are added in the frontend nginx config.
   OAUTH_AS_ENABLED: "true"
-  OAUTH_AS_ISSUER: {{ include "langsmith.remoteMcpIssuer" . | quote }}
+  OAUTH_AS_ISSUER: {{ include "langsmith.oauthAsIssuer" . | quote }}
   {{- end }}
   {{- if and .Values.fleet.enabled .Values.fleetTriggerServer.enabled }}
   MCP_SERVER_URL: "http://{{ include "langsmith.fullname" . }}-{{ .Values.fleetToolServer.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.fleetToolServer.service.port }}"

--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -299,7 +299,7 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
 
-    {{- if .Values.config.signingJwks }}
+    {{- if .Values.config.hostname }}
         # Remote MCP server (OAuth-protected) under /api -> platform-backend.
         # OAuth 2.1 discovery (RFC 8414 / RFC 9728), token endpoints, and the MCP JSON-RPC endpoint.
         # RFC 8414 path-insertion form of the authorization-server metadata (clients try this first).
@@ -876,7 +876,7 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
 
-    {{- if .Values.config.signingJwks }}
+    {{- if .Values.config.hostname }}
         # Remote MCP server (OAuth-protected) under /api -> platform-backend.
         # OAuth 2.1 discovery (RFC 8414 / RFC 9728), token endpoints, and the MCP JSON-RPC endpoint.
         # RFC 8414 path-insertion form of the authorization-server metadata (clients try this first).

--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -299,6 +299,70 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
 
+    {{- if .Values.config.remoteMcp.signingJwks }}
+        # Remote MCP server (OAuth-protected) under /api -> platform-backend.
+        # OAuth 2.1 discovery (RFC 8414 / RFC 9728), token endpoints, and the MCP JSON-RPC endpoint.
+        # RFC 8414 path-insertion form of the authorization-server metadata (clients try this first).
+        location = /.well-known/oauth-authorization-server/{{ .Values.config.basePath }}/api {
+            rewrite ^ /.well-known/oauth-authorization-server  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # Path-append form of the authorization-server metadata.
+        location = /{{ .Values.config.basePath }}/api/.well-known/oauth-authorization-server {
+            rewrite ^ /.well-known/oauth-authorization-server  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # Protected-resource metadata (the URL advertised in the MCP 401 WWW-Authenticate header).
+        location = /{{ .Values.config.basePath }}/api/.well-known/oauth-protected-resource/mcp {
+            rewrite ^ /.well-known/oauth-protected-resource/mcp  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # JWKS advertised under the /api issuer (jwks_uri).
+        location = /{{ .Values.config.basePath }}/api/.well-known/jwks.json {
+            rewrite ^ /.well-known/jwks.json  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # OAuth Authorization Server endpoints (authorize, token, register, revoke, device).
+        location /{{ .Values.config.basePath }}/api/oauth/ {
+            rewrite /{{ .Values.config.basePath }}/api/oauth/(.*) /oauth/$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # MCP JSON-RPC endpoint (kept distinct from the root /mcp fleet tool server).
+        location /{{ .Values.config.basePath }}/api/mcp {
+            rewrite /{{ .Values.config.basePath }}/api(/mcp.*) $1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+    {{- end }}
+
         # Backend Routes
         location /{{ .Values.config.basePath }}/api/v1 {
             rewrite /{{ .Values.config.basePath }}/api/v1/(.*) /api/v1/$1  break;
@@ -811,6 +875,70 @@ data:
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
+
+    {{- if .Values.config.remoteMcp.signingJwks }}
+        # Remote MCP server (OAuth-protected) under /api -> platform-backend.
+        # OAuth 2.1 discovery (RFC 8414 / RFC 9728), token endpoints, and the MCP JSON-RPC endpoint.
+        # RFC 8414 path-insertion form of the authorization-server metadata (clients try this first).
+        location = /.well-known/oauth-authorization-server/api {
+            rewrite ^ /.well-known/oauth-authorization-server  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # Path-append form of the authorization-server metadata.
+        location = /api/.well-known/oauth-authorization-server {
+            rewrite ^ /.well-known/oauth-authorization-server  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # Protected-resource metadata (the URL advertised in the MCP 401 WWW-Authenticate header).
+        location = /api/.well-known/oauth-protected-resource/mcp {
+            rewrite ^ /.well-known/oauth-protected-resource/mcp  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # JWKS advertised under the /api issuer (jwks_uri).
+        location = /api/.well-known/jwks.json {
+            rewrite ^ /.well-known/jwks.json  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # OAuth Authorization Server endpoints (authorize, token, register, revoke, device).
+        location /api/oauth/ {
+            rewrite /api/oauth/(.*) /oauth/$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # MCP JSON-RPC endpoint (kept distinct from the root /mcp fleet tool server).
+        location /api/mcp {
+            rewrite /api(/mcp.*) $1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+    {{- end }}
 
         # Backend Routes
         location /api/v1 {

--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -299,7 +299,7 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
 
-    {{- if .Values.config.remoteMcp.signingJwks }}
+    {{- if .Values.config.signingJwks }}
         # Remote MCP server (OAuth-protected) under /api -> platform-backend.
         # OAuth 2.1 discovery (RFC 8414 / RFC 9728), token endpoints, and the MCP JSON-RPC endpoint.
         # RFC 8414 path-insertion form of the authorization-server metadata (clients try this first).
@@ -876,7 +876,7 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
 
-    {{- if .Values.config.remoteMcp.signingJwks }}
+    {{- if .Values.config.signingJwks }}
         # Remote MCP server (OAuth-protected) under /api -> platform-backend.
         # OAuth 2.1 discovery (RFC 8414 / RFC 9728), token endpoints, and the MCP JSON-RPC endpoint.
         # RFC 8414 path-insertion form of the authorization-server metadata (clients try this first).

--- a/charts/langsmith/templates/platform-backend/deployment.yaml
+++ b/charts/langsmith/templates/platform-backend/deployment.yaml
@@ -5,7 +5,7 @@
 - name: DOCS_PREFIX
   value: /{{ . }}/api
 {{- end }}
-{{- if .Values.config.remoteMcp.signingJwks }}
+{{- if .Values.config.signingJwks }}
 - name: LANGSMITH_SIGNING_JWKS
   valueFrom:
     secretKeyRef:

--- a/charts/langsmith/templates/platform-backend/deployment.yaml
+++ b/charts/langsmith/templates/platform-backend/deployment.yaml
@@ -5,6 +5,14 @@
 - name: DOCS_PREFIX
   value: /{{ . }}/api
 {{- end }}
+{{- if .Values.config.remoteMcp.signingJwks }}
+- name: LANGSMITH_SIGNING_JWKS
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "langsmith.secretsName" . }}
+      key: langsmith_signing_jwks
+      optional: {{ .Values.config.disableSecretCreation }}
+{{- end }}
 {{- end -}}
 {{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "platformBackendEnvVars" . | fromYamlArray) .Values.platformBackend.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}

--- a/charts/langsmith/templates/platform-backend/deployment.yaml
+++ b/charts/langsmith/templates/platform-backend/deployment.yaml
@@ -5,13 +5,23 @@
 - name: DOCS_PREFIX
   value: /{{ . }}/api
 {{- end }}
-{{- if .Values.config.signingJwks }}
+# Signing JWKS for the OAuth Authorization Server / remote MCP and the LLM auth
+# proxy. The chart owns this env (like api_key_salt) and sources it from the chart
+# secret (config.signingJwks) or config.existingSecretName; operators must not set
+# LANGSMITH_SIGNING_JWKS manually (enforced in validate.yaml). The skip-guard keeps a
+# manual override from tripping the generic duplicate-key error before validate.yaml
+# surfaces the clear message. The OAuth AS only activates when this key is present.
+{{- $providedEnv := list -}}
+{{- range concat (.Values.commonEnv | default (list)) (.Values.platformBackend.deployment.extraEnv | default (list)) -}}
+{{- $providedEnv = append $providedEnv .name -}}
+{{- end -}}
+{{- if not (has "LANGSMITH_SIGNING_JWKS" $providedEnv) }}
 - name: LANGSMITH_SIGNING_JWKS
   valueFrom:
     secretKeyRef:
       name: {{ include "langsmith.secretsName" . }}
       key: langsmith_signing_jwks
-      optional: {{ .Values.config.disableSecretCreation }}
+      optional: true
 {{- end }}
 {{- end -}}
 {{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "platformBackendEnvVars" . | fromYamlArray) .Values.platformBackend.deployment.extraEnv -}}

--- a/charts/langsmith/templates/secrets.yaml
+++ b/charts/langsmith/templates/secrets.yaml
@@ -13,7 +13,7 @@ data:
   oauth_client_id: {{ .Values.config.oauth.oauthClientId | b64enc | quote }}
   oauth_client_secret: {{ .Values.config.oauth.oauthClientSecret | b64enc | quote }}
   oauth_issuer_url: {{ .Values.config.oauth.oauthIssuerUrl | b64enc | quote }}
-  langsmith_signing_jwks: {{ .Values.config.remoteMcp.signingJwks | b64enc | quote }}
+  langsmith_signing_jwks: {{ .Values.config.signingJwks | b64enc | quote }}
   langsmith_license_key: {{ .Values.config.langsmithLicenseKey | b64enc | quote }}
   api_key_salt: {{ .Values.config.apiKeySalt | default .Values.config.langsmithLicenseKey | b64enc | quote }}
   jwt_secret: {{ .Values.config.basicAuth.jwtSecret | b64enc | quote }}

--- a/charts/langsmith/templates/secrets.yaml
+++ b/charts/langsmith/templates/secrets.yaml
@@ -13,6 +13,7 @@ data:
   oauth_client_id: {{ .Values.config.oauth.oauthClientId | b64enc | quote }}
   oauth_client_secret: {{ .Values.config.oauth.oauthClientSecret | b64enc | quote }}
   oauth_issuer_url: {{ .Values.config.oauth.oauthIssuerUrl | b64enc | quote }}
+  langsmith_signing_jwks: {{ .Values.config.remoteMcp.signingJwks | b64enc | quote }}
   langsmith_license_key: {{ .Values.config.langsmithLicenseKey | b64enc | quote }}
   api_key_salt: {{ .Values.config.apiKeySalt | default .Values.config.langsmithLicenseKey | b64enc | quote }}
   jwt_secret: {{ .Values.config.basicAuth.jwtSecret | b64enc | quote }}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -220,9 +220,9 @@ AWS Marketplace Helm template verification).
 {{- end -}}
 
 {{- /* Validate remote MCP / OAuth Authorization Server configuration */ -}}
-{{- if .Values.config.remoteMcp.signingJwks -}}
-{{- if and (not .Values.config.hostname) (not .Values.config.remoteMcp.issuer) -}}
-{{- fail "config.remoteMcp.signingJwks is set but no OAuth issuer can be derived. Set config.hostname (recommended) or config.remoteMcp.issuer explicitly." -}}
+{{- if .Values.config.signingJwks -}}
+{{- if and (not .Values.config.hostname) (not .Values.config.oauthAsIssuer) -}}
+{{- fail "config.signingJwks is set but no OAuth issuer can be derived. Set config.hostname (recommended) or config.oauthAsIssuer explicitly." -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -219,10 +219,12 @@ AWS Marketplace Helm template verification).
 {{- fail "config.polly is no longer supported (the bundled-agent bootstrap path was removed in chart 0.15.1). Use the top-level polly block: polly.enabled, polly.encryptionKey, etc." -}}
 {{- end -}}
 
-{{- /* Validate remote MCP / OAuth Authorization Server configuration */ -}}
-{{- if .Values.config.signingJwks -}}
-{{- if and (not .Values.config.hostname) (not .Values.config.oauthAsIssuer) -}}
-{{- fail "config.signingJwks is set but no OAuth issuer can be derived. Set config.hostname (recommended) or config.oauthAsIssuer explicitly." -}}
+{{- /* The chart owns LANGSMITH_SIGNING_JWKS (sourced from the signing JWKS secret).
+       Forbid operators from setting it manually via commonEnv/extraEnv so there is a
+       single source of truth and no duplicate env var. */ -}}
+{{- range concat (.Values.commonEnv | default (list)) (.Values.platformBackend.deployment.extraEnv | default (list)) -}}
+{{- if eq .name "LANGSMITH_SIGNING_JWKS" -}}
+{{- fail "Do not set LANGSMITH_SIGNING_JWKS manually in commonEnv / platformBackend.deployment.extraEnv. The chart provides it from the signing JWKS secret — put the JWKS at key 'langsmith_signing_jwks' in config.existingSecretName, or set config.signingJwks." -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -219,6 +219,13 @@ AWS Marketplace Helm template verification).
 {{- fail "config.polly is no longer supported (the bundled-agent bootstrap path was removed in chart 0.15.1). Use the top-level polly block: polly.enabled, polly.encryptionKey, etc." -}}
 {{- end -}}
 
+{{- /* Validate remote MCP / OAuth Authorization Server configuration */ -}}
+{{- if .Values.config.remoteMcp.signingJwks -}}
+{{- if and (not .Values.config.hostname) (not .Values.config.remoteMcp.issuer) -}}
+{{- fail "config.remoteMcp.signingJwks is set but no OAuth issuer can be derived. Set config.hostname (recommended) or config.remoteMcp.issuer explicitly." -}}
+{{- end -}}
+{{- end -}}
+
 {{- /* Validate autoscaling configuration for all services */ -}}
 {{- $autoscalingServices := dict
   "aceBackend" .Values.aceBackend.autoscaling

--- a/charts/langsmith/tests/remote_mcp_test.yaml
+++ b/charts/langsmith/tests/remote_mcp_test.yaml
@@ -50,6 +50,32 @@ tests:
           path: data.OAUTH_AS_ISSUER
           value: "https://langsmith.example.com/langsmith/api"
 
+  - it: emits LLM_AUTH_PROXY_ISSUER when configured
+    template: templates/config-map.yaml
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+      config.llmAuthProxyIssuer: "langsmith"
+    asserts:
+      - equal:
+          path: data.LLM_AUTH_PROXY_ISSUER
+          value: "langsmith"
+
+  - it: omits LLM_AUTH_PROXY_ISSUER when not configured
+    template: templates/config-map.yaml
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+    asserts:
+      - notExists:
+          path: data.LLM_AUTH_PROXY_ISSUER
+
   - it: omits OAUTH_AS env when no hostname is set
     template: templates/config-map.yaml
     set:

--- a/charts/langsmith/tests/remote_mcp_test.yaml
+++ b/charts/langsmith/tests/remote_mcp_test.yaml
@@ -5,8 +5,8 @@ set:
   insights.enabled: false
   polly.enabled: false
 tests:
-  # --- Shared config (env) ---
-  - it: sets OAUTH_AS env when signingJwks is provided
+  # --- Shared config (env): OAuth AS is enabled whenever a hostname is set ---
+  - it: sets OAUTH_AS env when a hostname is configured
     template: templates/config-map.yaml
     set:
       config.langsmithLicenseKey: "lic"
@@ -14,7 +14,6 @@ tests:
       config.oauth.enabled: true
       config.authType: "oauth"
       config.hostname: "langsmith.example.com"
-      config.signingJwks: '{"keys":[{"kty":"OKP"}]}'
     asserts:
       - equal:
           path: data.OAUTH_AS_ENABLED
@@ -31,7 +30,6 @@ tests:
       config.oauth.enabled: true
       config.authType: "oauth"
       config.hostname: "langsmith.example.com"
-      config.signingJwks: '{"keys":[{"kty":"OKP"}]}'
       config.oauthAsIssuer: "https://mcp.example.com/api"
     asserts:
       - equal:
@@ -47,28 +45,84 @@ tests:
       config.authType: "oauth"
       config.hostname: "langsmith.example.com"
       config.basePath: "langsmith"
-      config.signingJwks: '{"keys":[{"kty":"OKP"}]}'
     asserts:
       - equal:
           path: data.OAUTH_AS_ISSUER
           value: "https://langsmith.example.com/langsmith/api"
 
-  - it: omits OAUTH_AS env when signingJwks is empty
+  - it: omits OAUTH_AS env when no hostname is set
     template: templates/config-map.yaml
     set:
-      config.langsmithLicenseKey: "lic"
-      config.apiKeySalt: "salt"
+      config.existingSecretName: "langsmith-existing-secrets"
       config.oauth.enabled: true
       config.authType: "oauth"
-      config.hostname: "langsmith.example.com"
     asserts:
       - notExists:
           path: data.OAUTH_AS_ENABLED
       - notExists:
           path: data.OAUTH_AS_ISSUER
 
-  # --- Secret ---
-  - it: stores the signing JWKS in the managed secret (base64)
+  # --- Signing JWKS env is always wired and optional (like api_key_salt) ---
+  - it: always wires LANGSMITH_SIGNING_JWKS optionally into platform-backend
+    template: templates/platform-backend/deployment.yaml
+    release:
+      name: ls
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+      # signingJwks intentionally not set — the env must still be wired, optionally.
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGSMITH_SIGNING_JWKS
+            valueFrom:
+              secretKeyRef:
+                name: ls-langsmith-secrets
+                key: langsmith_signing_jwks
+                optional: true
+
+  - it: fails when an operator sets LANGSMITH_SIGNING_JWKS manually via extraEnv
+    template: templates/validate.yaml
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+      platformBackend.deployment.extraEnv:
+        - name: LANGSMITH_SIGNING_JWKS
+          valueFrom:
+            secretKeyRef:
+              name: my-own-secret
+              key: langsmith_signing_jwks
+    asserts:
+      - failedTemplate:
+          errorMessage: "Do not set LANGSMITH_SIGNING_JWKS manually in commonEnv / platformBackend.deployment.extraEnv. The chart provides it from the signing JWKS secret — put the JWKS at key 'langsmith_signing_jwks' in config.existingSecretName, or set config.signingJwks."
+
+  - it: sources LANGSMITH_SIGNING_JWKS from config.existingSecretName when set
+    template: templates/platform-backend/deployment.yaml
+    set:
+      config.existingSecretName: "langsmith-existing-secrets"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGSMITH_SIGNING_JWKS
+            valueFrom:
+              secretKeyRef:
+                name: langsmith-existing-secrets
+                key: langsmith_signing_jwks
+                optional: true
+
+  # --- Chart-managed secret stores the inline value (like api_key_salt) ---
+  - it: stores the inline signing JWKS in the managed secret (base64)
     template: templates/secrets.yaml
     set:
       config.langsmithLicenseKey: "lic"
@@ -82,47 +136,8 @@ tests:
           path: data.langsmith_signing_jwks
           value: "YWJj" # base64("abc")
 
-  # --- platform-backend signing key env ---
-  - it: injects LANGSMITH_SIGNING_JWKS into platform-backend from the secret
-    template: templates/platform-backend/deployment.yaml
-    release:
-      name: ls
-    set:
-      config.langsmithLicenseKey: "lic"
-      config.apiKeySalt: "salt"
-      config.oauth.enabled: true
-      config.authType: "oauth"
-      config.hostname: "langsmith.example.com"
-      config.signingJwks: '{"keys":[{"kty":"OKP"}]}'
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: LANGSMITH_SIGNING_JWKS
-            valueFrom:
-              secretKeyRef:
-                name: ls-langsmith-secrets
-                key: langsmith_signing_jwks
-                optional: false
-
-  - it: omits LANGSMITH_SIGNING_JWKS when signingJwks is empty
-    template: templates/platform-backend/deployment.yaml
-    release:
-      name: ls
-    set:
-      config.langsmithLicenseKey: "lic"
-      config.apiKeySalt: "salt"
-      config.oauth.enabled: true
-      config.authType: "oauth"
-      config.hostname: "langsmith.example.com"
-    asserts:
-      - notContains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: LANGSMITH_SIGNING_JWKS
-
-  # --- nginx routing (no basePath) ---
-  - it: adds /api MCP + OAuth + well-known routes when enabled
+  # --- nginx routing follows hostname ---
+  - it: adds /api MCP + OAuth + well-known routes when a hostname is set
     template: templates/frontend/config-map.yaml
     set:
       frontend.enabled: true
@@ -131,7 +146,6 @@ tests:
       config.oauth.enabled: true
       config.authType: "oauth"
       config.hostname: "langsmith.example.com"
-      config.signingJwks: '{"keys":[{"kty":"OKP"}]}'
     asserts:
       - matchRegex:
           path: data["nginx.conf"]
@@ -146,15 +160,13 @@ tests:
           path: data["nginx.conf"]
           pattern: "location = /api/.well-known/oauth-protected-resource/mcp"
 
-  - it: omits the /api MCP routes when disabled
+  - it: omits the /api MCP routes when no hostname is set
     template: templates/frontend/config-map.yaml
     set:
       frontend.enabled: true
-      config.langsmithLicenseKey: "lic"
-      config.apiKeySalt: "salt"
+      config.existingSecretName: "langsmith-existing-secrets"
       config.oauth.enabled: true
       config.authType: "oauth"
-      config.hostname: "langsmith.example.com"
     asserts:
       - notMatchRegex:
           path: data["nginx.conf"]
@@ -163,7 +175,6 @@ tests:
           path: data["nginx.conf"]
           pattern: "oauth-authorization-server/api"
 
-  # --- nginx routing (basePath) ---
   - it: prefixes the /api MCP routes with basePath
     template: templates/frontend/config-map.yaml
     set:
@@ -174,7 +185,6 @@ tests:
       config.authType: "oauth"
       config.hostname: "langsmith.example.com"
       config.basePath: "langsmith"
-      config.signingJwks: '{"keys":[{"kty":"OKP"}]}'
     asserts:
       - matchRegex:
           path: data["nginx.conf"]
@@ -182,16 +192,3 @@ tests:
       - matchRegex:
           path: data["nginx.conf"]
           pattern: "location = /.well-known/oauth-authorization-server/langsmith/api"
-
-  # --- Validation guard ---
-  - it: fails when signingJwks is set but no issuer can be derived
-    template: templates/validate.yaml
-    set:
-      config.langsmithLicenseKey: "lic"
-      config.apiKeySalt: "salt"
-      config.oauth.enabled: true
-      config.authType: "oauth"
-      config.signingJwks: '{"keys":[{"kty":"OKP"}]}'
-    asserts:
-      - failedTemplate:
-          errorMessage: "config.signingJwks is set but no OAuth issuer can be derived. Set config.hostname (recommended) or config.oauthAsIssuer explicitly."

--- a/charts/langsmith/tests/remote_mcp_test.yaml
+++ b/charts/langsmith/tests/remote_mcp_test.yaml
@@ -6,7 +6,7 @@ set:
   polly.enabled: false
 tests:
   # --- Shared config (env) ---
-  - it: sets OAUTH_AS env when remoteMcp.signingJwks is provided
+  - it: sets OAUTH_AS env when signingJwks is provided
     template: templates/config-map.yaml
     set:
       config.langsmithLicenseKey: "lic"
@@ -14,7 +14,7 @@ tests:
       config.oauth.enabled: true
       config.authType: "oauth"
       config.hostname: "langsmith.example.com"
-      config.remoteMcp.signingJwks: '{"keys":[{"kty":"OKP"}]}'
+      config.signingJwks: '{"keys":[{"kty":"OKP"}]}'
     asserts:
       - equal:
           path: data.OAUTH_AS_ENABLED
@@ -31,8 +31,8 @@ tests:
       config.oauth.enabled: true
       config.authType: "oauth"
       config.hostname: "langsmith.example.com"
-      config.remoteMcp.signingJwks: '{"keys":[{"kty":"OKP"}]}'
-      config.remoteMcp.issuer: "https://mcp.example.com/api"
+      config.signingJwks: '{"keys":[{"kty":"OKP"}]}'
+      config.oauthAsIssuer: "https://mcp.example.com/api"
     asserts:
       - equal:
           path: data.OAUTH_AS_ISSUER
@@ -47,7 +47,7 @@ tests:
       config.authType: "oauth"
       config.hostname: "langsmith.example.com"
       config.basePath: "langsmith"
-      config.remoteMcp.signingJwks: '{"keys":[{"kty":"OKP"}]}'
+      config.signingJwks: '{"keys":[{"kty":"OKP"}]}'
     asserts:
       - equal:
           path: data.OAUTH_AS_ISSUER
@@ -76,7 +76,7 @@ tests:
       config.oauth.enabled: true
       config.authType: "oauth"
       config.hostname: "langsmith.example.com"
-      config.remoteMcp.signingJwks: "abc"
+      config.signingJwks: "abc"
     asserts:
       - equal:
           path: data.langsmith_signing_jwks
@@ -93,7 +93,7 @@ tests:
       config.oauth.enabled: true
       config.authType: "oauth"
       config.hostname: "langsmith.example.com"
-      config.remoteMcp.signingJwks: '{"keys":[{"kty":"OKP"}]}'
+      config.signingJwks: '{"keys":[{"kty":"OKP"}]}'
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -131,7 +131,7 @@ tests:
       config.oauth.enabled: true
       config.authType: "oauth"
       config.hostname: "langsmith.example.com"
-      config.remoteMcp.signingJwks: '{"keys":[{"kty":"OKP"}]}'
+      config.signingJwks: '{"keys":[{"kty":"OKP"}]}'
     asserts:
       - matchRegex:
           path: data["nginx.conf"]
@@ -174,7 +174,7 @@ tests:
       config.authType: "oauth"
       config.hostname: "langsmith.example.com"
       config.basePath: "langsmith"
-      config.remoteMcp.signingJwks: '{"keys":[{"kty":"OKP"}]}'
+      config.signingJwks: '{"keys":[{"kty":"OKP"}]}'
     asserts:
       - matchRegex:
           path: data["nginx.conf"]
@@ -191,7 +191,7 @@ tests:
       config.apiKeySalt: "salt"
       config.oauth.enabled: true
       config.authType: "oauth"
-      config.remoteMcp.signingJwks: '{"keys":[{"kty":"OKP"}]}'
+      config.signingJwks: '{"keys":[{"kty":"OKP"}]}'
     asserts:
       - failedTemplate:
-          errorMessage: "config.remoteMcp.signingJwks is set but no OAuth issuer can be derived. Set config.hostname (recommended) or config.remoteMcp.issuer explicitly."
+          errorMessage: "config.signingJwks is set but no OAuth issuer can be derived. Set config.hostname (recommended) or config.oauthAsIssuer explicitly."

--- a/charts/langsmith/tests/remote_mcp_test.yaml
+++ b/charts/langsmith/tests/remote_mcp_test.yaml
@@ -1,0 +1,197 @@
+suite: remote MCP server / OAuth Authorization Server config
+# insights/polly are enabled by default on this chart and would otherwise require
+# encryption keys to pass validate.yaml (which renders for every test).
+set:
+  insights.enabled: false
+  polly.enabled: false
+tests:
+  # --- Shared config (env) ---
+  - it: sets OAUTH_AS env when remoteMcp.signingJwks is provided
+    template: templates/config-map.yaml
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+      config.remoteMcp.signingJwks: '{"keys":[{"kty":"OKP"}]}'
+    asserts:
+      - equal:
+          path: data.OAUTH_AS_ENABLED
+          value: "true"
+      - equal:
+          path: data.OAUTH_AS_ISSUER
+          value: "https://langsmith.example.com/api"
+
+  - it: honors an explicit issuer override
+    template: templates/config-map.yaml
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+      config.remoteMcp.signingJwks: '{"keys":[{"kty":"OKP"}]}'
+      config.remoteMcp.issuer: "https://mcp.example.com/api"
+    asserts:
+      - equal:
+          path: data.OAUTH_AS_ISSUER
+          value: "https://mcp.example.com/api"
+
+  - it: folds basePath into the derived issuer
+    template: templates/config-map.yaml
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+      config.basePath: "langsmith"
+      config.remoteMcp.signingJwks: '{"keys":[{"kty":"OKP"}]}'
+    asserts:
+      - equal:
+          path: data.OAUTH_AS_ISSUER
+          value: "https://langsmith.example.com/langsmith/api"
+
+  - it: omits OAUTH_AS env when signingJwks is empty
+    template: templates/config-map.yaml
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+    asserts:
+      - notExists:
+          path: data.OAUTH_AS_ENABLED
+      - notExists:
+          path: data.OAUTH_AS_ISSUER
+
+  # --- Secret ---
+  - it: stores the signing JWKS in the managed secret (base64)
+    template: templates/secrets.yaml
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+      config.remoteMcp.signingJwks: "abc"
+    asserts:
+      - equal:
+          path: data.langsmith_signing_jwks
+          value: "YWJj" # base64("abc")
+
+  # --- platform-backend signing key env ---
+  - it: injects LANGSMITH_SIGNING_JWKS into platform-backend from the secret
+    template: templates/platform-backend/deployment.yaml
+    release:
+      name: ls
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+      config.remoteMcp.signingJwks: '{"keys":[{"kty":"OKP"}]}'
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGSMITH_SIGNING_JWKS
+            valueFrom:
+              secretKeyRef:
+                name: ls-langsmith-secrets
+                key: langsmith_signing_jwks
+                optional: false
+
+  - it: omits LANGSMITH_SIGNING_JWKS when signingJwks is empty
+    template: templates/platform-backend/deployment.yaml
+    release:
+      name: ls
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGSMITH_SIGNING_JWKS
+
+  # --- nginx routing (no basePath) ---
+  - it: adds /api MCP + OAuth + well-known routes when enabled
+    template: templates/frontend/config-map.yaml
+    set:
+      frontend.enabled: true
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+      config.remoteMcp.signingJwks: '{"keys":[{"kty":"OKP"}]}'
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "location /api/mcp"
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "location /api/oauth/"
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "location = /.well-known/oauth-authorization-server/api"
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "location = /api/.well-known/oauth-protected-resource/mcp"
+
+  - it: omits the /api MCP routes when disabled
+    template: templates/frontend/config-map.yaml
+    set:
+      frontend.enabled: true
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+    asserts:
+      - notMatchRegex:
+          path: data["nginx.conf"]
+          pattern: "location /api/mcp"
+      - notMatchRegex:
+          path: data["nginx.conf"]
+          pattern: "oauth-authorization-server/api"
+
+  # --- nginx routing (basePath) ---
+  - it: prefixes the /api MCP routes with basePath
+    template: templates/frontend/config-map.yaml
+    set:
+      frontend.enabled: true
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+      config.basePath: "langsmith"
+      config.remoteMcp.signingJwks: '{"keys":[{"kty":"OKP"}]}'
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "location /langsmith/api/mcp"
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "location = /.well-known/oauth-authorization-server/langsmith/api"
+
+  # --- Validation guard ---
+  - it: fails when signingJwks is set but no issuer can be derived
+    template: templates/validate.yaml
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.remoteMcp.signingJwks: '{"keys":[{"kty":"OKP"}]}'
+    asserts:
+      - failedTemplate:
+          errorMessage: "config.remoteMcp.signingJwks is set but no OAuth issuer can be derived. Set config.hostname (recommended) or config.remoteMcp.issuer explicitly."

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -947,14 +947,14 @@ config:
     oauthScopes: "email,profile,openid"  # Comma-separated list of scopes. We require at least 'email', 'profile', and 'openid'. Some OIDC providers require the 'offline_access' scope for refresh tokens.
     oauthSessionMaxSec: "86400"  # 24 hours. Maximum age of a session in seconds. Your session will attempt to refresh until the max age at which point you will be logged out.
 
-  # -- Ed25519 JWKS (JSON) that LangSmith uses to sign tokens — this is the shared
-  # signing key for the LLM auth proxy, the OAuth Authorization Server, and sandbox
-  # callbacks; its public keys are served at /.well-known/jwks.json. Maps to the
-  # LANGSMITH_SIGNING_JWKS env var. Setting it also enables the OAuth-protected remote
-  # MCP server and exposes the OAuth AS + MCP routes under <hostname>/api (requires
-  # config.hostname, or set config.oauthAsIssuer). Must be Ed25519/OKP (RSA keys are
-  # rejected). Treated as a secret; honored only when the chart manages the secret
-  # (i.e. config.existingSecretName / config.disableSecretCreation are unset).
+  # -- Optional Ed25519 JWKS (JSON) used to sign OAuth Authorization Server / remote MCP
+  # and LLM-auth-proxy tokens; its public keys are served at /.well-known/jwks.json (maps
+  # to LANGSMITH_SIGNING_JWKS). Like config.apiKeySalt, it is stored in the chart secret
+  # and always referenced optionally — or provide the key `langsmith_signing_jwks` in
+  # config.existingSecretName instead of setting it here. When config.hostname is set the
+  # chart enables the OAuth AS and exposes the MCP/OAuth routes under <hostname>/api, but
+  # they only activate once this signing JWKS is present (otherwise they are inert).
+  # Must be Ed25519/OKP (RSA is rejected).
   signingJwks: ""
   # -- Optional override for the OAuth Authorization Server issuer URL advertised to
   # remote MCP clients. Defaults to <config.hostname>[/config.basePath]/api.

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -947,22 +947,18 @@ config:
     oauthScopes: "email,profile,openid"  # Comma-separated list of scopes. We require at least 'email', 'profile', and 'openid'. Some OIDC providers require the 'offline_access' scope for refresh tokens.
     oauthSessionMaxSec: "86400"  # 24 hours. Maximum age of a session in seconds. Your session will attempt to refresh until the max age at which point you will be logged out.
 
-  # -- Remote MCP server: expose LangSmith as an OAuth-protected MCP server for
-  # external clients (e.g. Claude, Cursor). Served under <hostname>/api alongside
-  # the OAuth 2.1 Authorization Server. It turns on automatically when signingJwks
-  # is set; leave signingJwks empty to keep it disabled.
-  remoteMcp:
-    # -- Ed25519 JWKS (JSON) used to sign OAuth Authorization Server / MCP access
-    # tokens; the public keys are also served at /.well-known/jwks.json. Maps to the
-    # LANGSMITH_SIGNING_JWKS env var. Setting this enables the remote MCP server and
-    # OAuth Authorization Server and exposes their routes under /api. Requires
-    # config.hostname to be set (or set issuer below). Generate per the smith-go jwks
-    # README. Treated as a secret. Only honored when the chart manages the secret
-    # (i.e. config.existingSecretName / config.disableSecretCreation are unset).
-    signingJwks: ""
-    # -- Optional override for the OAuth issuer URL. Defaults to
-    # <config.hostname>[/config.basePath]/api. Set only if the auto-derived value is wrong.
-    issuer: ""
+  # -- Ed25519 JWKS (JSON) that LangSmith uses to sign tokens — this is the shared
+  # signing key for the LLM auth proxy, the OAuth Authorization Server, and sandbox
+  # callbacks; its public keys are served at /.well-known/jwks.json. Maps to the
+  # LANGSMITH_SIGNING_JWKS env var. Setting it also enables the OAuth-protected remote
+  # MCP server and exposes the OAuth AS + MCP routes under <hostname>/api (requires
+  # config.hostname, or set config.oauthAsIssuer). Must be Ed25519/OKP (RSA keys are
+  # rejected). Treated as a secret; honored only when the chart manages the secret
+  # (i.e. config.existingSecretName / config.disableSecretCreation are unset).
+  signingJwks: ""
+  # -- Optional override for the OAuth Authorization Server issuer URL advertised to
+  # remote MCP clients. Defaults to <config.hostname>[/config.basePath]/api.
+  oauthAsIssuer: ""
   # -- TTL configuration
   # Optional. Used to set TTLS for longlived and shortlived objects.
   ttl:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -946,6 +946,23 @@ config:
     oauthIssuerUrl: ""
     oauthScopes: "email,profile,openid"  # Comma-separated list of scopes. We require at least 'email', 'profile', and 'openid'. Some OIDC providers require the 'offline_access' scope for refresh tokens.
     oauthSessionMaxSec: "86400"  # 24 hours. Maximum age of a session in seconds. Your session will attempt to refresh until the max age at which point you will be logged out.
+
+  # -- Remote MCP server: expose LangSmith as an OAuth-protected MCP server for
+  # external clients (e.g. Claude, Cursor). Served under <hostname>/api alongside
+  # the OAuth 2.1 Authorization Server. It turns on automatically when signingJwks
+  # is set; leave signingJwks empty to keep it disabled.
+  remoteMcp:
+    # -- Ed25519 JWKS (JSON) used to sign OAuth Authorization Server / MCP access
+    # tokens; the public keys are also served at /.well-known/jwks.json. Maps to the
+    # LANGSMITH_SIGNING_JWKS env var. Setting this enables the remote MCP server and
+    # OAuth Authorization Server and exposes their routes under /api. Requires
+    # config.hostname to be set (or set issuer below). Generate per the smith-go jwks
+    # README. Treated as a secret. Only honored when the chart manages the secret
+    # (i.e. config.existingSecretName / config.disableSecretCreation are unset).
+    signingJwks: ""
+    # -- Optional override for the OAuth issuer URL. Defaults to
+    # <config.hostname>[/config.basePath]/api. Set only if the auto-derived value is wrong.
+    issuer: ""
   # -- TTL configuration
   # Optional. Used to set TTLS for longlived and shortlived objects.
   ttl:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -959,6 +959,10 @@ config:
   # -- Optional override for the OAuth Authorization Server issuer URL advertised to
   # remote MCP clients. Defaults to <config.hostname>[/config.basePath]/api.
   oauthAsIssuer: ""
+  # -- Optional issuer (iss claim) for tokens minted by the LLM auth proxy. Maps to
+  # LLM_AUTH_PROXY_ISSUER. Must match the jwtIssuer configured in the auth proxy chart.
+  # Left empty by default (not emitted); set it when using the LLM auth proxy.
+  llmAuthProxyIssuer: ""
   # -- TTL configuration
   # Optional. Used to set TTLS for longlived and shortlived objects.
   ttl:


### PR DESCRIPTION
## Summary

Exposes the OAuth-protected **remote MCP server** (and its OAuth 2.1 Authorization Server) under the self-hosted `/api` route prefix, so external MCP clients (Claude, Cursor, …) can connect to a self-hosted/BYOC LangSmith. Today this subsystem is only reachable on SaaS (everything at host root); self-hosted routes everything under `/api(/v1)` and never proxied/advertised the OAuth+MCP+well-known endpoints with a path-prefixed issuer.

## Enablement model

- **Automatic on `config.hostname`.** When a hostname is set, the chart sets `OAUTH_AS_ENABLED=true`, derives `OAUTH_AS_ISSUER` (`<hostname>[/basePath]/api`), and adds the `/api` nginx routes.
- **Activates only when a signing JWKS is present.** smith-go self-gates (`OAuthASEnabled && signer != nil`, `main.go:751`), so without the signing key the endpoints are **inert** (they 404). No client can use them without a key.
- **The chart owns `LANGSMITH_SIGNING_JWKS`** (modeled on `api_key_salt`): wired by default from the signing JWKS secret — `config.signingJwks` (inline → chart-managed secret) or key `langsmith_signing_jwks` in `config.existingSecretName`. Operators **must not** set it manually via `commonEnv`/`extraEnv`; `validate.yaml` fails with a clear message (a skip-guard keeps the generic duplicate-key error from masking it).

## New values

- `config.signingJwks` — optional inline Ed25519/OKP JWKS (RSA rejected).
- `config.oauthAsIssuer` — optional issuer override (defaults to `<hostname>[/basePath]/api`).
- `config.llmAuthProxyIssuer` — optional `LLM_AUTH_PROXY_ISSUER` (emitted only when set).

## nginx routes (both basePath and non-basePath blocks)

`/api/mcp` (MCP JSON-RPC, distinct from the root `/mcp` fleet tool server) · `/api/oauth/` · `/api/.well-known/oauth-protected-resource/mcp` (RFC 9728) · authorization-server metadata in RFC 8414 path-insertion (`/.well-known/oauth-authorization-server/api`) **and** path-append forms · `/api/.well-known/jwks.json`.

## ⚠️ Behavior changes on the v15 train

1. **OAuth AS + `/api` routes now render for every install with a `config.hostname`** (≈all). They're **inert without a signing JWKS** (smith-go self-gates; routes 404). Installs that *do* have a signing JWKS (e.g. LLM-auth-proxy users) will have remote MCP **enabled** after upgrade — the endpoints are OAuth-protected.
2. **Forced migration:** any install currently setting `LANGSMITH_SIGNING_JWKS` via `commonEnv`/`extraEnv` will **fail the render** on upgrade until they remove it (the chart owns it now; put the key in `config.existingSecretName` / `config.signingJwks`).

No `langchainplus` (smith-go) change required — `OAUTH_AS_ISSUER` is set explicitly.

## Testing

`helm unittest` (29 tests incl. new `tests/remote_mcp_test.yaml`), `helm lint`, and `nginx -t` on the rendered frontend config (feature on) all pass. Chart `0.15.3 → 0.15.4`.

Targets `v15-stable` for the internal dogfood AKS deploy.
