### PR TITLE
feat(langsmith): add preInstallManifests for pre-install hook ordering

### DIFF
--- a/charts/langsmith/templates/pre-install-manifests.yaml
+++ b/charts/langsmith/templates/pre-install-manifests.yaml
@@ -1,0 +1,50 @@
+{{- /*
+Renders each entry in .Values.preInstallManifests as a Helm pre-install /
+pre-upgrade hook so the resource is applied before the rest of the chart's
+manifests. Intended for prerequisites the chart consumes during install/upgrade
+-- for example, an ExternalSecret (External Secrets Operator) whose
+materialized Kubernetes Secret is referenced via `config.existingSecretName`
+or the per-datastore `*.external.existingSecretName` values.
+
+Entry forms
+-----------
+Each entry may be a YAML object or a multi-line YAML string. Both are rendered
+through `tpl` so template expressions like `{{ .Release.Name }}` work. Each
+entry must be a single resource (no `---` separators inside one string).
+
+Annotation handling
+-------------------
+The following annotations are injected automatically. User-provided values for
+the same keys take precedence, so the template is idempotent for manifests
+that already carry hook annotations -- partial overrides are merged
+(any default the user did not set is still applied).
+
+  helm.sh/hook: pre-install,pre-upgrade
+  helm.sh/hook-weight: "-5"
+  helm.sh/hook-delete-policy: before-hook-creation
+
+Caveats
+-------
+Hook resources are not tracked as part of the Helm release and are recreated
+on every upgrade. For ExternalSecret entries, prefer
+`target.creationPolicy: Orphan` (or `target.deletionPolicy: Retain` on newer
+ESO versions) so the materialized Secret survives upgrades and pods consuming
+it don't restart.
+*/ -}}
+{{- range .Values.preInstallManifests }}
+{{- $manifest := . }}
+{{- if typeIs "string" $manifest }}
+{{-   $manifest = tpl . $ | fromYaml }}
+{{- else }}
+{{-   $manifest = tpl (toYaml .) $ | fromYaml }}
+{{- end }}
+{{- $_ := set $manifest "metadata" (default (dict) $manifest.metadata) }}
+{{- $hookAnnotations := dict
+      "helm.sh/hook" "pre-install,pre-upgrade"
+      "helm.sh/hook-weight" "-5"
+      "helm.sh/hook-delete-policy" "before-hook-creation" }}
+{{- $userAnnotations := default (dict) $manifest.metadata.annotations }}
+{{- $_ := set $manifest.metadata "annotations" (merge $userAnnotations $hookAnnotations) }}
+---
+{{ toYaml $manifest }}
+{{- end }}

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -6,6 +6,31 @@ nameOverride: ""
 fullnameOverride: ""
 # -- Namespace to install the chart into. If not set, will use the namespace of the current context.
 namespace: ""
+# -- Prerequisite manifests rendered as Helm pre-install / pre-upgrade hooks so they
+# -- are applied before the rest of the chart's resources. Typical use case is an
+# -- ExternalSecret that produces a Secret consumed via `config.existingSecretName`.
+# -- See `templates/pre-install-manifests.yaml` for entry forms, injected
+# -- annotations, idempotency rules, and caveats.
+# Example:
+# preInstallManifests:
+#   - apiVersion: external-secrets.io/v1beta1
+#     kind: ExternalSecret
+#     metadata:
+#       name: langsmith-app
+#     spec:
+#       refreshInterval: 1h
+#       secretStoreRef:
+#         name: vault-backend
+#         kind: ClusterSecretStore
+#       target:
+#         name: langsmith-app-secret
+#         creationPolicy: Orphan
+#       data:
+#         - secretKey: langsmith_license_key
+#           remoteRef:
+#             key: secret/langsmith/app
+#             property: langsmith_license_key
+preInstallManifests: []
 # -- Annotations that will be applied to all resources created by the chart
 commonAnnotations: {}
 # -- Annotations that will be applied to all pods created by the chart


### PR DESCRIPTION
Adds a top-level preInstallManifests list to the langsmith chart. Each entry is rendered as a Helm pre-install/pre-upgrade hook so the resource is applied before the rest of the chart's manifests.

Primary use case is an ExternalSecret (External Secrets Operator) whose materialized Secret is referenced via config.existingSecretName or the per-datastore *.external.existingSecretName values.

Hook annotations are injected automatically with user values taking precedence for partial overrides. Default is [] so existing installs are unaffected.