### PR TITLE
chore: remove smithdb ingestion rollout strategy

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.0-rc.10
+version: 0.16.0-rc.11
 appVersion: "0.16.11rc1"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.16.0-rc.10](https://img.shields.io/badge/Version-0.16.0--rc.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.11rc1](https://img.shields.io/badge/AppVersion-0.16.11rc1-informational?style=flat-square)
+![Version: 0.16.0-rc.11](https://img.shields.io/badge/Version-0.16.0--rc.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.11rc1](https://img.shields.io/badge/AppVersion-0.16.11rc1-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -1039,9 +1039,6 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.ingestion.deployment.resources | object | `{}` |  |
 | smithdb.ingestion.deployment.securityContext | object | `{}` |  |
 | smithdb.ingestion.deployment.sidecars | list | `[]` |  |
-| smithdb.ingestion.deployment.strategy.rollingUpdate.maxSurge | int | `1` |  |
-| smithdb.ingestion.deployment.strategy.rollingUpdate.maxUnavailable | int | `0` |  |
-| smithdb.ingestion.deployment.strategy.type | string | `"RollingUpdate"` |  |
 | smithdb.ingestion.deployment.terminationGracePeriodSeconds | int | `300` |  |
 | smithdb.ingestion.deployment.tolerations | list | `[]` |  |
 | smithdb.ingestion.deployment.topologySpreadConstraints | list | `[]` |  |

--- a/charts/langsmith/templates/smithdb/ingestion-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/ingestion-deployment.yaml
@@ -19,8 +19,6 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.smithdb.ingestion.deployment.replicas }}
-  strategy:
-    {{- toYaml .Values.smithdb.ingestion.deployment.strategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "langsmith.selectorLabels" . | nindent 6 }}

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -175,18 +175,13 @@ tests:
           content:
             name: VITE_SELF_HOSTED_SMITHDB_V2_ENDPOINTS_ENABLED
 
-  - it: should render zero-downtime rollout strategy for smithdb ingestion
+  - it: should not render a custom rollout strategy for smithdb ingestion
     values:
       - ./values/smithdb-enabled.yaml
     template: smithdb/ingestion-deployment.yaml
     asserts:
-      - equal:
+      - notExists:
           path: spec.strategy
-          value:
-            type: RollingUpdate
-            rollingUpdate:
-              maxSurge: 1
-              maxUnavailable: 0
 
   - it: should disable smithdb cluster-manager tracing by default
     values:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1350,11 +1350,6 @@ smithdb:
     containerGrpcPort: 8082
     deployment:
       replicas: 1
-      strategy:
-        type: RollingUpdate
-        rollingUpdate:
-          maxSurge: 1
-          maxUnavailable: 0
       labels: {}
       annotations: {}
       podSecurityContext: {}


### PR DESCRIPTION
## Description
Removes the custom zero-downtime rollout strategy from the LangSmith SmithDB ingestion Deployment so the chart no longer opts ingestion into rolling-start behavior. Bumps the chart prerelease version and updates docs/tests.

## Test Plan
- [x] `helm lint charts/langsmith -f charts/langsmith/tests/values/smithdb-enabled.yaml`
- [x] `helm unittest charts/langsmith`
- [x] `helm template ... --show-only templates/smithdb/ingestion-deployment.yaml` confirms no `spec.strategy`

Made by [Open SWE](https://openswe.vercel.app/agents/db174493-0bc5-0669-488d-e6deb28665c2)