### PR TITLE
feat(langsmith): add kubectl describe pod to debugging script

### DIFF
--- a/charts/langsmith/scripts/get_k8s_debugging_info.sh
+++ b/charts/langsmith/scripts/get_k8s_debugging_info.sh
@@ -33,9 +33,13 @@ kubectl top pods -n "$NS" --containers > "$DIR/pod-resource-usage.txt"
 
 echo "Pulling container logs for all pods. Also pulling previous logs from restarted containers..."
 mkdir -p "$DIR/logs"
+mkdir -p "$DIR/describe"
 PODS=$(kubectl get pods -n "$NS" -o jsonpath='{.items[*].metadata.name}')
 
 for POD in $PODS; do
+  echo "Describing pod $POD..."
+  kubectl describe pod "$POD" -n "$NS" > "$DIR/describe/${POD}_describe.txt" 2>/dev/null
+
   CONTAINERS=$(kubectl get pod "$POD" -n "$NS" -o jsonpath='{.spec.containers[*].name}')
   for CONTAINER in $CONTAINERS; do
     echo "Pulling current container logs (last 24h) for $POD/$CONTAINER..."


### PR DESCRIPTION
## Summary
- Adds `kubectl describe pod` output to the `get_k8s_debugging_info.sh` debugging script
- Describe output is saved to `describe/<pod>_describe.txt` for each pod in the namespace
- The new `describe/` directory is included in the final zip/tar bundle alongside existing logs

## Why
`kubectl describe pod` surfaces events, resource requests/limits, image pull errors, scheduling failures, and probe statuses that aren't visible in logs alone. This makes the debug bundle more self-contained for support triage.
