### PR TITLE
fix(langsmith): route /api/v1/traces to platform-backend in self-hosted nginx

### DIFF
--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -328,6 +328,15 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
 
+        location /{{ .Values.config.basePath }}/api/v1/traces {
+            rewrite /{{ .Values.config.basePath }}/api/v1/traces/(.*) /traces/$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
     {{- if .Values.config.hostname }}
         # Remote MCP server (OAuth-protected) under /api -> platform-backend.
         # OAuth 2.1 discovery (RFC 8414 / RFC 9728), token endpoints, and the MCP JSON-RPC endpoint.
@@ -945,6 +954,15 @@ data:
 
         location /api/v1/commits {
             rewrite /api/v1/commits/(.*) /commits/$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        location /api/v1/traces {
+            rewrite /api/v1/traces/(.*) /traces/$1  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
             proxy_buffering off;


### PR DESCRIPTION
## Summary

- `GET /api/v1/traces/{id}/runs` is the streaming trace-runs endpoint that powers the trace detail view in self-hosted
- Without an explicit nginx rule, the request falls through to the `location /api/v1` catch-all which routes to the Python backend — Python has no such route, resulting in a 404 and a blank trace detail panel
- Adds `location /api/v1/traces` → `platformBackend` (smith-go) in both server blocks, following the same pattern as `/api/v1/commits`

The rewrite strips the prefix and forwards to smith-go, which handles `GET /traces/{trace_id}/runs`.

See langchain-ai/langchainplus#28262 for the companion fix to `smith-backend/nginx/nginx.conf` (docker-compose deployments).

Fixes LSO-3015

## Self-Hosted Release Note

Fixes a bug where opening a trace in the trace detail view shows no runs (blank panel) on self-hosted Kubernetes deployments.

## Test Plan

- [x] Code change verified by pattern match against the existing `/api/v1/commits` rule, which routes the same way and is confirmed working in self-hosted
- [x] Post-merge: confirm `GET /api/v1/traces/{id}/runs` returns 200 on the self-hosted preview from langchain-ai/langchainplus#28262 once ArgoCD syncs the updated chart