### PR TITLE
chore: bump chart version to 0.16.0-rc.5

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.0-rc.4
+version: 0.16.0-rc.5
 appVersion: "0.16.5rc1"


### PR DESCRIPTION
## Summary

Bumps chart version `0.16.0-rc.4` → `0.16.0-rc.5` so `chart-releaser-action` publishes a new Helm release containing the `/api/v1/traces` nginx routing fix from #777.

Without this bump, `CR_SKIP_EXISTING: true` skips release creation and self-hosted customers cannot `helm upgrade` to get the fix.

## Test Plan

- [x] Merge unblocks self-hosted customers from getting the traces routing fix via `helm upgrade`