### PR TITLE
fix: add missing salesforceOAuthProvider mapping

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.0-rc.1
+version: 0.16.0-rc.2
 appVersion: "0.16.1rc1"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.16.0-rc.2](https://img.shields.io/badge/Version-0.16.0--rc.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.4rc1](https://img.shields.io/badge/AppVersion-0.16.4rc1-informational?style=flat-square)
+![Version: 0.16.0-rc.3](https://img.shields.io/badge/Version-0.16.0--rc.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.4rc1](https://img.shields.io/badge/AppVersion-0.16.4rc1-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -86,6 +86,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | fleet.oauth.linkedinOAuthProvider | string | `""` |  |
 | fleet.oauth.microsoftOAuthProvider | string | `""` |  |
 | fleet.oauth.providerOrgId | string | `""` |  |
+| fleet.oauth.salesforceOAuthProvider | string | `""` |  |
 | fleet.oauth.slackBotId | string | `""` |  |
 | fleet.oauth.slackOAuthProvider | string | `""` |  |
 | fleet.oauth.slackSigningSecret | string | `""` |  |
@@ -877,6 +878,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | config.agentBuilder.oauth.linearOAuthProvider | string | `""` |  |
 | config.agentBuilder.oauth.linkedinOAuthProvider | string | `""` |  |
 | config.agentBuilder.oauth.microsoftOAuthProvider | string | `""` |  |
+| config.agentBuilder.oauth.salesforceOAuthProvider | string | `""` |  |
 | config.agentBuilder.oauth.slackBotId | string | `""` |  |
 | config.agentBuilder.oauth.slackOAuthProvider | string | `""` |  |
 | config.agentBuilder.oauth.slackSigningSecret | string | `""` |  |

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -1005,6 +1005,7 @@ Served through the frontend at /mcp (or /<basePath>/mcp).
 {{- $linearOAuth := .Values.config.agentBuilder.oauth.linearOAuthProvider | default .Values.fleet.oauth.linearOAuthProvider }}
 {{- $githubOAuth := .Values.config.agentBuilder.oauth.githubOAuthProvider | default .Values.fleet.oauth.githubOAuthProvider }}
 {{- $microsoftOAuth := .Values.config.agentBuilder.oauth.microsoftOAuthProvider | default .Values.fleet.oauth.microsoftOAuthProvider }}
+{{- $salesforceOAuth := .Values.config.agentBuilder.oauth.salesforceOAuthProvider | default .Values.fleet.oauth.salesforceOAuthProvider }}
 {{- if $googleOAuth }}
 - name: "GOOGLE_OAUTH_PROVIDER"
   value: {{ $googleOAuth | quote }}
@@ -1028,6 +1029,10 @@ Served through the frontend at /mcp (or /<basePath>/mcp).
 {{- if $microsoftOAuth }}
 - name: "MICROSOFT_OAUTH_PROVIDER"
   value: {{ $microsoftOAuth | quote }}
+{{- end }}
+{{- if $salesforceOAuth }}
+- name: "SALESFORCE_OAUTH_PROVIDER"
+  value: {{ $salesforceOAuth | quote }}
 {{- end }}
 {{- end -}}
 

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -145,6 +145,7 @@ fleet:
     linearOAuthProvider: ""
     githubOAuthProvider: ""
     microsoftOAuthProvider: ""
+    salesforceOAuthProvider: ""
     slackSigningSecret: ""
     slackBotId: ""
   apiServer:
@@ -888,12 +889,14 @@ config:
     # - linearOAuthProvider: Linear tools
     # - githubOAuthProvider: GitHub tools
     # - microsoftOAuthProvider: Outlook, Teams, SharePoint tools + Outlook trigger
+    # - salesforceOAuthProvider: Salesforce tools
     oauth:
       googleOAuthProvider: ""
       linkedinOAuthProvider: ""
       linearOAuthProvider: ""
       githubOAuthProvider: ""
       microsoftOAuthProvider: ""
+      salesforceOAuthProvider: ""
       slackOAuthProvider: ""
       slackSigningSecret: ""
       slackBotId: ""


### PR DESCRIPTION
## Summary

The Salesforce integration shipped for Fleet (langchainplus #20295) but the `SALESFORCE_OAUTH_PROVIDER` env var was never wired up in the Helm chart, so self-hosted customers have no supported way to enable it — the fleet tool server only registers Salesforce tools when the variable is set, so the integration never appears in the UI (reported via Pylon #24496 / AB-2687).

This adds `salesforceOAuthProvider` to `fleet.oauth` and the legacy `config.agentBuilder.oauth` block, plus the env var mapping in `agentBuilderOAuthEnvVars`, exactly mirroring the microsoftOAuthProvider fix (#672). The shared helper feeds all three services that read the variable: the fleet tool server (tool registration), the trigger server, and host-backend (public-provider allowlist). Default stays empty, so the integration remains disabled unless explicitly configured.

A docs PR for the self-hosted "Available providers" section (covering the Salesforce-side app setup) will follow under AB-2687.

## Verification

- `helm template` with `fleet.oauth.salesforceOAuthProvider=my-salesforce` (fleet + hostBackend enabled): `SALESFORCE_OAUTH_PROVIDER=my-salesforce` renders on the fleet tool-server, trigger-server, and host-backend deployments.
- `helm template` with the value unset: zero occurrences (fail-closed, matches the other providers).
- `helm lint` passes (pre-existing icon INFO only).

Linear: AB-2687