### PR TITLE
fix: route v2 dataset experiment runs

### DIFF
--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -137,6 +137,15 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
 
+        location /{{ .Values.config.basePath }}/api/v2/datasets/ {
+            rewrite /{{ .Values.config.basePath }}/api/v2/datasets/(.*) /v2/datasets/$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
         {{- if and .Values.smithdb.enabled .Values.smithdb.langsmith.frontend.useSmithDBEndpoints }}
         location /{{ .Values.config.basePath }}/api/v2/ {
             rewrite /{{ .Values.config.basePath }}/api/v2/(.*) /v2/$1  break;
@@ -746,6 +755,15 @@ data:
         # Platform Backend Routes
         location /api/v1/platform/ {
             rewrite /api/v1/platform/(.*) /v1/platform/$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        location /api/v2/datasets/ {
+            rewrite /api/v2/datasets/(.*) /v2/datasets/$1  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
             proxy_buffering off;


### PR DESCRIPTION
## Description
Routes `/api/v2/datasets/*` requests in the LangSmith frontend config map to platform-backend so self-hosted experiment-runs calls reach smith-go even when generic SmithDB v2 routing is disabled.

## Self-Hosted Release Note pls
Fixes self-hosted routing for v2 dataset experiment-runs requests.

## Test Plan
- [x] Rendered the LangSmith chart with and without `config.basePath` and confirmed the dataset v2 location is present.

Made by [Open SWE](https://openswe.vercel.app/agents/2e87df3b-8c8d-1a2a-1633-a259817c8209)