### PR TITLE
chore: release 1.2.1 — namespace-scoped RBAC + deploy off by default

### DIFF
--- a/charts/mission-control/Chart.yaml
+++ b/charts/mission-control/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: mission-control
 description: Mission Control to deploy and manage Langsmith in EKS
-version: 1.2.0
+version: 1.2.1
 appVersion: "1.2.0"

--- a/charts/mission-control/README.md
+++ b/charts/mission-control/README.md
@@ -1,6 +1,6 @@
 # mission-control
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 Mission Control to deploy and manage Langsmith in EKS
 
@@ -48,6 +48,7 @@ All write operations and external egress are gated behind Helm feature flags. Wi
 | `features.discover` | `true` | Infra discovery scan (connection strings, license keys) |
 | `features.deploy` | `true` | In-UI `helm upgrade --install` (LangSmith + sibling charts) |
 | `features.contention` | `false` | Contention Insights — Redis/Postgres/ClickHouse probes + incident persistence (opt-in; adds pods/exec + configmap/secret write verbs) |
+| `features.deployClusterScopedResources` | `false` | Allow deploy to create/manage cluster-scoped objects (Namespaces, CRDs, ClusterRoles/ClusterRoleBindings). Off by default; namespace-scoped deploy uses a Role instead. |
 
 Read-only console  zero write verbs, no external egress:
 
@@ -121,6 +122,7 @@ helm install mission-control langchain/mission-control \
 | config.features.contention | bool | `false` | Contention insights: live probe of Redis/Postgres/ClickHouse/workers plus a background detector that persists incidents as Secrets. Grants update/delete on the `mission-control-contention-config` ConfigMap and unscoped secrets:create,delete for incident storage (incident names carry per-second timestamps which cannot be enumerated up front). Defaults to false: existing installs upgrading the chart do not silently gain the new RBAC verbs. Set to true to enable the sidebar tab and the /api/contention/* endpoints. |
 | config.features.dbTools | bool | `true` | Database detection, preflight checks, and support query execution. Adds no extra RBAC verbs; gates the /db/* endpoints at the application layer. |
 | config.features.deploy | bool | `true` |  |
+| config.features.deployClusterScopedResources | bool | `false` | Allow the deploy feature to create and manage cluster-scoped resources (Namespaces, ClusterRoles, ClusterRoleBindings, CRDs). When false (default) the deploy RBAC is namespace-scoped only (Role + RoleBinding); cluster-level write verbs are not granted. Set to true only when Mission Control needs to install charts that create cluster-level objects. |
 | config.features.diagnostics | bool | `true` | Diagnostic bundle download (pod logs + resource manifests packaged as a zip). |
 | config.features.discover | bool | `true` | Namespace-scoped infrastructure discovery via the /api/discover endpoint. Adds no extra RBAC verbs; gates the endpoint at the application layer. |
 | config.features.fixIssue | bool | `true` | Fix Issue button: deletes pods stuck in CreateContainerConfigError. Grants pods:delete. |

--- a/charts/mission-control/README.md.gotmpl
+++ b/charts/mission-control/README.md.gotmpl
@@ -48,6 +48,7 @@ All write operations and external egress are gated behind Helm feature flags. Wi
 | `features.discover` | `true` | Infra discovery scan (connection strings, license keys) |
 | `features.deploy` | `true` | In-UI `helm upgrade --install` (LangSmith + sibling charts) |
 | `features.contention` | `false` | Contention Insights — Redis/Postgres/ClickHouse probes + incident persistence (opt-in; adds pods/exec + configmap/secret write verbs) |
+| `features.deployClusterScopedResources` | `false` | Allow deploy to create/manage cluster-scoped objects (Namespaces, CRDs, ClusterRoles/ClusterRoleBindings). Off by default; namespace-scoped deploy uses a Role instead. |
 
 Read-only console  zero write verbs, no external egress:
 

--- a/charts/mission-control/templates/backend/cluster-role.yaml
+++ b/charts/mission-control/templates/backend/cluster-role.yaml
@@ -234,77 +234,23 @@ rules:
     verbs: ["patch"]
   {{- end }}
 
-  # ── Deploy feature (disable via features.deploy=false - on by default) ────
-  # Required by `helm upgrade --install <release> <chart>` executed from the
-  # UI. The chart name flows from a server-side allowlist (CHART_REGISTRY),
-  # not from user input, so unknown charts cannot be installed via this verb
-  # set.
+  # ── Deploy feature: cluster-scoped write verbs (opt-in) ──────────────────
+  # Namespace-scoped deploy write verbs have moved to role.yaml (Kind: Role)
+  # so that a standard deploy only requires namespace-level access.
   #
-  # Why some verbs are unscoped here even though the MC-managed secret list
-  # above is scoped by name:
-  #   • Helm itself stores release state in Secrets named
-  #     `sh.helm.release.v1.<release>.v<N>` and prunes old revisions, so it
-  #     needs cluster-wide secrets:create,update,delete to function.
-  #   • Charts in the langchain repo create Secrets/ConfigMaps with names
-  #     chosen by the chart author (e.g. `langsmith-config`); these cannot
-  #     be enumerated at chart-install time.
-  # The trade-off: enabling deploy grants Mission Control broad write rights
-  # on secrets/configmaps in the cluster. Set features.deploy=false in
-  # compliance-sensitive installs to revert to the scoped, read-mostly mode.
-  {{- if .Values.config.features.deploy }}
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["watch", "update", "delete"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "patch"]
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["create", "update", "patch", "delete"]
-  - apiGroups: [""]
-    resources: ["services", "persistentvolumeclaims", "serviceaccounts"]
-    verbs: ["create", "update", "patch", "delete"]
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["create", "update", "patch", "delete"]
+  # This ClusterRole block is only rendered when
+  # features.deployClusterScopedResources=true, which opts in to the broader
+  # cluster-level writes needed by charts that create Namespaces, CRDs, or
+  # ClusterRoles/ClusterRoleBindings. Default is false.
+  {{- if and .Values.config.features.deploy (default false .Values.config.features.deployClusterScopedResources) }}
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["create"]
-  - apiGroups: ["apps"]
-    resources: ["deployments", "statefulsets", "daemonsets"]
-    verbs: ["create", "update", "patch", "delete"]
-  - apiGroups: ["batch"]
-    resources: ["jobs", "cronjobs"]
-    verbs: ["create", "update", "patch", "delete"]
-  - apiGroups: ["networking.k8s.io"]
-    resources: ["ingresses", "networkpolicies"]
-    verbs: ["create", "update", "patch", "delete"]
-  - apiGroups: ["policy"]
-    resources: ["poddisruptionbudgets"]
-    verbs: ["create", "update", "patch", "delete"]
-  - apiGroups: ["autoscaling"]
-    resources: ["horizontalpodautoscalers"]
-    verbs: ["create", "update", "patch", "delete"]
   - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["roles", "rolebindings", "clusterroles", "clusterrolebindings"]
+    resources: ["clusterroles", "clusterrolebindings"]
     verbs: ["create", "update", "patch", "delete"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
-    verbs: ["create", "update", "patch", "delete"]
-  - apiGroups: ["apps.langchain.ai"]
-    resources: ["lgps", "lgps/finalizers", "lgps/status"]
-    verbs: ["create", "update", "patch", "delete"]
-  - apiGroups: ["keda.sh"]
-    resources: ["scaledobjects"]
-    verbs: ["create", "update", "patch", "delete"]
-  - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["httproutes"]
-    verbs: ["create", "update", "patch", "delete"]
-  - apiGroups: ["networking.istio.io"]
-    resources: ["virtualservices"]
-    verbs: ["create", "update", "patch", "delete"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
     verbs: ["create", "update", "patch", "delete"]
   {{- end }}
 {{- end }}

--- a/charts/mission-control/templates/backend/role-binding.yaml
+++ b/charts/mission-control/templates/backend/role-binding.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.backend.serviceAccount.create .Values.config.features.deploy }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "missionControl.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "missionControl.labels" . | nindent 4 }}
+  {{- with (include "missionControl.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "missionControl.serviceAccountName" . }}
+    namespace: {{ .Values.namespace | default .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "missionControl.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/mission-control/templates/backend/role.yaml
+++ b/charts/mission-control/templates/backend/role.yaml
@@ -1,0 +1,67 @@
+{{- if and .Values.backend.serviceAccount.create .Values.config.features.deploy }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "missionControl.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "missionControl.labels" . | nindent 4 }}
+  {{- with (include "missionControl.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+rules:
+  # ── Deploy feature: namespace-scoped write verbs ──────────────────────────
+  # These verbs are required by `helm upgrade --install` executed from the UI.
+  # Cluster-scoped write verbs (Namespaces, CRDs, ClusterRoles) live in the
+  # ClusterRole and are only rendered when
+  # features.deployClusterScopedResources=true.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["watch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["services", "persistentvolumeclaims", "serviceaccounts"]
+    verbs: ["create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets"]
+    verbs: ["create", "update", "patch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["create", "update", "patch", "delete"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "networkpolicies"]
+    verbs: ["create", "update", "patch", "delete"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["create", "update", "patch", "delete"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["create", "update", "patch", "delete"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
+    verbs: ["create", "update", "patch", "delete"]
+  - apiGroups: ["apps.langchain.ai"]
+    resources: ["lgps", "lgps/finalizers", "lgps/status"]
+    verbs: ["create", "update", "patch", "delete"]
+  - apiGroups: ["keda.sh"]
+    resources: ["scaledobjects"]
+    verbs: ["create", "update", "patch", "delete"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["create", "update", "patch", "delete"]
+  - apiGroups: ["networking.istio.io"]
+    resources: ["virtualservices"]
+    verbs: ["create", "update", "patch", "delete"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "update", "patch", "delete"]
+{{- end }}

--- a/charts/mission-control/templates/backend/statefulset.yaml
+++ b/charts/mission-control/templates/backend/statefulset.yaml
@@ -119,6 +119,8 @@ spec:
               value: {{ ternary "true" "false" .Values.config.features.valuesOverride | quote }}
             - name: MC_FEATURE_CONTENTION
               value: {{ ternary "true" "false" (default false .Values.config.features.contention) | quote }}
+            - name: MC_FEATURE_DEPLOY_CLUSTER_SCOPED_RESOURCES
+              value: {{ ternary "true" "false" (default false .Values.config.features.deployClusterScopedResources) | quote }}
             {{- if .Values.config.discoverNamespaces }}
             - name: DISCOVER_NAMESPACES
               value: {{ .Values.config.discoverNamespaces | quote }}

--- a/charts/mission-control/values.yaml
+++ b/charts/mission-control/values.yaml
@@ -86,6 +86,12 @@ config:
     # gain the new RBAC verbs. Set to true to enable the sidebar tab and the
     # /api/contention/* endpoints.
     contention: false
+    # -- Allow the deploy feature to create and manage cluster-scoped resources
+    # (Namespaces, ClusterRoles, ClusterRoleBindings, CRDs). When false (default)
+    # the deploy RBAC is namespace-scoped only (Role + RoleBinding); cluster-level
+    # write verbs are not granted. Set to true only when Mission Control needs to
+    # install charts that create cluster-level objects.
+    deployClusterScopedResources: false
 
   # -- Extra namespaces (comma-separated) the discover feature is allowed to scan.
   # Default scans only the chart's release namespace to prevent cross-namespace secret


### PR DESCRIPTION
Move deploy write verbs from ClusterRole to a new namespace-scoped Role (+ RoleBinding). Cluster-scoped write verbs (Namespaces, CRDs, ClusterRoles/ClusterRoleBindings) are now opt-in via the new features.deployClusterScopedResources flag (default: false).

Adds MC_FEATURE_DEPLOY_CLUSTER_SCOPED_RESOURCES env var to the backend StatefulSet so the app can gate cluster-scoped operations at runtime.