### PR TITLE
feat(langsmith): expose remote MCP server + OAuth AS under /api

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.15.8
+version: 0.15.9
 appVersion: "0.15.13"

--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.15.9
+version: 0.16.0-rc.1
 appVersion: "0.16.1rc1"

--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
 version: 0.15.9
-appVersion: "0.15.13"
+appVersion: "0.16.1rc1"

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -975,14 +975,11 @@ which default to http:// for local development.
 
 {{/*
 OAuth Authorization Server issuer URL advertised to remote MCP clients.
-Defaults to <hostnameWithProtocol>[/basePath]/api; overridable via config.oauthAsIssuer.
+Derived from <hostnameWithProtocol>[/basePath]/api. The /api path is fixed because the
+frontend nginx routes are hardcoded to it; host and scheme come from config.hostname.
 */}}
 {{- define "langsmith.oauthAsIssuer" -}}
-{{- if .Values.config.oauthAsIssuer -}}
-{{- .Values.config.oauthAsIssuer -}}
-{{- else -}}
 {{- include "langsmith.hostnameWithProtocol" . }}{{- with .Values.config.basePath }}/{{ . }}{{- end }}/api
-{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -974,6 +974,18 @@ which default to http:// for local development.
 {{- end -}}
 
 {{/*
+OAuth Authorization Server issuer URL advertised to remote MCP clients.
+Defaults to <hostnameWithProtocol>[/basePath]/api; overridable via config.oauthAsIssuer.
+*/}}
+{{- define "langsmith.oauthAsIssuer" -}}
+{{- if .Values.config.oauthAsIssuer -}}
+{{- .Values.config.oauthAsIssuer -}}
+{{- else -}}
+{{- include "langsmith.hostnameWithProtocol" . }}{{- with .Values.config.basePath }}/{{ . }}{{- end }}/api
+{{- end -}}
+{{- end -}}
+
+{{/*
 Public URL for the default Agent Builder MCP server.
 Served through the frontend at /mcp (or /<basePath>/mcp).
 */}}

--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -40,6 +40,16 @@ data:
   SMITH_BACKEND_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.backend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.backend.service.port }}"
   HOST_BACKEND_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.hostBackend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.hostBackend.service.port }}"
   LANGSMITH_AUTH_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }}"
+  {{- if .Values.config.hostname }}
+  # Remote MCP server / OAuth Authorization Server (served under /api). The AS only
+  # activates when a signing JWKS is present (langsmith_signing_jwks in the secret);
+  # without it these are inert. Routes are added in the frontend nginx config.
+  OAUTH_AS_ENABLED: "true"
+  OAUTH_AS_ISSUER: {{ include "langsmith.oauthAsIssuer" . | quote }}
+  {{- end }}
+  {{- if .Values.config.llmAuthProxyIssuer }}
+  LLM_AUTH_PROXY_ISSUER: {{ .Values.config.llmAuthProxyIssuer | quote }}
+  {{- end }}
   {{- if and .Values.fleet.enabled .Values.fleetTriggerServer.enabled }}
   MCP_SERVER_URL: "http://{{ include "langsmith.fullname" . }}-{{ .Values.fleetToolServer.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.fleetToolServer.service.port }}"
   {{- end }}

--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -370,6 +370,24 @@ data:
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
+
+        # The OAuth consent page (SPA at /oauth/consent) submits approval and reads client
+        # metadata at the AS's root /oauth/* paths (single-origin leaves the SPA's backend
+        # origin empty). Route those to platform-backend; /oauth/consent stays on the SPA.
+        location = /oauth/authorize/approve {
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+        location /oauth/client/ {
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
     {{- end }}
 
         # Backend Routes
@@ -950,6 +968,24 @@ data:
         # MCP JSON-RPC endpoint (kept distinct from the root /mcp fleet tool server).
         location /api/mcp {
             rewrite /api(/mcp.*) $1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # The OAuth consent page (SPA at /oauth/consent) submits approval and reads client
+        # metadata at the AS's root /oauth/* paths (single-origin leaves the SPA's backend
+        # origin empty). Route those to platform-backend; /oauth/consent stays on the SPA.
+        location = /oauth/authorize/approve {
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+        location /oauth/client/ {
             proxy_set_header Connection '';
             proxy_http_version 1.1;
             proxy_buffering off;

--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -308,6 +308,70 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
 
+    {{- if .Values.config.hostname }}
+        # Remote MCP server (OAuth-protected) under /api -> platform-backend.
+        # OAuth 2.1 discovery (RFC 8414 / RFC 9728), token endpoints, and the MCP JSON-RPC endpoint.
+        # RFC 8414 path-insertion form of the authorization-server metadata (clients try this first).
+        location = /.well-known/oauth-authorization-server/{{ .Values.config.basePath }}/api {
+            rewrite ^ /.well-known/oauth-authorization-server  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # Path-append form of the authorization-server metadata.
+        location = /{{ .Values.config.basePath }}/api/.well-known/oauth-authorization-server {
+            rewrite ^ /.well-known/oauth-authorization-server  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # Protected-resource metadata (the URL advertised in the MCP 401 WWW-Authenticate header).
+        location = /{{ .Values.config.basePath }}/api/.well-known/oauth-protected-resource/mcp {
+            rewrite ^ /.well-known/oauth-protected-resource/mcp  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # JWKS advertised under the /api issuer (jwks_uri).
+        location = /{{ .Values.config.basePath }}/api/.well-known/jwks.json {
+            rewrite ^ /.well-known/jwks.json  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # OAuth Authorization Server endpoints (authorize, token, register, revoke, device).
+        location /{{ .Values.config.basePath }}/api/oauth/ {
+            rewrite /{{ .Values.config.basePath }}/api/oauth/(.*) /oauth/$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # MCP JSON-RPC endpoint (kept distinct from the root /mcp fleet tool server).
+        location /{{ .Values.config.basePath }}/api/mcp {
+            rewrite /{{ .Values.config.basePath }}/api(/mcp.*) $1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+    {{- end }}
+
         # Backend Routes
         location /{{ .Values.config.basePath }}/api/v1 {
             rewrite /{{ .Values.config.basePath }}/api/v1/(.*) /api/v1/$1  break;
@@ -829,6 +893,70 @@ data:
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
+
+    {{- if .Values.config.hostname }}
+        # Remote MCP server (OAuth-protected) under /api -> platform-backend.
+        # OAuth 2.1 discovery (RFC 8414 / RFC 9728), token endpoints, and the MCP JSON-RPC endpoint.
+        # RFC 8414 path-insertion form of the authorization-server metadata (clients try this first).
+        location = /.well-known/oauth-authorization-server/api {
+            rewrite ^ /.well-known/oauth-authorization-server  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # Path-append form of the authorization-server metadata.
+        location = /api/.well-known/oauth-authorization-server {
+            rewrite ^ /.well-known/oauth-authorization-server  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # Protected-resource metadata (the URL advertised in the MCP 401 WWW-Authenticate header).
+        location = /api/.well-known/oauth-protected-resource/mcp {
+            rewrite ^ /.well-known/oauth-protected-resource/mcp  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # JWKS advertised under the /api issuer (jwks_uri).
+        location = /api/.well-known/jwks.json {
+            rewrite ^ /.well-known/jwks.json  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # OAuth Authorization Server endpoints (authorize, token, register, revoke, device).
+        location /api/oauth/ {
+            rewrite /api/oauth/(.*) /oauth/$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # MCP JSON-RPC endpoint (kept distinct from the root /mcp fleet tool server).
+        location /api/mcp {
+            rewrite /api(/mcp.*) $1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+    {{- end }}
 
         # Backend Routes
         location /api/v1 {

--- a/charts/langsmith/templates/platform-backend/deployment.yaml
+++ b/charts/langsmith/templates/platform-backend/deployment.yaml
@@ -5,6 +5,24 @@
 - name: DOCS_PREFIX
   value: /{{ . }}/api
 {{- end }}
+# Signing JWKS for the OAuth Authorization Server / remote MCP and the LLM auth
+# proxy. The chart owns this env (like api_key_salt) and sources it from the chart
+# secret (config.signingJwks) or config.existingSecretName; operators must not set
+# LANGSMITH_SIGNING_JWKS manually (enforced in validate.yaml). The skip-guard keeps a
+# manual override from tripping the generic duplicate-key error before validate.yaml
+# surfaces the clear message. The OAuth AS only activates when this key is present.
+{{- $providedEnv := list -}}
+{{- range concat (.Values.commonEnv | default (list)) (.Values.platformBackend.deployment.extraEnv | default (list)) -}}
+{{- $providedEnv = append $providedEnv .name -}}
+{{- end -}}
+{{- if not (has "LANGSMITH_SIGNING_JWKS" $providedEnv) }}
+- name: LANGSMITH_SIGNING_JWKS
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "langsmith.secretsName" . }}
+      key: langsmith_signing_jwks
+      optional: true
+{{- end }}
 {{- end -}}
 {{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "platformBackendEnvVars" . | fromYamlArray) .Values.platformBackend.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}

--- a/charts/langsmith/templates/platform-backend/deployment.yaml
+++ b/charts/langsmith/templates/platform-backend/deployment.yaml
@@ -7,22 +7,15 @@
 {{- end }}
 # Signing JWKS for the OAuth Authorization Server / remote MCP and the LLM auth
 # proxy. The chart owns this env (like api_key_salt) and sources it from the chart
-# secret (config.signingJwks) or config.existingSecretName; operators must not set
-# LANGSMITH_SIGNING_JWKS manually (enforced in validate.yaml). The skip-guard keeps a
-# manual override from tripping the generic duplicate-key error before validate.yaml
-# surfaces the clear message. The OAuth AS only activates when this key is present.
-{{- $providedEnv := list -}}
-{{- range concat (.Values.commonEnv | default (list)) (.Values.platformBackend.deployment.extraEnv | default (list)) -}}
-{{- $providedEnv = append $providedEnv .name -}}
-{{- end -}}
-{{- if not (has "LANGSMITH_SIGNING_JWKS" $providedEnv) }}
+# secret (config.signingJwks) or config.existingSecretName, so operators must not set
+# LANGSMITH_SIGNING_JWKS manually — doing so trips the duplicate-env-var check
+# (langsmith.detectDuplicates). The OAuth AS only activates when this key is present.
 - name: LANGSMITH_SIGNING_JWKS
   valueFrom:
     secretKeyRef:
       name: {{ include "langsmith.secretsName" . }}
       key: langsmith_signing_jwks
       optional: true
-{{- end }}
 {{- end -}}
 {{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "platformBackendEnvVars" . | fromYamlArray) .Values.platformBackend.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}

--- a/charts/langsmith/templates/platform-backend/deployment.yaml
+++ b/charts/langsmith/templates/platform-backend/deployment.yaml
@@ -5,11 +5,8 @@
 - name: DOCS_PREFIX
   value: /{{ . }}/api
 {{- end }}
-# Signing JWKS for the OAuth Authorization Server / remote MCP and the LLM auth
-# proxy. The chart owns this env (like api_key_salt) and sources it from the chart
-# secret (config.signingJwks) or config.existingSecretName, so operators must not set
-# LANGSMITH_SIGNING_JWKS manually — doing so trips the duplicate-env-var check
-# (langsmith.detectDuplicates). The OAuth AS only activates when this key is present.
+# OAuth AS / remote MCP (and LLM-auth-proxy) signing key. Always wired (optional) from
+# the chart secret, so don't set LANGSMITH_SIGNING_JWKS manually — it trips detectDuplicates.
 - name: LANGSMITH_SIGNING_JWKS
   valueFrom:
     secretKeyRef:

--- a/charts/langsmith/templates/secrets.yaml
+++ b/charts/langsmith/templates/secrets.yaml
@@ -13,6 +13,7 @@ data:
   oauth_client_id: {{ .Values.config.oauth.oauthClientId | b64enc | quote }}
   oauth_client_secret: {{ .Values.config.oauth.oauthClientSecret | b64enc | quote }}
   oauth_issuer_url: {{ .Values.config.oauth.oauthIssuerUrl | b64enc | quote }}
+  langsmith_signing_jwks: {{ .Values.config.signingJwks | b64enc | quote }}
   langsmith_license_key: {{ .Values.config.langsmithLicenseKey | b64enc | quote }}
   api_key_salt: {{ .Values.config.apiKeySalt | default .Values.config.langsmithLicenseKey | b64enc | quote }}
   jwt_secret: {{ .Values.config.basicAuth.jwtSecret | b64enc | quote }}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -219,6 +219,15 @@ AWS Marketplace Helm template verification).
 {{- fail "config.polly is no longer supported (the bundled-agent bootstrap path was removed in chart 0.15.1). Use the top-level polly block: polly.enabled, polly.encryptionKey, etc." -}}
 {{- end -}}
 
+{{- /* The chart owns LANGSMITH_SIGNING_JWKS (sourced from the signing JWKS secret).
+       Forbid operators from setting it manually via commonEnv/extraEnv so there is a
+       single source of truth and no duplicate env var. */ -}}
+{{- range concat (.Values.commonEnv | default (list)) (.Values.platformBackend.deployment.extraEnv | default (list)) -}}
+{{- if eq .name "LANGSMITH_SIGNING_JWKS" -}}
+{{- fail "Do not set LANGSMITH_SIGNING_JWKS manually in commonEnv / platformBackend.deployment.extraEnv. The chart provides it from the signing JWKS secret — put the JWKS at key 'langsmith_signing_jwks' in config.existingSecretName, or set config.signingJwks." -}}
+{{- end -}}
+{{- end -}}
+
 {{- /* Validate autoscaling configuration for all services */ -}}
 {{- $autoscalingServices := dict
   "aceBackend" .Values.aceBackend.autoscaling

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -219,15 +219,6 @@ AWS Marketplace Helm template verification).
 {{- fail "config.polly is no longer supported (the bundled-agent bootstrap path was removed in chart 0.15.1). Use the top-level polly block: polly.enabled, polly.encryptionKey, etc." -}}
 {{- end -}}
 
-{{- /* The chart owns LANGSMITH_SIGNING_JWKS (sourced from the signing JWKS secret).
-       Forbid operators from setting it manually via commonEnv/extraEnv so there is a
-       single source of truth and no duplicate env var. */ -}}
-{{- range concat (.Values.commonEnv | default (list)) (.Values.platformBackend.deployment.extraEnv | default (list)) -}}
-{{- if eq .name "LANGSMITH_SIGNING_JWKS" -}}
-{{- fail "Do not set LANGSMITH_SIGNING_JWKS manually in commonEnv / platformBackend.deployment.extraEnv. The chart provides it from the signing JWKS secret — put the JWKS at key 'langsmith_signing_jwks' in config.existingSecretName, or set config.signingJwks." -}}
-{{- end -}}
-{{- end -}}
-
 {{- /* Validate autoscaling configuration for all services */ -}}
 {{- $autoscalingServices := dict
   "aceBackend" .Values.aceBackend.autoscaling

--- a/charts/langsmith/tests/remote_mcp_test.yaml
+++ b/charts/langsmith/tests/remote_mcp_test.yaml
@@ -22,20 +22,6 @@ tests:
           path: data.OAUTH_AS_ISSUER
           value: "https://langsmith.example.com/api"
 
-  - it: honors an explicit issuer override
-    template: templates/config-map.yaml
-    set:
-      config.langsmithLicenseKey: "lic"
-      config.apiKeySalt: "salt"
-      config.oauth.enabled: true
-      config.authType: "oauth"
-      config.hostname: "langsmith.example.com"
-      config.oauthAsIssuer: "https://mcp.example.com/api"
-    asserts:
-      - equal:
-          path: data.OAUTH_AS_ISSUER
-          value: "https://mcp.example.com/api"
-
   - it: folds basePath into the derived issuer
     template: templates/config-map.yaml
     set:

--- a/charts/langsmith/tests/remote_mcp_test.yaml
+++ b/charts/langsmith/tests/remote_mcp_test.yaml
@@ -111,8 +111,10 @@ tests:
                 key: langsmith_signing_jwks
                 optional: true
 
-  - it: fails when an operator sets LANGSMITH_SIGNING_JWKS manually via extraEnv
-    template: templates/validate.yaml
+  - it: fails on duplicate when an operator sets LANGSMITH_SIGNING_JWKS manually via extraEnv
+    # The chart always wires LANGSMITH_SIGNING_JWKS from the secret, so a manual copy in
+    # extraEnv produces a duplicate env var, caught by langsmith.detectDuplicates.
+    template: templates/platform-backend/deployment.yaml
     set:
       config.langsmithLicenseKey: "lic"
       config.apiKeySalt: "salt"
@@ -127,7 +129,7 @@ tests:
               key: langsmith_signing_jwks
     asserts:
       - failedTemplate:
-          errorMessage: "Do not set LANGSMITH_SIGNING_JWKS manually in commonEnv / platformBackend.deployment.extraEnv. The chart provides it from the signing JWKS secret — put the JWKS at key 'langsmith_signing_jwks' in config.existingSecretName, or set config.signingJwks."
+          errorMessage: "Duplicate keys detected: [LANGSMITH_SIGNING_JWKS]"
 
   - it: sources LANGSMITH_SIGNING_JWKS from config.existingSecretName when set
     template: templates/platform-backend/deployment.yaml

--- a/charts/langsmith/tests/remote_mcp_test.yaml
+++ b/charts/langsmith/tests/remote_mcp_test.yaml
@@ -1,0 +1,220 @@
+suite: remote MCP server / OAuth Authorization Server config
+# insights/polly are enabled by default on this chart and would otherwise require
+# encryption keys to pass validate.yaml (which renders for every test).
+set:
+  insights.enabled: false
+  polly.enabled: false
+tests:
+  # --- Shared config (env): OAuth AS is enabled whenever a hostname is set ---
+  - it: sets OAUTH_AS env when a hostname is configured
+    template: templates/config-map.yaml
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+    asserts:
+      - equal:
+          path: data.OAUTH_AS_ENABLED
+          value: "true"
+      - equal:
+          path: data.OAUTH_AS_ISSUER
+          value: "https://langsmith.example.com/api"
+
+  - it: honors an explicit issuer override
+    template: templates/config-map.yaml
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+      config.oauthAsIssuer: "https://mcp.example.com/api"
+    asserts:
+      - equal:
+          path: data.OAUTH_AS_ISSUER
+          value: "https://mcp.example.com/api"
+
+  - it: folds basePath into the derived issuer
+    template: templates/config-map.yaml
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+      config.basePath: "langsmith"
+    asserts:
+      - equal:
+          path: data.OAUTH_AS_ISSUER
+          value: "https://langsmith.example.com/langsmith/api"
+
+  - it: emits LLM_AUTH_PROXY_ISSUER when configured
+    template: templates/config-map.yaml
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+      config.llmAuthProxyIssuer: "langsmith"
+    asserts:
+      - equal:
+          path: data.LLM_AUTH_PROXY_ISSUER
+          value: "langsmith"
+
+  - it: omits LLM_AUTH_PROXY_ISSUER when not configured
+    template: templates/config-map.yaml
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+    asserts:
+      - notExists:
+          path: data.LLM_AUTH_PROXY_ISSUER
+
+  - it: omits OAUTH_AS env when no hostname is set
+    template: templates/config-map.yaml
+    set:
+      config.existingSecretName: "langsmith-existing-secrets"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+    asserts:
+      - notExists:
+          path: data.OAUTH_AS_ENABLED
+      - notExists:
+          path: data.OAUTH_AS_ISSUER
+
+  # --- Signing JWKS env is always wired and optional (like api_key_salt) ---
+  - it: always wires LANGSMITH_SIGNING_JWKS optionally into platform-backend
+    template: templates/platform-backend/deployment.yaml
+    release:
+      name: ls
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+      # signingJwks intentionally not set — the env must still be wired, optionally.
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGSMITH_SIGNING_JWKS
+            valueFrom:
+              secretKeyRef:
+                name: ls-langsmith-secrets
+                key: langsmith_signing_jwks
+                optional: true
+
+  - it: fails when an operator sets LANGSMITH_SIGNING_JWKS manually via extraEnv
+    template: templates/validate.yaml
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+      platformBackend.deployment.extraEnv:
+        - name: LANGSMITH_SIGNING_JWKS
+          valueFrom:
+            secretKeyRef:
+              name: my-own-secret
+              key: langsmith_signing_jwks
+    asserts:
+      - failedTemplate:
+          errorMessage: "Do not set LANGSMITH_SIGNING_JWKS manually in commonEnv / platformBackend.deployment.extraEnv. The chart provides it from the signing JWKS secret — put the JWKS at key 'langsmith_signing_jwks' in config.existingSecretName, or set config.signingJwks."
+
+  - it: sources LANGSMITH_SIGNING_JWKS from config.existingSecretName when set
+    template: templates/platform-backend/deployment.yaml
+    set:
+      config.existingSecretName: "langsmith-existing-secrets"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGSMITH_SIGNING_JWKS
+            valueFrom:
+              secretKeyRef:
+                name: langsmith-existing-secrets
+                key: langsmith_signing_jwks
+                optional: true
+
+  # --- Chart-managed secret stores the inline value (like api_key_salt) ---
+  - it: stores the inline signing JWKS in the managed secret (base64)
+    template: templates/secrets.yaml
+    set:
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+      config.signingJwks: "abc"
+    asserts:
+      - equal:
+          path: data.langsmith_signing_jwks
+          value: "YWJj" # base64("abc")
+
+  # --- nginx routing follows hostname ---
+  - it: adds /api MCP + OAuth + well-known routes when a hostname is set
+    template: templates/frontend/config-map.yaml
+    set:
+      frontend.enabled: true
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "location /api/mcp"
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "location /api/oauth/"
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "location = /.well-known/oauth-authorization-server/api"
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "location = /api/.well-known/oauth-protected-resource/mcp"
+
+  - it: omits the /api MCP routes when no hostname is set
+    template: templates/frontend/config-map.yaml
+    set:
+      frontend.enabled: true
+      config.existingSecretName: "langsmith-existing-secrets"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+    asserts:
+      - notMatchRegex:
+          path: data["nginx.conf"]
+          pattern: "location /api/mcp"
+      - notMatchRegex:
+          path: data["nginx.conf"]
+          pattern: "oauth-authorization-server/api"
+
+  - it: prefixes the /api MCP routes with basePath
+    template: templates/frontend/config-map.yaml
+    set:
+      frontend.enabled: true
+      config.langsmithLicenseKey: "lic"
+      config.apiKeySalt: "salt"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      config.hostname: "langsmith.example.com"
+      config.basePath: "langsmith"
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "location /langsmith/api/mcp"
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "location = /.well-known/oauth-authorization-server/langsmith/api"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -964,6 +964,23 @@ config:
     oauthIssuerUrl: ""
     oauthScopes: "email,profile,openid"  # Comma-separated list of scopes. We require at least 'email', 'profile', and 'openid'. Some OIDC providers require the 'offline_access' scope for refresh tokens.
     oauthSessionMaxSec: "86400"  # 24 hours. Maximum age of a session in seconds. Your session will attempt to refresh until the max age at which point you will be logged out.
+
+  # -- Optional Ed25519 JWKS (JSON) used to sign OAuth Authorization Server / remote MCP
+  # and LLM-auth-proxy tokens; its public keys are served at /.well-known/jwks.json (maps
+  # to LANGSMITH_SIGNING_JWKS). Like config.apiKeySalt, it is stored in the chart secret
+  # and always referenced optionally — or provide the key `langsmith_signing_jwks` in
+  # config.existingSecretName instead of setting it here. When config.hostname is set the
+  # chart enables the OAuth AS and exposes the MCP/OAuth routes under <hostname>/api, but
+  # they only activate once this signing JWKS is present (otherwise they are inert).
+  # Must be Ed25519/OKP (RSA is rejected).
+  signingJwks: ""
+  # -- Optional override for the OAuth Authorization Server issuer URL advertised to
+  # remote MCP clients. Defaults to <config.hostname>[/config.basePath]/api.
+  oauthAsIssuer: ""
+  # -- Optional issuer (iss claim) for tokens minted by the LLM auth proxy. Maps to
+  # LLM_AUTH_PROXY_ISSUER. Must match the jwtIssuer configured in the auth proxy chart.
+  # Left empty by default (not emitted); set it when using the LLM auth proxy.
+  llmAuthProxyIssuer: ""
   # -- TTL configuration
   # Optional. Used to set TTLS for longlived and shortlived objects.
   ttl:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -40,23 +40,23 @@ images:
   aceBackendImage:
     repository: "docker.io/langchain/langsmith-ace-backend"
     pullPolicy: IfNotPresent
-    tag: "0.15.13"
+    tag: "0.16.1rc1"
   backendImage:
     repository: "docker.io/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
-    tag: "0.15.13"
+    tag: "0.16.1rc1"
   insightsAgentImage:
     repository: "docker.io/langchain/langsmith-clio"
     pullPolicy: IfNotPresent
-    tag: "0.15.13"
+    tag: "0.16.1rc1"
   frontendImage:
     repository: "docker.io/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
-    tag: "0.15.13"
+    tag: "0.16.1rc1"
   hostBackendImage:
     repository: "docker.io/langchain/hosted-langserve-backend"
     pullPolicy: IfNotPresent
-    tag: "0.15.13"
+    tag: "0.16.1rc1"
   operatorImage:
     repository: "docker.io/langchain/langgraph-operator"
     pullPolicy: IfNotPresent
@@ -64,11 +64,11 @@ images:
   platformBackendImage:
     repository: "docker.io/langchain/langsmith-go-backend"
     pullPolicy: IfNotPresent
-    tag: "0.15.13"
+    tag: "0.16.1rc1"
   playgroundImage:
     repository: "docker.io/langchain/langsmith-playground"
     pullPolicy: IfNotPresent
-    tag: "0.15.13"
+    tag: "0.16.1rc1"
   # For production environments, we strongly recommend connecting to a managed PostgreSQL instance instead of using the one provided by the chart.
   # Docs: https://docs.langchain.com/langsmith/self-host-external-postgres
   postgresImage:
@@ -88,19 +88,19 @@ images:
   fleetToolServerImage:
     repository: "docker.io/langchain/agent-builder-tool-server"
     pullPolicy: IfNotPresent
-    tag: "0.15.13"
+    tag: "0.16.1rc1"
   fleetTriggerServerImage:
     repository: "docker.io/langchain/agent-builder-trigger-server"
     pullPolicy: IfNotPresent
-    tag: "0.15.13"
+    tag: "0.16.1rc1"
   agentBuilderImage:
     repository: "docker.io/langchain/agent-builder-deep-agent"
     pullPolicy: IfNotPresent
-    tag: "0.15.13"
+    tag: "0.16.1rc1"
   pollyAgentImage:
     repository: "docker.io/langchain/langsmith-polly"
     pullPolicy: IfNotPresent
-    tag: "0.15.13"
+    tag: "0.16.1rc1"
   # Optional: only mirror/pull when presidioAnalyzer.enabled is true
   presidioAnalyzerImage:
     repository: "mcr.microsoft.com/presidio-analyzer"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -965,14 +965,10 @@ config:
     oauthScopes: "email,profile,openid"  # Comma-separated list of scopes. We require at least 'email', 'profile', and 'openid'. Some OIDC providers require the 'offline_access' scope for refresh tokens.
     oauthSessionMaxSec: "86400"  # 24 hours. Maximum age of a session in seconds. Your session will attempt to refresh until the max age at which point you will be logged out.
 
-  # -- Optional Ed25519 JWKS (JSON) used to sign OAuth Authorization Server / remote MCP
-  # and LLM-auth-proxy tokens; its public keys are served at /.well-known/jwks.json (maps
-  # to LANGSMITH_SIGNING_JWKS). Like config.apiKeySalt, it is stored in the chart secret
-  # and always referenced optionally — or provide the key `langsmith_signing_jwks` in
-  # config.existingSecretName instead of setting it here. When config.hostname is set the
-  # chart enables the OAuth AS and exposes the MCP/OAuth routes under <hostname>/api, but
-  # they only activate once this signing JWKS is present (otherwise they are inert).
-  # Must be Ed25519/OKP (RSA is rejected).
+  # -- Ed25519/OKP JWKS (JSON) signing the OAuth AS / remote MCP (and LLM-auth-proxy)
+  # tokens; public keys are served at /.well-known/jwks.json. Set it here (stored in the
+  # chart secret) or as key `langsmith_signing_jwks` in config.existingSecretName. The
+  # remote MCP server / OAuth AS stay inert until this is set.
   signingJwks: ""
   # -- Optional issuer (iss claim) for tokens minted by the LLM auth proxy. Maps to
   # LLM_AUTH_PROXY_ISSUER. Must match the jwtIssuer configured in the auth proxy chart.

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -974,9 +974,6 @@ config:
   # they only activate once this signing JWKS is present (otherwise they are inert).
   # Must be Ed25519/OKP (RSA is rejected).
   signingJwks: ""
-  # -- Optional override for the OAuth Authorization Server issuer URL advertised to
-  # remote MCP clients. Defaults to <config.hostname>[/config.basePath]/api.
-  oauthAsIssuer: ""
   # -- Optional issuer (iss claim) for tokens minted by the LLM auth proxy. Maps to
   # LLM_AUTH_PROXY_ISSUER. Must match the jwtIssuer configured in the auth proxy chart.
   # Left empty by default (not emitted); set it when using the LLM auth proxy.


### PR DESCRIPTION
## Summary

Exposes the OAuth-protected **remote MCP server** (and its OAuth 2.1 Authorization Server) under the self-hosted `/api` route prefix, so external MCP clients (Claude, Cursor, …) can connect to a self-hosted/BYOC LangSmith. Self-hosted routes everything under `/api(/v1)` and never proxied/advertised the OAuth + MCP + well-known endpoints with a path-prefixed issuer.

Targets `main` → ships in **v16**.

## Enablement model

- **Automatic on `config.hostname`.** Sets `OAUTH_AS_ENABLED=true`, derives `OAUTH_AS_ISSUER` (`<hostname>[/basePath]/api`), and adds the `/api` nginx routes.
- **Activates only when a signing JWKS is present.** smith-go self-gates (`OAuthASEnabled && signer != nil`), so without the key the endpoints are inert (404).
- **The chart owns `LANGSMITH_SIGNING_JWKS`** (like `api_key_salt`): sourced from `config.signingJwks` (inline → chart secret) or key `langsmith_signing_jwks` in `config.existingSecretName`. It is always wired (optional) from the secret, so a manual copy in `commonEnv`/`extraEnv` collides and fails the duplicate-env-var check.

## ⚠️ Breaking change (v16)

Installs that currently set `LANGSMITH_SIGNING_JWKS` themselves via `commonEnv` / `platformBackend.deployment.extraEnv` will **fail to render on upgrade** with `Duplicate keys detected: [LANGSMITH_SIGNING_JWKS]`, because the chart now always wires this env from the signing-JWKS secret.

**Fix:** remove the manual entry and put the JWKS at key `langsmith_signing_jwks` in `config.existingSecretName`, or set `config.signingJwks`. Most installs never set this var and are unaffected.

## New values

`config.signingJwks` · `config.llmAuthProxyIssuer`. (The issuer is always derived from `config.hostname`; there is no override knob.)

## nginx routes (both basePath / non-basePath)

`/api/mcp` · `/api/oauth/` · `/api/.well-known/oauth-protected-resource/mcp` (RFC 9728) · authorization-server metadata in RFC 8414 insertion (`/.well-known/oauth-authorization-server/api`) + append forms · `/api/.well-known/jwks.json`. Plus root `/oauth/authorize/approve` and `/oauth/client/` → platform-backend, for the single-origin consent page.

## Versions

- **App images:** all langsmith component tags `0.15.13 → 0.16.1rc1`, `appVersion → 0.16.1rc1` (public DockerHub RC carrying the remote-MCP/OAuth-AS code). Non-app images (postgres/redis/clickhouse/operator/presidio) unchanged.
- **Chart version:** `0.15.8 → 0.16.0-rc.1` (mirrors the v15 RC convention `0.15.0-rc.1`; drops to `0.16.0` at GA).

## Self-Hosted Release Note

Self-hosted/BYOC can now expose an OAuth-protected **remote MCP server** at `<host>/api/mcp` for external clients (Claude, Cursor). Enabled automatically when `config.hostname` is set and a signing JWKS is provided (`config.signingJwks` or key `langsmith_signing_jwks` in `config.existingSecretName`). **Breaking:** operators who previously set `LANGSMITH_SIGNING_JWKS` manually must move it into the chart secret, or the upgrade fails with a duplicate-key error.

## Test Plan

- [x] `helm unittest` (remote-MCP suite + full chart), `helm lint`, `nginx -t` on the rendered frontend config
- [x] Dogfooded on `langsmith-eks-self-hosted-ci` (tracks `helm@main`) via a deployments-repo PR: OAuth discovery chain, token flow, and consent flow verified end-to-end with a real client
