### PR TITLE
feat: adding resource contention/insights

### DIFF
--- a/charts/mission-control/Chart.yaml
+++ b/charts/mission-control/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: mission-control
 description: Mission Control to deploy and manage Langsmith in EKS
-version: 1.1.0
-appVersion: "1.1.0"
+version: 1.2.0
+appVersion: "1.2.0"

--- a/charts/mission-control/README.md
+++ b/charts/mission-control/README.md
@@ -1,6 +1,6 @@
 # mission-control
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 Mission Control to deploy and manage Langsmith in EKS
 
@@ -47,6 +47,7 @@ All write operations and external egress are gated behind Helm feature flags. Wi
 | `features.configSave` | `true` | Draft config persistence to a K8s Secret |
 | `features.discover` | `true` | Infra discovery scan (connection strings, license keys) |
 | `features.deploy` | `true` | In-UI `helm upgrade --install` (LangSmith + sibling charts) |
+| `features.contention` | `false` | Contention Insights — Redis/Postgres/ClickHouse probes + incident persistence (opt-in; adds pods/exec + configmap/secret write verbs) |
 
 Read-only console  zero write verbs, no external egress:
 
@@ -117,6 +118,7 @@ helm install mission-control langchain/mission-control \
 | config.features.alerts | bool | `true` | Alert notifications (SMTP + webhook). Grants write access to alert-config secrets. Egress: outbound SMTP and webhook to the configured endpoints. |
 | config.features.chat | bool | `true` | Chat assistant: floating widget that proxies to chat.langchain.com. Egress: outbound HTTPS to chat.langchain.com and *.us.langgraph.app. |
 | config.features.configSave | bool | `true` | Persists working configuration to the draft Kubernetes Secret. Grants write access to the mission-control-draft secret. |
+| config.features.contention | bool | `false` | Contention insights: live probe of Redis/Postgres/ClickHouse/workers plus a background detector that persists incidents as Secrets. Grants update/delete on the `mission-control-contention-config` ConfigMap and unscoped secrets:create,delete for incident storage (incident names carry per-second timestamps which cannot be enumerated up front). Defaults to false: existing installs upgrading the chart do not silently gain the new RBAC verbs. Set to true to enable the sidebar tab and the /api/contention/* endpoints. |
 | config.features.dbTools | bool | `true` | Database detection, preflight checks, and support query execution. Adds no extra RBAC verbs; gates the /db/* endpoints at the application layer. |
 | config.features.deploy | bool | `true` |  |
 | config.features.diagnostics | bool | `true` | Diagnostic bundle download (pod logs + resource manifests packaged as a zip). |

--- a/charts/mission-control/README.md.gotmpl
+++ b/charts/mission-control/README.md.gotmpl
@@ -47,6 +47,7 @@ All write operations and external egress are gated behind Helm feature flags. Wi
 | `features.configSave` | `true` | Draft config persistence to a K8s Secret |
 | `features.discover` | `true` | Infra discovery scan (connection strings, license keys) |
 | `features.deploy` | `true` | In-UI `helm upgrade --install` (LangSmith + sibling charts) |
+| `features.contention` | `false` | Contention Insights — Redis/Postgres/ClickHouse probes + incident persistence (opt-in; adds pods/exec + configmap/secret write verbs) |
 
 Read-only console  zero write verbs, no external egress:
 

--- a/charts/mission-control/install-script.sh
+++ b/charts/mission-control/install-script.sh
@@ -305,6 +305,10 @@ config:
     dbTools: true
     deploy: true
     valuesOverride: true
+    # Contention Insights is opt-in: set to true to gain new RBAC verbs
+    # (configmap update/delete on `mission-control-contention-config`;
+    # unscoped secrets:create,delete for dynamic incident secret names).
+    contention: false
   discoverNamespaces: ""
 
 diagnostics:

--- a/charts/mission-control/templates/backend/cluster-role.yaml
+++ b/charts/mission-control/templates/backend/cluster-role.yaml
@@ -179,6 +179,47 @@ rules:
     verbs: ["delete"]
   {{- end }}
 
+  # ── Contention Insights (disable via features.contention=false) ──────────
+  # Read-only probes use the existing pods/configmaps read verbs above. The
+  # detector additionally needs to:
+  #   - update/delete its own ConfigMap (scoped by name below)
+  #   - create the ConfigMap on first write (unscoped - RBAC create cannot be
+  #     scoped by resourceName; application layer writes only the named CM)
+  #   - create + delete incident Secrets named
+  #     `mission-control-contention-incident-<unix_ts>`. resourceNames cannot
+  #     match a prefix and incident names are dynamic, so secrets:create,delete
+  #     are unscoped under this flag. Same trade-off as the deploy block.
+  #     Set features.contention=false to remove these verbs entirely.
+  {{- if (default false .Values.config.features.contention) }}
+  # The DB probes exec read-only commands (redis-cli INFO/SLOWLOG/XLEN,
+  # psql -c SELECT, clickhouse-client SELECT) inside the data-store pods via the
+  # K8s exec API. k8s_exec.py uses kubernetes.stream(connect_get_namespaced_pod_exec),
+  # which issues a GET against the pods/exec subresource, so "get" is required;
+  # "create" is retained for POST/kubectl-style exec. Without "get" the probe fails
+  # with 403 "cannot get resource pods/exec" even though "create" is allowed. The
+  # exec layer (k8s_exec.py) restricts the executable to a fixed allowlist
+  # (redis-cli/psql/clickhouse-client/sh) running hardcoded commands; log-signal
+  # probes use the pods/log read verb above.
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["update", "delete", "patch"]
+    resourceNames:
+      - mission-control-contention-config
+  {{- if not .Values.config.features.deploy }}
+  # Only add unscoped secret create/delete here if deploy hasn't already
+  # granted them (avoids duplicate rules in the rendered ClusterRole).
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "delete"]
+  {{- end }}
+  {{- end }}
+
   # ── Adopt button (disable via features.adopt=false) ───────────────────────
   # Patches Helm ownership annotations onto existing resources so helm upgrade
   # can manage resources that were created outside the release.

--- a/charts/mission-control/templates/backend/statefulset.yaml
+++ b/charts/mission-control/templates/backend/statefulset.yaml
@@ -117,6 +117,8 @@ spec:
               value: {{ ternary "true" "false" .Values.config.features.dbTools | quote }}
             - name: MC_FEATURE_VALUES_OVERRIDE
               value: {{ ternary "true" "false" .Values.config.features.valuesOverride | quote }}
+            - name: MC_FEATURE_CONTENTION
+              value: {{ ternary "true" "false" (default false .Values.config.features.contention) | quote }}
             {{- if .Values.config.discoverNamespaces }}
             - name: DISCOVER_NAMESPACES
               value: {{ .Values.config.discoverNamespaces | quote }}

--- a/charts/mission-control/values.yaml
+++ b/charts/mission-control/values.yaml
@@ -42,6 +42,8 @@ config:
 
   # Feature flags. Disabling a flag removes its write verbs from the ClusterRole.
   # With every flag false the ClusterRole is read-only.
+  # Contention Insights (`contention`, below) is opt-in: it defaults to false so
+  # existing installs do not silently gain new RBAC verbs on upgrade.
   features:
     # -- Fix Issue button: deletes pods stuck in CreateContainerConfigError. Grants pods:delete.
     fixIssue: true
@@ -75,6 +77,15 @@ config:
     # `mission-control-values-overrides` Secret. Set to false to remove the pill
     # and 403 the /api/values-overrides/* endpoints.
     valuesOverride: true
+    # -- Contention insights: live probe of Redis/Postgres/ClickHouse/workers
+    # plus a background detector that persists incidents as Secrets. Grants
+    # update/delete on the `mission-control-contention-config` ConfigMap and
+    # unscoped secrets:create,delete for incident storage (incident names
+    # carry per-second timestamps which cannot be enumerated up front).
+    # Defaults to false: existing installs upgrading the chart do not silently
+    # gain the new RBAC verbs. Set to true to enable the sidebar tab and the
+    # /api/contention/* endpoints.
+    contention: false
 
   # -- Extra namespaces (comma-separated) the discover feature is allowed to scan.
   # Default scans only the chart's release namespace to prevent cross-namespace secret


### PR DESCRIPTION
Summary

- Adds a new optional "Contention Insights" feature (off by default) existing installs are unaffected on upgrade
- When turned on, lets Mission Control probe Redis, Postgres, and ClickHouse for contention and surface incidents in the UI
- Requires a few extra Kubernetes permissions to do the probing these are only granted when the feature is explicitly enabled
- Bumps the chart version to 1.2.0