### PR TITLE
fix(langsmith): route root /oauth/device/authorize for device-flow activation

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.0-rc.1
+version: 0.16.0-rc.2
 appVersion: "0.16.1rc1"

--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -371,9 +371,9 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
 
-        # The OAuth consent page (SPA at /oauth/consent) submits approval and reads client
-        # metadata at the AS's root /oauth/* paths (single-origin leaves the SPA's backend
-        # origin empty). Route those to platform-backend; /oauth/consent stays on the SPA.
+        # The OAuth consent page (SPA at /oauth/consent) and the device-activation page (SPA
+        # at /activate) submit to the AS's root /oauth/* paths (single-origin leaves the SPA's
+        # backend origin empty). Route those to platform-backend; the SPA pages stay on the SPA.
         location = /oauth/authorize/approve {
             proxy_set_header Connection '';
             proxy_http_version 1.1;
@@ -382,6 +382,13 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
         location /oauth/client/ {
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+        location = /oauth/device/authorize {
             proxy_set_header Connection '';
             proxy_http_version 1.1;
             proxy_buffering off;
@@ -975,9 +982,9 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
 
-        # The OAuth consent page (SPA at /oauth/consent) submits approval and reads client
-        # metadata at the AS's root /oauth/* paths (single-origin leaves the SPA's backend
-        # origin empty). Route those to platform-backend; /oauth/consent stays on the SPA.
+        # The OAuth consent page (SPA at /oauth/consent) and the device-activation page (SPA
+        # at /activate) submit to the AS's root /oauth/* paths (single-origin leaves the SPA's
+        # backend origin empty). Route those to platform-backend; the SPA pages stay on the SPA.
         location = /oauth/authorize/approve {
             proxy_set_header Connection '';
             proxy_http_version 1.1;
@@ -986,6 +993,13 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
         location /oauth/client/ {
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+        location = /oauth/device/authorize {
             proxy_set_header Connection '';
             proxy_http_version 1.1;
             proxy_buffering off;

--- a/charts/langsmith/tests/remote_mcp_test.yaml
+++ b/charts/langsmith/tests/remote_mcp_test.yaml
@@ -173,6 +173,13 @@ tests:
       - matchRegex:
           path: data["nginx.conf"]
           pattern: "location = /api/.well-known/oauth-protected-resource/mcp"
+      # Root /oauth/* paths the SPA consent + device-activation pages submit to (single-origin).
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "location = /oauth/authorize/approve"
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "location = /oauth/device/authorize"
 
   - it: omits the /api MCP routes when no hostname is set
     template: templates/frontend/config-map.yaml


### PR DESCRIPTION
## Summary

Follow-up to [#762](https://github.com/langchain-ai/helm/pull/762). The OAuth **device flow** (used by `langsmith auth login` and other CLI clients) failed at the activation step on self-hosted: the `/activate` page showed **"Invalid or expired code"** even with a valid code.

## Root cause

The device-activation page (SPA at `/activate`) POSTs to the Authorization Server's **root** `/oauth/device/authorize`. In single-origin self-hosted, the SPA's backend origin is empty, so the request goes to the root path — but #762 only routed the two *consent* root paths (`/oauth/authorize/approve`, `/oauth/client/`), not the device one. The POST fell through to the SPA `location /` (405, non-JSON), and the page's fallback error is literally "Invalid or expired code." The request never reached platform-backend.

Verified on the dogfood:

```
POST /oauth/device/authorize        -> 405   (SPA fallback — the bug)
POST /api/oauth/device/authorize    -> 401   (reaches backend, as expected)
POST /oauth/authorize/approve       -> 401   (consent, already routed in #762)
```

## Fix

Route root `location = /oauth/device/authorize` to platform-backend (both basePath and non-basePath branches), mirroring the consent routes. Bumps chart `0.16.0-rc.1 -> 0.16.0-rc.2`.

This is the complete set of root `/oauth/*` browser endpoints — the frontend only calls `/oauth/authorize/approve`, `/oauth/client/`, and `/oauth/device/authorize` at root; the first two were covered, this adds the third.

## Test Plan

- [x] `helm unittest` — added assertions for both root `/oauth/authorize/approve` and `/oauth/device/authorize`
- [ ] Re-run `langsmith auth login --api-url https://<host>/api` against a deployment with this chart and confirm the `/activate` code is accepted
