### PR TITLE
feat(langsmith): support common DNS policy

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -15,6 +15,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | clusterDomain | string | `"cluster.local"` | Kubernetes cluster domain. Only change if not using 'cluster.local' |
 | commonAnnotations | object | `{}` | Annotations that will be applied to all resources created by the chart |
 | commonDnsConfig | object | `{"options":[{"name":"ndots","value":"4"}]}` | Set to null to disable and use Kubernetes defaults (ndots: 5). |
+| commonDnsPolicy | string | `""` | DNS policy applied to all pods. Set to "None" with commonDnsConfig.nameservers to use custom DNS resolvers. |
 | commonEnv | list | `[]` | Common environment variables that will be applied to all deployments/statefulsets except for the playground/aceBackend services (which are sandboxed). Be careful not to override values already specified by the chart. |
 | commonInitContainers | list | `[]` | Common init containers added to all deployments/statefulsets except for the playground/aceBackend services (which are sandboxed). |
 | commonLabels | object | `{}` | Labels that will be applied to all resources created by the chart |

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -164,9 +164,12 @@ Usage: {{ include "langsmith.podSecurityContext" (dict "Values" .Values "compone
 {{- end -}}
 
 {{/*
-Common DNS configuration for all pods. When commonDnsConfig is set, it will be applied to all pods.
+Common DNS policy and configuration for all pods. When configured, they will be applied to all pods.
 */}}
 {{- define "langsmith.dnsConfig" -}}
+{{- with .Values.commonDnsPolicy }}
+dnsPolicy: {{ . | quote }}
+{{- end }}
 {{- if .Values.commonDnsConfig }}
 dnsConfig:
   {{- toYaml .Values.commonDnsConfig | nindent 2 }}

--- a/charts/langsmith/tests/dns_policy_test.yaml
+++ b/charts/langsmith/tests/dns_policy_test.yaml
@@ -1,0 +1,30 @@
+suite: Common DNS policy rendering
+templates:
+  - frontend/deployment.yaml
+  - config-map.yaml
+  - frontend/config-map.yaml
+  - secrets.yaml
+  - redis/secrets.yaml
+  - postgres/secrets.yaml
+  - clickhouse/secrets.yaml
+tests:
+  - it: omits dnsPolicy when it is not configured
+    template: frontend/deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.dnsPolicy
+
+  - it: renders dnsPolicy with custom nameservers
+    template: frontend/deployment.yaml
+    set:
+      commonDnsPolicy: None
+      commonDnsConfig:
+        nameservers:
+          - 10.0.0.2
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: None
+      - equal:
+          path: spec.template.spec.dnsConfig.nameservers[0]
+          value: 10.0.0.2

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -47,6 +47,8 @@ commonVolumeMounts: []
 commonInitContainers: []
 # -- Common pod security context applied to all pods. Component-specific podSecurityContext values will be merged on top of this (component values take precedence).
 commonPodSecurityContext: {}
+# -- DNS policy applied to all pods. Set to "None" with commonDnsConfig.nameservers to use custom DNS resolvers.
+commonDnsPolicy: ""
 # -- Common DNS configuration applied to all pods. Reduces DNS query amplification in Kubernetes by
 # -- ensuring service FQDNs (which have 4 dots) are resolved directly without search domain expansion.
 # -- Set to null to disable and use Kubernetes defaults (ndots: 5).


### PR DESCRIPTION
## Summary

Adds an opt-in `commonDnsPolicy` value alongside the existing chart-wide DNS configuration.

## Why

Kubernetes requires `dnsPolicy: None` when a workload uses custom DNS resolvers. The chart already applies `commonDnsConfig` to every pod, but could not render the accompanying policy.

## Changes

- Render `commonDnsPolicy` on every pod through the existing shared DNS helper.
- Keep the default empty, so existing releases are unchanged.
- Document the value and add rendering coverage for custom nameservers.

## Validation

- `helm lint charts/langsmith -f charts/langsmith/ci/lightweight-config-values.yaml`
- `helm unittest charts/langsmith` (62 tests)
- Rendered the chart with `commonDnsPolicy=None` and a custom nameserver.
