### PR TITLE
chore: sync mission-control chart RBAC rework and strictReadOnly toggle

### DIFF
--- a/charts/mission-control/Chart.yaml
+++ b/charts/mission-control/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: mission-control
 description: Mission Control to deploy and manage Langsmith in EKS
-version: 1.2.1
+version: 1.2.2
 appVersion: "1.2.0"

--- a/charts/mission-control/README.md
+++ b/charts/mission-control/README.md
@@ -1,6 +1,6 @@
 # mission-control
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 Mission Control to deploy and manage Langsmith in EKS
 
@@ -31,11 +31,12 @@ On first install (when `auth.enabled: true`, the default), `helm install` prints
 - **Releases**  lists chart versions per product with GitHub release notes; highlights the deployed version.
 - **Diagnostic Logs**  one-click bundle of pod logs + `kubectl describe` output as a zip.
 - **Alerts**  configurable email + webhook notifications on cluster conditions.
+- **Contention Insights**  detects resource contention across Redis, Postgres, ClickHouse, and worker pods so eval/backfill amplification cannot silently degrade production tracing. Optional background detector persists incidents as labelled K8s Secrets with debouncing and bounded retention. Disabled by default.
 - **Chat Assistant**  in-app LangChain docs agent.
 
 ## Enterprise / compliance
 
-All write operations and external egress are gated behind Helm feature flags. With every flag off the ClusterRole is read-only.
+All write operations and external egress are gated behind Helm feature flags. With every flag off, runtime RBAC is read-only. `config.strictReadOnly: true` forces all of them off in one switch instead of setting each individually - see below.
 
 | Flag | Default | Controls |
 |---|---|---|
@@ -46,48 +47,21 @@ All write operations and external egress are gated behind Helm feature flags. Wi
 | `features.diagnostics` | `true` | Diagnostic log bundle download |
 | `features.configSave` | `true` | Draft config persistence to a K8s Secret |
 | `features.discover` | `true` | Infra discovery scan (connection strings, license keys) |
-| `features.deploy` | `true` | In-UI `helm upgrade --install` (LangSmith + sibling charts) |
-| `features.contention` | `false` | Contention Insights — Redis/Postgres/ClickHouse probes + incident persistence (opt-in; adds pods/exec + configmap/secret write verbs) |
-| `features.deployClusterScopedResources` | `false` | Allow deploy to create/manage cluster-scoped objects (Namespaces, CRDs, ClusterRoles/ClusterRoleBindings). Off by default; namespace-scoped deploy uses a Role instead. |
+| `features.dbTools` | `true` | Support query execution against connected databases |
+| `features.deploy` | `false` | In-UI `helm upgrade --install` (LangSmith + sibling charts) |
+| `features.deployClusterScopedResources` | `false` | Opt-in deploy support for chart-rendered Namespaces, CRDs, ClusterRoles, and ClusterRoleBindings |
+| `features.valuesOverride` | `true` | Operator-uploaded values.yaml overrides per product |
+| `features.contention` | `false` | Contention Insights - live probes + optional background detector + incident persistence. Off by default; opt in to gain new RBAC verbs. |
 
-Read-only console  zero write verbs, no external egress:
+Read-only console  zero write verbs, no external egress, no infra disclosure:
 
 ```bash
 helm upgrade --install mission-control langchain/mission-control \
   --namespace langsmith \
-  --set features.fixIssue=false \
-  --set features.adopt=false \
-  --set features.alerts=false \
-  --set features.chat=false \
-  --set features.diagnostics=false \
-  --set features.configSave=false \
-  --set features.discover=false
+  --set config.strictReadOnly=true
 ```
 
-## Examples
-
-The `examples/` directory contains ready-to-use values overrides for common scenarios:
-
-| File | Use case |
-|---|---|
-| `examples/minimal.yaml` | Custom namespace + image pull secret |
-| `examples/ingress.yaml` | Expose via ingress controller instead of port-forward |
-| `examples/persistence.yaml` | Retain diagnostic bundles across pod restarts |
-| `examples/high-availability.yaml` | Multi-replica backend with JWT signing secret |
-
-Apply an example with `-f`:
-
-```bash
-helm install mission-control langchain/mission-control -f examples/ingress.yaml
-```
-
-Multiple overrides can be layered:
-
-```bash
-helm install mission-control langchain/mission-control \
-  -f examples/minimal.yaml \
-  -f examples/persistence.yaml
-```
+Equivalent to setting every flag above to `false` individually, but guaranteed not to miss one - a previous version of this recipe omitted `deploy` and `contention`, the two flags with the broadest RBAC grants. See [Permissions & RBAC](https://github.com/langchain-ai/langchain-mission-control/blob/main/docs/permissions.md#strict-read-only-mode) for exactly what RBAC remains under strict mode, and the [GitOps section](https://github.com/langchain-ai/langchain-mission-control/blob/main/docs/permissions.md#bring-your-own-serviceaccount--rbac-gitops) for bringing your own ServiceAccount/RBAC.
 
 ## Values
 
@@ -100,17 +74,18 @@ helm install mission-control langchain/mission-control \
 | backend.resources.limits.memory | string | `"512Mi"` |  |
 | backend.resources.requests.cpu | string | `"250m"` |  |
 | backend.resources.requests.memory | string | `"256Mi"` |  |
+| backend.rbac.create | bool | `true` | When true (default) the chart creates the ClusterRole/ClusterRoleBinding and namespace Role/RoleBinding granting the backend ServiceAccount its permissions. Set to false for fully GitOps-managed RBAC - your own IaC pipeline grants the ServiceAccount named by `serviceAccount.name` the equivalent rules. See `templates/backend/cluster-role.yaml` and `templates/backend/role.yaml`. |
 | backend.securityContext | object | `{}` | Container-level security context. |
 | backend.service.port | int | `8000` |  |
 | backend.service.type | string | `"ClusterIP"` | Internal Service type; port-forward is the default access path. |
-| backend.serviceAccount.create | bool | `true` | When true (default) the chart creates a ServiceAccount, ClusterRole, and ClusterRoleBinding. Set to false to bring your own ServiceAccount; you must then grant it the same RBAC. |
-| backend.serviceAccount.name | string | `""` | Override the generated ServiceAccount name. |
+| backend.serviceAccount.create | bool | `true` | When true (default) the chart creates the ServiceAccount object. Set to false to bring your own ServiceAccount (e.g. annotated for IRSA/GKE Workload Identity by your own IaC) - independent of `rbac.create`, so this chart can still manage the ClusterRole/ClusterRoleBinding and namespace Role/RoleBinding bound to it. |
+| backend.serviceAccount.name | string | `""` | Name of the ServiceAccount to use. Required when `create: false`; optional override of the generated name otherwise. |
 | commonAnnotations | object | `{}` | Annotations that will be applied to all resources created by the chart |
 | commonLabels | object | `{}` | Labels that will be applied to all resources created by the chart |
 | commonPodAnnotations | object | `{}` | Annotations that will be applied to all pods created by the chart |
 | config.auth.allowedOrigins | string | `""` | Optional: comma-separated list of origins allowed to make credentialed requests. Required only when the backend and frontend are served from different hostnames. |
 | config.auth.enabled | bool | `true` |  |
-| config.auth.existingSecret | string | `"mission-control-auth"` | Pre-created Secret with username/password (and optionally JWT signing) keys. Leave as-is to use the first-run setup flow described above. |
+| config.auth.existingSecret | string | `"mission-control-auth"` | Pre-created Secret with username/password (and optionally JWT signing) keys. Leave as-is to use the first-run setup flow described above. Under `strictReadOnly: true` this must be pre-created before install - the setup flow cannot create it in that mode. |
 | config.auth.jwtSecretKey | string | `""` | Optional: key in `existingSecret` holding the JWT signing secret. Required when backend.replicas > 1 so all pods can validate each other's tokens. Generate with: openssl rand -base64 32 |
 | config.auth.passwordKey | string | `"password"` | Key in `existingSecret` holding the basic-auth password. |
 | config.auth.usernameKey | string | `"username"` | Key in `existingSecret` holding the basic-auth username. |
@@ -119,14 +94,15 @@ helm install mission-control langchain/mission-control \
 | config.features.alerts | bool | `true` | Alert notifications (SMTP + webhook). Grants write access to alert-config secrets. Egress: outbound SMTP and webhook to the configured endpoints. |
 | config.features.chat | bool | `true` | Chat assistant: floating widget that proxies to chat.langchain.com. Egress: outbound HTTPS to chat.langchain.com and *.us.langgraph.app. |
 | config.features.configSave | bool | `true` | Persists working configuration to the draft Kubernetes Secret. Grants write access to the mission-control-draft secret. |
-| config.features.contention | bool | `false` | Contention insights: live probe of Redis/Postgres/ClickHouse/workers plus a background detector that persists incidents as Secrets. Grants update/delete on the `mission-control-contention-config` ConfigMap and unscoped secrets:create,delete for incident storage (incident names carry per-second timestamps which cannot be enumerated up front). Defaults to false: existing installs upgrading the chart do not silently gain the new RBAC verbs. Set to true to enable the sidebar tab and the /api/contention/* endpoints. |
+| config.features.contention | bool | `false` | Contention Insights: live probe of Redis/Postgres/ClickHouse/workers + opt-in background detector that persists incidents as labelled K8s Secrets. Defaults to false: existing installs upgrading the chart do not silently gain new RBAC verbs. When true, grants update/delete/patch on the `mission-control-contention-config` ConfigMap (scoped) and unscoped secrets:create,delete for incident storage (incident names use per-second timestamps and cannot be enumerated as resourceNames). |
 | config.features.dbTools | bool | `true` | Database detection, preflight checks, and support query execution. Adds no extra RBAC verbs; gates the /db/* endpoints at the application layer. |
-| config.features.deploy | bool | `true` |  |
-| config.features.deployClusterScopedResources | bool | `false` | Allow the deploy feature to create and manage cluster-scoped resources (Namespaces, ClusterRoles, ClusterRoleBindings, CRDs). When false (default) the deploy RBAC is namespace-scoped only (Role + RoleBinding); cluster-level write verbs are not granted. Set to true only when Mission Control needs to install charts that create cluster-level objects. |
+| config.features.deploy | bool | `false` | In-UI `helm upgrade --install` for LangSmith and sibling charts. Grants namespace-scoped write RBAC for rendered Helm resources. Set to `true` only when operators want the UI to run Helm deploys. |
+| config.features.deployClusterScopedResources | bool | `false` | Explicit opt-in for in-UI deploys to create or patch Namespaces, CRDs, ClusterRoles, and ClusterRoleBindings. Prefer an admin pre-install step for these resources. |
+| config.features.valuesOverride | bool | `true` | Operator-uploaded values.yaml overrides per product (airgapped support). Grants update/delete on the `mission-control-values-overrides` Secret. Set to false to remove the pill and 403 the /api/values-overrides/* endpoints. |
 | config.features.diagnostics | bool | `true` | Diagnostic bundle download (pod logs + resource manifests packaged as a zip). |
 | config.features.discover | bool | `true` | Namespace-scoped infrastructure discovery via the /api/discover endpoint. Adds no extra RBAC verbs; gates the endpoint at the application layer. |
 | config.features.fixIssue | bool | `true` | Fix Issue button: deletes pods stuck in CreateContainerConfigError. Grants pods:delete. |
-| config.features.valuesOverride | bool | `true` | Operator-uploaded values.yaml overrides per product (airgapped support). Adds the settings pill in the topbar and grants update/delete on the `mission-control-values-overrides` Secret. Set to false to remove the pill and 403 the /api/values-overrides/* endpoints. |
+| config.strictReadOnly | bool | `false` | Single switch for locked-down / GitOps installs. Forces every `config.features.*` flag above (including `deployClusterScopedResources`) to false regardless of its individual setting, reducing the ClusterRole/Role to their read-only base (no create/update/delete/patch verbs) and 403ing every write/disclosure endpoint. Pair with `backend.serviceAccount.create=false` / `backend.rbac.create=false` to also bring your own ServiceAccount/RBAC. |
 | diagnostics.persistence.accessMode | string | `"ReadWriteOnce"` |  |
 | diagnostics.persistence.enabled | bool | `false` |  |
 | diagnostics.persistence.size | string | `"1Gi"` |  |
@@ -144,10 +120,10 @@ helm install mission-control langchain/mission-control \
 | fullnameOverride | string | `""` | String to fully override the chart's full name |
 | images.backendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.backendImage.repository | string | `"langchain/mission-control-backend"` |  |
-| images.backendImage.tag | string | `"latest"` | Backend image tag. Defaults to `latest`; pin to a specific release like `1.2.0` for reproducible deploys. Versioned tags are published alongside `latest` on every release. |
+| images.backendImage.tag | string | `"latest"` | Backend image tag. Defaults to `latest`; pin to a specific release like `1.0.0` for reproducible deploys. Versioned tags are published alongside `latest` on every release. |
 | images.frontendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.frontendImage.repository | string | `"langchain/mission-control-frontend"` |  |
-| images.frontendImage.tag | string | `"latest"` | Frontend image tag. Defaults to `latest`; pin to a specific release like `1.2.0` for reproducible deploys. Versioned tags are published alongside `latest` on every release. |
+| images.frontendImage.tag | string | `"latest"` | Frontend image tag. Defaults to `latest`; pin to a specific release like `1.0.0` for reproducible deploys. Versioned tags are published alongside `latest` on every release. |
 | images.imagePullSecrets | list | `[{"name":"regcred"}]` | Image pull secrets used by all components. |
 | images.registry | string | `""` | If supplied, all child <image>.repository values will be prepended with this registry name + `/` |
 | ingress.enabled | bool | `false` |  |

--- a/charts/mission-control/templates/backend/cluster-role-binding.yaml
+++ b/charts/mission-control/templates/backend/cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-{{- if (dig "rbac" "create" true .Values.backend) }}
+{{- if .Values.backend.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/mission-control/templates/backend/cluster-role-binding.yaml
+++ b/charts/mission-control/templates/backend/cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.backend.serviceAccount.create }}
+{{- if (dig "rbac" "create" true .Values.backend) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/mission-control/templates/backend/cluster-role.yaml
+++ b/charts/mission-control/templates/backend/cluster-role.yaml
@@ -1,4 +1,13 @@
-{{- if .Values.backend.serviceAccount.create }}
+{{- if (dig "rbac" "create" true .Values.backend) }}
+{{/*
+config.strictReadOnly forces every config.features.* flag off in one switch.
+$strict is read below wherever a feature flag would otherwise grant a write
+verb, so strictReadOnly=true can never leave a write verb behind because a
+flag was missed - the same $strict variable (computed the same way) also
+gates the MC_FEATURE_* env vars in templates/backend/statefulset.yaml, so the
+RBAC and the application-layer gate cannot drift apart.
+*/}}
+{{- $strict := .Values.config.strictReadOnly | default false }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -87,162 +96,19 @@ rules:
     resources: ["leases"]
     verbs: ["get", "list", "watch"]
 
-  # ── Secrets: read all; write scoped to named MC-managed secrets ───────────
+  # ── Secrets: read-only for deploy/status discovery ────────────────────────
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]
 
-  # Build the list of named secrets that require write access based on which
-  # features are enabled. When all write features are disabled, the create and
-  # update/delete rules are omitted entirely - zero secret write verbs.
-  # The deploy feature requires unscoped secrets:update,delete (see deploy block
-  # below) - listing per-release MC secret names here only matters when deploy
-  # is OFF and configSave is ON (read-only console + draft persistence).
-  {{- $secretNames := list }}
-  {{- $deployProducts := list "langgraph-cloud" "langgraph-dataplane" "langsmith-auth-proxy" "langsmith-observability" "mission-control" }}
-  {{- if .Values.config.features.configSave }}
-  {{- $secretNames = append $secretNames (include "missionControl.draftSecretName" .) }}
-  {{- range $deployProducts }}
-  {{- $secretNames = append $secretNames (printf "mission-control-draft-%s" .) }}
-  {{- end }}
-  {{- end }}
-  {{- if .Values.config.features.deploy }}
-  {{- $secretNames = append $secretNames (include "missionControl.deployedSecretName" .) }}
-  {{- $secretNames = append $secretNames (include "missionControl.backupSecretName" .) }}
-  {{- $secretNames = append $secretNames (include "missionControl.historySecretName" .) }}
-  {{- range $deployProducts }}
-  {{- $secretNames = append $secretNames (printf "mission-control-deployed-%s" .) }}
-  {{- $secretNames = append $secretNames (printf "mission-control-backup-%s" .) }}
-  {{- $secretNames = append $secretNames (printf "mission-control-history-%s" .) }}
-  {{- end }}
-  {{- end }}
-  {{- if .Values.config.features.alerts }}
-  {{- $secretNames = append $secretNames (include "missionControl.alertsConfigSecretName" .) }}
-  {{- $secretNames = append $secretNames (include "missionControl.alertsKeySecretName" .) }}
-  {{- $secretNames = append $secretNames (include "missionControl.alertsLogSecretName" .) }}
-  {{- end }}
-  {{- if .Values.config.features.valuesOverride }}
-  {{- $secretNames = append $secretNames "mission-control-values-overrides" }}
-  {{- end }}
-
-  {{- if $secretNames }}
-  # Kubernetes RBAC does not support resourceNames on "create" - namespace-wide
-  # is unavoidable. Scoping is enforced at the application layer.
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["create"]
-
-  # update/delete scoped to the exact set of secrets Mission Control manages.
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["update", "delete"]
-    resourceNames:
-      {{- range $secretNames }}
-      - {{ . }}
-      {{- end }}
-  {{- end }}
-
-  # ── Auth setup flow ────────────────────────────────────────────────────────
-  # When auth is enabled the backend may need to create the auth Secret on
-  # first run (setup mode) and then restart itself to load the new credentials.
-  # create cannot be scoped by resourceName (K8s limitation); the application
-  # layer only ever creates the single auth secret during setup.
-  {{- if .Values.config.auth.enabled }}
-  {{- if not $secretNames }}
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["create"]
-  {{- end }}
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["update"]
-    resourceNames:
-      - {{ include "missionControl.authSecretName" . }}
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["delete"]
-    resourceNames:
-      - {{ include "missionControl.setupTokenSecretName" . }}
-  - apiGroups: ["apps"]
-    resources: ["statefulsets"]
-    verbs: ["patch"]
-    resourceNames:
-      - {{ include "missionControl.backendWorkloadName" . }}
-  {{- end }}
-
-  # ── Fix Issue button (disable via features.fixIssue=false) ────────────────
-  # Grants pods:delete to restart pods stuck in CreateContainerConfigError.
-  # Disable if your security policy prohibits pod deletion by tooling.
-  {{- if .Values.config.features.fixIssue }}
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["delete"]
-  {{- end }}
-
-  # ── Contention Insights (disable via features.contention=false) ──────────
-  # Read-only probes use the existing pods/configmaps read verbs above. The
-  # detector additionally needs to:
-  #   - update/delete its own ConfigMap (scoped by name below)
-  #   - create the ConfigMap on first write (unscoped - RBAC create cannot be
-  #     scoped by resourceName; application layer writes only the named CM)
-  #   - create + delete incident Secrets named
-  #     `mission-control-contention-incident-<unix_ts>`. resourceNames cannot
-  #     match a prefix and incident names are dynamic, so secrets:create,delete
-  #     are unscoped under this flag. Same trade-off as the deploy block.
-  #     Set features.contention=false to remove these verbs entirely.
-  {{- if (default false .Values.config.features.contention) }}
-  # The DB probes exec read-only commands (redis-cli INFO/SLOWLOG/XLEN,
-  # psql -c SELECT, clickhouse-client SELECT) inside the data-store pods via the
-  # K8s exec API. k8s_exec.py uses kubernetes.stream(connect_get_namespaced_pod_exec),
-  # which issues a GET against the pods/exec subresource, so "get" is required;
-  # "create" is retained for POST/kubectl-style exec. Without "get" the probe fails
-  # with 403 "cannot get resource pods/exec" even though "create" is allowed. The
-  # exec layer (k8s_exec.py) restricts the executable to a fixed allowlist
-  # (redis-cli/psql/clickhouse-client/sh) running hardcoded commands; log-signal
-  # probes use the pods/log read verb above.
-  - apiGroups: [""]
-    resources: ["pods/exec"]
-    verbs: ["create", "get"]
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["create"]
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["update", "delete", "patch"]
-    resourceNames:
-      - mission-control-contention-config
-  {{- if not .Values.config.features.deploy }}
-  # Only add unscoped secret create/delete here if deploy hasn't already
-  # granted them (avoids duplicate rules in the rendered ClusterRole).
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["create", "delete"]
-  {{- end }}
-  {{- end }}
-
-  # ── Adopt button (disable via features.adopt=false) ───────────────────────
-  # Patches Helm ownership annotations onto existing resources so helm upgrade
-  # can manage resources that were created outside the release.
-  # patch on deployments/statefulsets is equivalent to update - disable if
-  # your policy requires workload immutability enforced by RBAC.
-  {{- if .Values.config.features.adopt }}
-  - apiGroups: [""]
-    resources: ["secrets", "configmaps", "serviceaccounts"]
-    verbs: ["patch"]
-  - apiGroups: ["apps"]
-    resources: ["deployments", "statefulsets"]
-    verbs: ["patch"]
-  {{- end }}
-
-  # ── Deploy feature: cluster-scoped write verbs (opt-in) ──────────────────
-  # Namespace-scoped deploy write verbs have moved to role.yaml (Kind: Role)
-  # so that a standard deploy only requires namespace-level access.
-  #
-  # This ClusterRole block is only rendered when
-  # features.deployClusterScopedResources=true, which opts in to the broader
-  # cluster-level writes needed by charts that create Namespaces, CRDs, or
-  # ClusterRoles/ClusterRoleBindings. Default is false.
-  {{- if and .Values.config.features.deploy (default false .Values.config.features.deployClusterScopedResources) }}
+  # ── Deploy cluster-scoped resources (explicit opt-in) ─────────────────────
+  # Everything else (namespace-scoped secrets writes, auth setup, fixIssue,
+  # contention, adopt, and the bulk of the deploy feature) lives in the
+  # namespace-scoped Role - see templates/backend/role.yaml. This ClusterRole
+  # only carries the base read-only rules above plus this narrow cluster-scoped
+  # opt-in. `$strict` (config.strictReadOnly) forces this off even if an
+  # operator has explicitly set both deploy flags to true.
+  {{- if and .Values.config.features.deploy (default false .Values.config.features.deployClusterScopedResources) (not $strict) }}
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["create"]

--- a/charts/mission-control/templates/backend/cluster-role.yaml
+++ b/charts/mission-control/templates/backend/cluster-role.yaml
@@ -1,4 +1,4 @@
-{{- if (dig "rbac" "create" true .Values.backend) }}
+{{- if .Values.backend.rbac.create }}
 {{/*
 config.strictReadOnly forces every config.features.* flag off in one switch.
 $strict is read below wherever a feature flag would otherwise grant a write

--- a/charts/mission-control/templates/backend/role-binding.yaml
+++ b/charts/mission-control/templates/backend/role-binding.yaml
@@ -1,5 +1,5 @@
 {{- $strict := .Values.config.strictReadOnly | default false }}
-{{- $roleEnabled := or (and .Values.config.features.configSave (not $strict)) (and .Values.config.features.deploy (not $strict)) (and .Values.config.features.alerts (not $strict)) (and .Values.config.features.valuesOverride (not $strict)) .Values.config.auth.enabled (and .Values.config.features.fixIssue (not $strict)) (and (default false .Values.config.features.contention) (not $strict)) (and .Values.config.features.adopt (not $strict)) }}
+{{- $roleEnabled := or (and .Values.config.features.configSave (not $strict)) (and .Values.config.features.deploy (not $strict)) (and .Values.config.features.alerts (not $strict)) (and .Values.config.features.valuesOverride (not $strict)) (and .Values.config.auth.enabled (not $strict)) (and .Values.config.features.fixIssue (not $strict)) (and (default false .Values.config.features.contention) (not $strict)) (and .Values.config.features.adopt (not $strict)) }}
 {{- if and (dig "rbac" "create" true .Values.backend) $roleEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/mission-control/templates/backend/role-binding.yaml
+++ b/charts/mission-control/templates/backend/role-binding.yaml
@@ -1,6 +1,6 @@
 {{- $strict := .Values.config.strictReadOnly | default false }}
 {{- $roleEnabled := or (and .Values.config.features.configSave (not $strict)) (and .Values.config.features.deploy (not $strict)) (and .Values.config.features.alerts (not $strict)) (and .Values.config.features.valuesOverride (not $strict)) (and .Values.config.auth.enabled (not $strict)) (and .Values.config.features.fixIssue (not $strict)) (and (default false .Values.config.features.contention) (not $strict)) (and .Values.config.features.adopt (not $strict)) }}
-{{- if and (dig "rbac" "create" true .Values.backend) $roleEnabled }}
+{{- if and .Values.backend.rbac.create $roleEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/mission-control/templates/backend/role-binding.yaml
+++ b/charts/mission-control/templates/backend/role-binding.yaml
@@ -1,4 +1,6 @@
-{{- if and .Values.backend.serviceAccount.create .Values.config.features.deploy }}
+{{- $strict := .Values.config.strictReadOnly | default false }}
+{{- $roleEnabled := or (and .Values.config.features.configSave (not $strict)) (and .Values.config.features.deploy (not $strict)) (and .Values.config.features.alerts (not $strict)) (and .Values.config.features.valuesOverride (not $strict)) .Values.config.auth.enabled (and .Values.config.features.fixIssue (not $strict)) (and (default false .Values.config.features.contention) (not $strict)) (and .Values.config.features.adopt (not $strict)) }}
+{{- if and (dig "rbac" "create" true .Values.backend) $roleEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/mission-control/templates/backend/role.yaml
+++ b/charts/mission-control/templates/backend/role.yaml
@@ -6,7 +6,7 @@ ServiceAccount and the app-layer features.require() gate the backend enforces
 can never drift apart.
 */}}
 {{- $strict := .Values.config.strictReadOnly | default false }}
-{{- $roleEnabled := or (and .Values.config.features.configSave (not $strict)) (and .Values.config.features.deploy (not $strict)) (and .Values.config.features.alerts (not $strict)) (and .Values.config.features.valuesOverride (not $strict)) .Values.config.auth.enabled (and .Values.config.features.fixIssue (not $strict)) (and (default false .Values.config.features.contention) (not $strict)) (and .Values.config.features.adopt (not $strict)) }}
+{{- $roleEnabled := or (and .Values.config.features.configSave (not $strict)) (and .Values.config.features.deploy (not $strict)) (and .Values.config.features.alerts (not $strict)) (and .Values.config.features.valuesOverride (not $strict)) (and .Values.config.auth.enabled (not $strict)) (and .Values.config.features.fixIssue (not $strict)) (and (default false .Values.config.features.contention) (not $strict)) (and .Values.config.features.adopt (not $strict)) }}
 {{- $secretNames := list }}
 {{- $deployProducts := list "langgraph-cloud" "langgraph-dataplane" "langsmith-auth-proxy" "langsmith-observability" "mission-control" }}
 {{- if (and .Values.config.features.configSave (not $strict)) }}
@@ -58,8 +58,8 @@ rules:
       - {{ . }}
       {{- end }}
   {{- end }}
-  {{- if .Values.config.auth.enabled }}
-  {{- if (and (not $secretNames) (not $strict)) }}
+  {{- if (and .Values.config.auth.enabled (not $strict)) }}
+  {{- if not $secretNames }}
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["create"]

--- a/charts/mission-control/templates/backend/role.yaml
+++ b/charts/mission-control/templates/backend/role.yaml
@@ -1,4 +1,39 @@
-{{- if and .Values.backend.serviceAccount.create .Values.config.features.deploy }}
+{{/*
+config.strictReadOnly forces every config.features.* flag off in one switch;
+$strict is computed identically here and in templates/backend/cluster-role.yaml
+and templates/backend/statefulset.yaml so the RBAC granted to the
+ServiceAccount and the app-layer features.require() gate the backend enforces
+can never drift apart.
+*/}}
+{{- $strict := .Values.config.strictReadOnly | default false }}
+{{- $roleEnabled := or (and .Values.config.features.configSave (not $strict)) (and .Values.config.features.deploy (not $strict)) (and .Values.config.features.alerts (not $strict)) (and .Values.config.features.valuesOverride (not $strict)) .Values.config.auth.enabled (and .Values.config.features.fixIssue (not $strict)) (and (default false .Values.config.features.contention) (not $strict)) (and .Values.config.features.adopt (not $strict)) }}
+{{- $secretNames := list }}
+{{- $deployProducts := list "langgraph-cloud" "langgraph-dataplane" "langsmith-auth-proxy" "langsmith-observability" "mission-control" }}
+{{- if (and .Values.config.features.configSave (not $strict)) }}
+{{- $secretNames = append $secretNames (include "missionControl.draftSecretName" .) }}
+{{- range $deployProducts }}
+{{- $secretNames = append $secretNames (printf "mission-control-draft-%s" .) }}
+{{- end }}
+{{- end }}
+{{- if (and .Values.config.features.deploy (not $strict)) }}
+{{- $secretNames = append $secretNames (include "missionControl.deployedSecretName" .) }}
+{{- $secretNames = append $secretNames (include "missionControl.backupSecretName" .) }}
+{{- $secretNames = append $secretNames (include "missionControl.historySecretName" .) }}
+{{- range $deployProducts }}
+{{- $secretNames = append $secretNames (printf "mission-control-deployed-%s" .) }}
+{{- $secretNames = append $secretNames (printf "mission-control-backup-%s" .) }}
+{{- $secretNames = append $secretNames (printf "mission-control-history-%s" .) }}
+{{- end }}
+{{- end }}
+{{- if (and .Values.config.features.alerts (not $strict)) }}
+{{- $secretNames = append $secretNames (include "missionControl.alertsConfigSecretName" .) }}
+{{- $secretNames = append $secretNames (include "missionControl.alertsKeySecretName" .) }}
+{{- $secretNames = append $secretNames (include "missionControl.alertsLogSecretName" .) }}
+{{- end }}
+{{- if (and .Values.config.features.valuesOverride (not $strict)) }}
+{{- $secretNames = append $secretNames "mission-control-values-overrides" }}
+{{- end }}
+{{- if and (dig "rbac" "create" true .Values.backend) $roleEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -11,11 +46,72 @@ metadata:
     {{- . | nindent 4 }}
   {{- end }}
 rules:
-  # ── Deploy feature: namespace-scoped write verbs ──────────────────────────
-  # These verbs are required by `helm upgrade --install` executed from the UI.
-  # Cluster-scoped write verbs (Namespaces, CRDs, ClusterRoles) live in the
-  # ClusterRole and are only rendered when
-  # features.deployClusterScopedResources=true.
+  {{- if $secretNames }}
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["update", "delete"]
+    resourceNames:
+      {{- range $secretNames }}
+      - {{ . }}
+      {{- end }}
+  {{- end }}
+  {{- if .Values.config.auth.enabled }}
+  {{- if (and (not $secretNames) (not $strict)) }}
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  {{- end }}
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["update"]
+    resourceNames:
+      - {{ include "missionControl.authSecretName" . }}
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["delete"]
+    resourceNames:
+      - {{ include "missionControl.setupTokenSecretName" . }}
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["patch"]
+    resourceNames:
+      - {{ include "missionControl.backendWorkloadName" . }}
+  {{- end }}
+  {{- if (and .Values.config.features.fixIssue (not $strict)) }}
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["delete"]
+  {{- end }}
+  {{- if (and (default false .Values.config.features.contention) (not $strict)) }}
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["update", "delete", "patch"]
+    resourceNames:
+      - mission-control-contention-config
+  {{- if not (and .Values.config.features.deploy (not $strict)) }}
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "delete"]
+  {{- end }}
+  {{- end }}
+  {{- if (and .Values.config.features.adopt (not $strict)) }}
+  - apiGroups: [""]
+    resources: ["secrets", "configmaps", "serviceaccounts"]
+    verbs: ["patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets"]
+    verbs: ["patch"]
+  {{- end }}
+  {{- if (and .Values.config.features.deploy (not $strict)) }}
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["watch", "update", "delete"]
@@ -64,4 +160,5 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["create", "update", "patch", "delete"]
+  {{- end }}
 {{- end }}

--- a/charts/mission-control/templates/backend/role.yaml
+++ b/charts/mission-control/templates/backend/role.yaml
@@ -33,7 +33,7 @@ can never drift apart.
 {{- if (and .Values.config.features.valuesOverride (not $strict)) }}
 {{- $secretNames = append $secretNames "mission-control-values-overrides" }}
 {{- end }}
-{{- if and (dig "rbac" "create" true .Values.backend) $roleEnabled }}
+{{- if and .Values.backend.rbac.create $roleEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/mission-control/templates/backend/statefulset.yaml
+++ b/charts/mission-control/templates/backend/statefulset.yaml
@@ -97,31 +97,39 @@ spec:
             - name: ALLOWED_ORIGINS
               value: {{ .Values.config.auth.allowedOrigins | quote }}
             {{- end }}
+            {{/*
+            config.strictReadOnly forces every feature flag off in one switch;
+            $strict is computed identically here and in
+            templates/backend/cluster-role.yaml so the RBAC granted to the
+            ServiceAccount and the app-layer features.require() gate the
+            backend enforces can never drift apart.
+            */}}
+            {{- $strict := .Values.config.strictReadOnly | default false }}
             - name: MC_FEATURE_FIX_ISSUE
-              value: {{ ternary "true" "false" .Values.config.features.fixIssue | quote }}
+              value: {{ ternary "true" "false" (and .Values.config.features.fixIssue (not $strict)) | quote }}
             - name: MC_FEATURE_ADOPT
-              value: {{ ternary "true" "false" .Values.config.features.adopt | quote }}
+              value: {{ ternary "true" "false" (and .Values.config.features.adopt (not $strict)) | quote }}
             - name: MC_FEATURE_ALERTS
-              value: {{ ternary "true" "false" .Values.config.features.alerts | quote }}
+              value: {{ ternary "true" "false" (and .Values.config.features.alerts (not $strict)) | quote }}
             - name: MC_FEATURE_CHAT
-              value: {{ ternary "true" "false" .Values.config.features.chat | quote }}
+              value: {{ ternary "true" "false" (and .Values.config.features.chat (not $strict)) | quote }}
             - name: MC_FEATURE_DIAGNOSTICS
-              value: {{ ternary "true" "false" .Values.config.features.diagnostics | quote }}
+              value: {{ ternary "true" "false" (and .Values.config.features.diagnostics (not $strict)) | quote }}
             - name: MC_FEATURE_CONFIG_SAVE
-              value: {{ ternary "true" "false" .Values.config.features.configSave | quote }}
+              value: {{ ternary "true" "false" (and .Values.config.features.configSave (not $strict)) | quote }}
             - name: MC_FEATURE_DEPLOY
-              value: {{ ternary "true" "false" .Values.config.features.deploy | quote }}
-            - name: MC_FEATURE_DISCOVER
-              value: {{ ternary "true" "false" .Values.config.features.discover | quote }}
-            - name: MC_FEATURE_DBTOOLS
-              value: {{ ternary "true" "false" .Values.config.features.dbTools | quote }}
-            - name: MC_FEATURE_VALUES_OVERRIDE
-              value: {{ ternary "true" "false" .Values.config.features.valuesOverride | quote }}
-            - name: MC_FEATURE_CONTENTION
-              value: {{ ternary "true" "false" (default false .Values.config.features.contention) | quote }}
+              value: {{ ternary "true" "false" (and .Values.config.features.deploy (not $strict)) | quote }}
             - name: MC_FEATURE_DEPLOY_CLUSTER_SCOPED_RESOURCES
-              value: {{ ternary "true" "false" (default false .Values.config.features.deployClusterScopedResources) | quote }}
-            {{- if .Values.config.discoverNamespaces }}
+              value: {{ ternary "true" "false" (and (default false .Values.config.features.deployClusterScopedResources) (not $strict)) | quote }}
+            - name: MC_FEATURE_DISCOVER
+              value: {{ ternary "true" "false" (and .Values.config.features.discover (not $strict)) | quote }}
+            - name: MC_FEATURE_DBTOOLS
+              value: {{ ternary "true" "false" (and .Values.config.features.dbTools (not $strict)) | quote }}
+            - name: MC_FEATURE_VALUES_OVERRIDE
+              value: {{ ternary "true" "false" (and .Values.config.features.valuesOverride (not $strict)) | quote }}
+            - name: MC_FEATURE_CONTENTION
+              value: {{ ternary "true" "false" (and (default false .Values.config.features.contention) (not $strict)) | quote }}
+            {{- if and .Values.config.discoverNamespaces (not $strict) }}
             - name: DISCOVER_NAMESPACES
               value: {{ .Values.config.discoverNamespaces | quote }}
             {{- end }}

--- a/charts/mission-control/values.yaml
+++ b/charts/mission-control/values.yaml
@@ -15,6 +15,20 @@ commonLabels: {}
 # and discovery scope. Infrastructure-level options (images, resources, services,
 # storage) stay at the top level outside `config`.
 config:
+  # -- Single switch for locked-down / GitOps installs. When true, every
+  # `config.features.*` flag below is treated as false regardless of its
+  # individual setting, so the rendered ClusterRole is reduced to its
+  # read-only base (get/list/watch on cluster resources, get/list on
+  # secrets - no create/update/delete/patch verbs anywhere) and the backend
+  # 403s every write/disclosure endpoint (deploy, contention, discover,
+  # dbTools, adopt, fixIssue, alerts, configSave, valuesOverride, chat).
+  # Replaces manually setting each `features.*` flag to false, which is easy
+  # to get wrong (e.g. forgetting `deploy`, the single largest RBAC grant).
+  # Pair with `backend.serviceAccount.create=false` (and optionally
+  # `backend.rbac.create=false`) to bring your own ServiceAccount/RBAC
+  # provisioned by your own IaC pipeline instead of this chart's release.
+  strictReadOnly: false
+
   # Backend API authentication (HTTP Basic Auth).
   # Keep config.auth.enabled=true in production.
   #
@@ -26,7 +40,11 @@ config:
   auth:
     enabled: true
     # -- Pre-created Secret with username/password (and optionally JWT signing) keys.
-    # Leave as-is to use the first-run setup flow described above.
+    # Leave as-is to use the first-run setup flow described above. Under
+    # `strictReadOnly: true` the chart never grants the backend an unscoped
+    # secrets:create verb, so this Secret must be pre-created (e.g. via your
+    # own GitOps secrets pipeline) before the first `helm install` - the
+    # first-run setup flow cannot create it for you in that mode.
     existingSecret: mission-control-auth
     # -- Key in `existingSecret` holding the basic-auth username.
     usernameKey: username
@@ -41,7 +59,8 @@ config:
     allowedOrigins: ""
 
   # Feature flags. Disabling a flag removes its write verbs from the ClusterRole.
-  # With every flag false the ClusterRole is read-only.
+  # With every flag false the ClusterRole is read-only. `strictReadOnly` above
+  # forces all of these off in one switch instead of setting each individually.
   # Contention Insights (`contention`, below) is opt-in: it defaults to false so
   # existing installs do not silently gain new RBAC verbs on upgrade.
   features:
@@ -71,7 +90,7 @@ config:
     # across multiple API groups - see templates/backend/cluster-role.yaml.
     # Set to false in read-only / compliance-locked installs to remove all deploy
     # write verbs from the ClusterRole and 403 the POST /deploy API.
-    deploy: true
+    deploy: false
     # -- Operator-uploaded values.yaml overrides per product (airgapped support).
     # Adds the settings pill in the topbar and grants update/delete on the
     # `mission-control-values-overrides` Secret. Set to false to remove the pill
@@ -108,13 +127,13 @@ images:
   backendImage:
     repository: langchain/mission-control-backend
     pullPolicy: IfNotPresent
-    # -- Backend image tag. Defaults to `latest`; pin to a specific release like `1.2.0`
+    # -- Backend image tag. Defaults to `latest`; pin to a specific release like `1.2.2`
     # for reproducible deploys. Versioned tags are published alongside `latest` on every release.
     tag: latest
   frontendImage:
     repository: langchain/mission-control-frontend
     pullPolicy: IfNotPresent
-    # -- Frontend image tag. Defaults to `latest`; pin to a specific release like `1.2.0`
+    # -- Frontend image tag. Defaults to `latest`; pin to a specific release like `1.2.2`
     # for reproducible deploys. Versioned tags are published alongside `latest` on every release.
     tag: latest
 
@@ -140,11 +159,26 @@ backend:
     type: ClusterIP
     port: 8000
   serviceAccount:
-    # -- When true (default) the chart creates a ServiceAccount, ClusterRole, and ClusterRoleBinding.
-    # Set to false to bring your own ServiceAccount; you must then grant it the same RBAC.
+    # -- When true (default) the chart creates the ServiceAccount object.
+    # Set to false to bring your own ServiceAccount - e.g. one your platform
+    # Terraform/IaC already annotated for IRSA or GKE Workload Identity - and
+    # supply its name via `name` below. This is independent of `rbac.create`:
+    # you can bring your own ServiceAccount while still letting this chart
+    # manage the ClusterRole/ClusterRoleBinding bound to it.
     create: true
-    # -- Override the generated ServiceAccount name.
+    # -- Name of the ServiceAccount to use. Required when `create: false`;
+    # optional override of the generated name otherwise.
     name: ""
+  rbac:
+    # -- When true (default) the chart creates the ClusterRole and
+    # ClusterRoleBinding granting the backend ServiceAccount (see
+    # `serviceAccount` above) its permissions. Set to false for fully
+    # GitOps-managed RBAC: your own IaC pipeline grants the ServiceAccount
+    # named by `serviceAccount.name` the equivalent rules, reviewed and
+    # applied outside this chart's release. See templates/backend/cluster-role.yaml
+    # for the exact rule set to replicate (respects `strictReadOnly` and
+    # `config.features.*` the same way).
+    create: true
 
 # Frontend (static React app served by an HTTP server) component.
 frontend:


### PR DESCRIPTION
Splits the backend ClusterRole into a read-only base plus a namespace-scoped Role/RoleBinding for write verbs, adds config.strictReadOnly to force every feature flag off in one switch, and backend.rbac.create for BYO-RBAC/GitOps installs. Also flips config.features.deploy to false by default.