### PR TITLE
feat(langsmith): allow uncapping CPU/memory limits for self-hosted deployments

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1178,9 +1178,10 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | config.customErrorSupportMessage | string | `""` | Custom error support message displayed on error pages (plain text). If empty, defaults to the built-in support messages linking to our Support Portal (https://support.langchain.com). |
 | config.customLogo | object | `{"coBrandingEnabled":true,"enabled":false,"logoUrl":""}` | Custom logo configuration. If enabled, the logoUrl and coBrandingEnabled values must be provided. The logoUrl must be a valid URL to an image like png, jpg, or svg. Co-branding will show LangSmith and customer logos side by side. |
 | config.defaultWorkspaceName | string | `"Workspace 1"` | Default workspace name to be provisioned when org is created. |
-| config.deployment | object | `{"basePath":"","enabled":false,"ingressHealthCheckEnabled":true,"tlsEnabled":true}` | Configuration for LangSmith Deployments features |
+| config.deployment | object | `{"basePath":"","enabled":false,"ingressHealthCheckEnabled":true,"tlsEnabled":true,"uncappedResourcesEnabled":false}` | Configuration for LangSmith Deployments features |
 | config.deployment.basePath | string | `""` | Base path for LangSmith Deployments routes managed by the operator. |
 | config.deployment.enabled | bool | `false` | Optional. Used to enable the LangSmith Deployments feature. Requires additional setup. Refer to the documentation for more information. |
+| config.deployment.uncappedResourcesEnabled | bool | `false` | Lift the SaaS CPU/memory caps on LangSmith Deployments resource specs. Opt-in for self-hosted. |
 | config.disableSecretCreation | bool | `false` |  |
 | config.existingSecretName | string | `""` |  |
 | config.googleIapEnabled | bool | `false` | Enables Google IAP (Identity-Aware Proxy) session handling in the frontend. When true, the frontend adds required IAP headers, uses credentialed fetches, and handles 401 re-auth via GCP's session refresh mechanism. |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1178,7 +1178,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | config.customErrorSupportMessage | string | `""` | Custom error support message displayed on error pages (plain text). If empty, defaults to the built-in support messages linking to our Support Portal (https://support.langchain.com). |
 | config.customLogo | object | `{"coBrandingEnabled":true,"enabled":false,"logoUrl":""}` | Custom logo configuration. If enabled, the logoUrl and coBrandingEnabled values must be provided. The logoUrl must be a valid URL to an image like png, jpg, or svg. Co-branding will show LangSmith and customer logos side by side. |
 | config.defaultWorkspaceName | string | `"Workspace 1"` | Default workspace name to be provisioned when org is created. |
-| config.deployment | object | `{"basePath":"","enabled":false,"ingressHealthCheckEnabled":true,"tlsEnabled":true,"uncappedResourcesEnabled":false}` | Configuration for LangSmith Deployments features |
+| config.deployment | object | `{"basePath":"","enabled":false,"ingressHealthCheckEnabled":true,"tlsEnabled":true,"uncappedResourcesEnabled":false}` | Configuration for LangSmith Deployment features |
 | config.deployment.basePath | string | `""` | Base path for LangSmith Deployments routes managed by the operator. |
 | config.deployment.enabled | bool | `false` | Optional. Used to enable the LangSmith Deployments feature. Requires additional setup. Refer to the documentation for more information. |
 | config.deployment.uncappedResourcesEnabled | bool | `false` | Lift the SaaS CPU/memory caps on LangSmith Deployments resource specs. Opt-in for self-hosted. |

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -450,6 +450,8 @@ Template containing common environment variables that are used by several servic
 {{- end }}
 - name: ENABLE_LGP_DEPLOYMENT_HEALTH_CHECK
   value: {{ .Values.config.deployment.ingressHealthCheckEnabled | quote }}
+- name: ENABLE_UNCAPPED_LGP_DEPLOYMENT_RESOURCES
+  value: {{ .Values.config.deployment.uncappedResourcesEnabled | quote }}
 {{- if and .Values.config.customCa.secretName .Values.config.customCa.secretKey }}
 - name: SSL_CERT_FILE
   value: /etc/ssl/certs/custom-ca-certificates.crt

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -912,7 +912,7 @@ config:
     tlsEnabled: true
     # Disable this if there is restricted access to the external facing ingress endpoint for your agent(s) from inside of your kubernetes cluster.
     ingressHealthCheckEnabled: true
-    # -- Lift the SaaS CPU/memory caps on LangSmith Deployments resource specs. Opt-in for self-hosted.
+    # -- Lift the SaaS CPU/memory caps on LangSmith Deployment resource specs. Opt-in for self-hosted.
     uncappedResourcesEnabled: false
 
   # DEPRECATED: use the top-level fleet block (fleet/fleetToolServer/

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -912,6 +912,8 @@ config:
     tlsEnabled: true
     # Disable this if there is restricted access to the external facing ingress endpoint for your agent(s) from inside of your kubernetes cluster.
     ingressHealthCheckEnabled: true
+    # -- Lift the SaaS CPU/memory caps on LangSmith Deployments resource specs. Opt-in for self-hosted.
+    uncappedResourcesEnabled: false
 
   # DEPRECATED: use the top-level fleet block (fleet/fleetToolServer/
   # fleetTriggerServer) instead. This bundled-agent path is managed by


### PR DESCRIPTION
## Summary

Exposes a chart value to lift the CPU/memory caps on **LangSmith Deployments** (LangGraph Platform) resource specs for self-hosted installs.

- Adds `config.deployment.uncappedResourcesEnabled` (default `false`), wired to the `ENABLE_UNCAPPED_LGP_DEPLOYMENT_RESOURCES` env var through `langsmith.commonEnv` — following the existing `ENABLE_LGP_DEPLOYMENT_HEALTH_CHECK` / `config.deployment.ingressHealthCheckEnabled` pattern (both are host-backend settings).
- When enabled, the host-backend's `ResourceSpec` validators skip the SaaS **upper** caps (e.g. 8/16 cores, 16–32 GB). Floors (0.1 CPU, 128/512 MB) and the 128 MB granularity are still enforced.
- Default `false` matches the backend default, so existing installs are unaffected.

Companion to langchain-ai/langchainplus#27405, which added the `ENABLE_UNCAPPED_LGP_DEPLOYMENT_RESOURCES` setting to `host-backend`.

## New values

`config.deployment.uncappedResourcesEnabled` (bool, default `false`).

## Self-Hosted Release Note

Self-hosted operators can now set `config.deployment.uncappedResourcesEnabled: true` to lift the CPU/memory upper caps on LangSmith Deployments (LangGraph Platform) resource specs, allowing agents larger than the default SaaS limits. Minimum sizes and 128 MB granularity still apply. Defaults to `false`.

## Test Plan

- [x] `helm template` with `--set config.deployment.uncappedResourcesEnabled=true` renders `ENABLE_UNCAPPED_LGP_DEPLOYMENT_RESOURCES` with `value: "true"`; default render yields `value: "false"` (present on all component deployments via `commonEnv`)
- [x] `helm lint` passes
- [ ] `helm unittest` (run in CI; no existing snapshot references this env var)
