### PR TITLE
chore: repoint support@langchain.dev mentions to the Support Portal

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -905,7 +905,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | config.blobStorage.s3UsePathStyle | bool | `false` |  |
 | config.customCa.secretKey | string | `""` |  |
 | config.customCa.secretName | string | `""` | Optional. Used to set a file containing trusted CA certificates. Make sure to also include a public CA to access beacon and playground. |
-| config.customErrorSupportMessage | string | `""` | Custom error support message displayed on error pages (plain text). If empty, defaults to the built-in support messages with support@langchain.dev links. |
+| config.customErrorSupportMessage | string | `""` | Custom error support message displayed on error pages (plain text). If empty, defaults to the built-in support messages linking to our Support Portal (https://support.langchain.com). |
 | config.customLogo | object | `{"coBrandingEnabled":true,"enabled":false,"logoUrl":""}` | Custom logo configuration. If enabled, the logoUrl and coBrandingEnabled values must be provided. The logoUrl must be a valid URL to an image like png, jpg, or svg. Co-branding will show LangSmith and customer logos side by side. |
 | config.defaultWorkspaceName | string | `"Workspace 1"` | Default workspace name to be provisioned when org is created. |
 | config.deployment | object | `{"basePath":"","enabled":false,"ingressHealthCheckEnabled":true,"tlsEnabled":true}` | Configuration for LangSmith Deployments features |

--- a/charts/langsmith/docs/UPGRADE-0.2.x.md
+++ b/charts/langsmith/docs/UPGRADE-0.2.x.md
@@ -72,7 +72,7 @@ langsmith-queue-d58cb64f7-87d68          1/1     Running     0          15h
     ![.langsmith_ui.png](../langsmith_ui.png)
 
 Note that old runs will not be visibile in the UI unless you migrate them. See [Migrating old runs](#migrating-old-runs) for more information.
-This step is only required if you need access to run data from before the upgrade to Langsmith 0.2.x. If you are unsure or need assistance, please reach out to support@langchain.dev and we'd be happy to help.
+This step is only required if you need access to run data from before the upgrade to Langsmith 0.2.x. If you are unsure or need assistance, please contact technical support via our [Support Portal](https://support.langchain.com) and we'd be happy to help.
 
 # Migrating old runs
 

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1037,7 +1037,7 @@ config:
     coBrandingEnabled: true
 
   # -- Custom error support message displayed on error pages (plain text).
-  # If empty, defaults to the built-in support messages with support@langchain.dev links.
+  # If empty, defaults to the built-in support messages linking to our Support Portal (https://support.langchain.com).
   customErrorSupportMessage: ""
 
   # -- Enables Google IAP (Identity-Aware Proxy) session handling in the frontend.


### PR DESCRIPTION
## What
Repoints customer-facing mentions of `support@langchain.dev` to the Support Portal (https://support.langchain.com), part of the org-wide cleanup to route users through the portal instead of a raw mailto.

## Notes
- User-facing strings/links only, no logic changes.
- "Support Portal" is the visible link text in rendered surfaces (JSX/MDX/HTML); plain-text error strings use "contact technical support via our Support Portal (https://support.langchain.com)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)