### PR TITLE
feat(langsmith): support internal service URL overrides

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -664,6 +664,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | insights.redis.statefulSet.updateStrategy | object | `{}` | Optional StatefulSet update strategy for the in-chart Insights Redis instance. Leave unset to keep the Kubernetes default RollingUpdate behavior. |
 | insights.redis.statefulSet.volumeMounts | list | `[]` |  |
 | insights.redis.statefulSet.volumes | list | `[]` |  |
+| internalServiceUrls | object | `{}` | Optional URLs for core internal services. Empty values preserve Kubernetes service DNS. |
 | istioGateway.annotations | object | `{}` |  |
 | istioGateway.enabled | bool | `false` |  |
 | istioGateway.labels | object | `{}` |  |

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -174,6 +174,45 @@ dnsConfig:
 {{- end }}
 
 {{/*
+Returns an internal URL override when configured, otherwise the provided default.
+*/}}
+{{- define "langsmith.internalServiceUrl" -}}
+{{- $root := .root -}}
+{{- $override := get $root.Values.internalServiceUrls .key -}}
+{{- if $override -}}
+{{- $override -}}
+{{- else -}}
+{{- .default -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns an internal service URL. A non-empty internalServiceUrls entry overrides
+the default Kubernetes service DNS URL.
+*/}}
+{{- define "langsmith.internalServiceEndpoint" -}}
+{{- $root := .root -}}
+{{- $default := printf "http://%s-%s.%s.svc.%s:%v" (include "langsmith.fullname" $root) .name .namespace $root.Values.clusterDomain .port -}}
+{{- include "langsmith.internalServiceUrl" (dict "root" $root "key" .key "default" $default) -}}
+{{- end -}}
+
+{{/*
+Returns the host LangChain API URL, preserving the existing deployment and base-path behavior.
+*/}}
+{{- define "langsmith.internalHostLangchainApiEndpoint" -}}
+{{- $namespace := .Values.namespace | default .Release.Namespace -}}
+{{- if .Values.internalServiceUrls.hostLangchainApi -}}
+{{- .Values.internalServiceUrls.hostLangchainApi -}}
+{{- else if not .Values.frontend.enabled -}}
+{{- printf "%s/api/v1" (include "langsmith.internalServiceEndpoint" (dict "root" . "key" "backend" "name" .Values.backend.name "namespace" $namespace "port" .Values.backend.service.port)) -}}
+{{- else if .Values.config.basePath -}}
+{{- printf "%s/%s/api/v1" (include "langsmith.internalServiceEndpoint" (dict "root" . "key" "frontend" "name" .Values.frontend.name "namespace" $namespace "port" .Values.frontend.service.httpPort)) .Values.config.basePath -}}
+{{- else -}}
+{{- printf "%s/api/v1" (include "langsmith.internalServiceEndpoint" (dict "root" . "key" "frontend" "name" .Values.frontend.name "namespace" $namespace "port" .Values.frontend.service.httpPort)) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Template containing common environment variables that are used by several services.
 */}}
 {{- define "langsmith.commonEnv" -}}
@@ -204,7 +243,8 @@ Template containing common environment variables that are used by several servic
 {{- if .Values.fleet.enabled }}
 {{- $ns := .Values.namespace | default .Release.Namespace -}}
 {{- $cd := .Values.clusterDomain -}}
-{{- $fleetApi := printf "http://%s.%s.svc.%s:%v" (include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "fleet")) $ns $cd .Values.fleet.apiServer.service.httpPort }}
+{{- $fleetApiDefault := printf "http://%s.%s.svc.%s:%v" (include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "fleet")) $ns $cd .Values.fleet.apiServer.service.httpPort -}}
+{{- $fleetApi := include "langsmith.internalServiceUrl" (dict "root" . "key" "fleetApiServer" "default" $fleetApiDefault) }}
 - name: LANGGRAPH_DEPLOYMENT_URL
   value: {{ $fleetApi | quote }}
 {{- end }}

--- a/charts/langsmith/templates/agent-gateway/deployment.yaml
+++ b/charts/langsmith/templates/agent-gateway/deployment.yaml
@@ -3,7 +3,7 @@
   value: {{ .Values.agentGateway.containerPort | quote }}
 {{- if .Values.presidioAnalyzer.enabled }}
 - name: PRESIDIO_ANALYZER_URL
-  value: "http://{{ include "langsmith.fullname" . }}-{{ .Values.presidioAnalyzer.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.presidioAnalyzer.service.port }}"
+  value: {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "presidioAnalyzer" "name" .Values.presidioAnalyzer.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.presidioAnalyzer.service.port) | quote }}
 {{- end }}
 {{- end -}}
 {{- if .Values.agentGateway.enabled }}

--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -35,12 +35,12 @@ data:
   {{- end }}
   LANGCHAIN_ENV: "local_kubernetes"
   LANGCHAIN_ENDPOINT: "/{{ if .Values.config.basePath }}{{ .Values.config.basePath }}/{{ end }}api/v1"
-  GO_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }}"
-  GO_ACE_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.aceBackend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.aceBackend.service.port }}"
-  PLAYGROUND_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.playground.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.playground.service.port }}"
-  SMITH_BACKEND_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.backend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.backend.service.port }}"
-  HOST_BACKEND_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.hostBackend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.hostBackend.service.port }}"
-  LANGSMITH_AUTH_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }}"
+  GO_ENDPOINT: {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) | quote }}
+  GO_ACE_ENDPOINT: {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "aceBackend" "name" .Values.aceBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.aceBackend.service.port) | quote }}
+  PLAYGROUND_ENDPOINT: {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "playground" "name" .Values.playground.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.playground.service.port) | quote }}
+  SMITH_BACKEND_ENDPOINT: {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "backend" "name" .Values.backend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.backend.service.port) | quote }}
+  HOST_BACKEND_ENDPOINT: {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "hostBackend" "name" .Values.hostBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.hostBackend.service.port) | quote }}
+  LANGSMITH_AUTH_ENDPOINT: {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) | quote }}
   {{- if and .Values.smithdb.enabled .Values.smithdb.langsmith.frontend.useSmithDBEndpoints }}
   {{- $smithdbQueryUrl := include "langsmith.smithdb.grpcServiceUrl" (dict "root" . "component" "query" "port" .Values.smithdb.query.service.port) }}
   SMITHDB_QUERY_SERVICE_URL: {{ $smithdbQueryUrl | quote }}
@@ -67,18 +67,10 @@ data:
   LLM_AUTH_PROXY_ISSUER: {{ .Values.config.llmAuthProxyIssuer | quote }}
   {{- end }}
   {{- if and .Values.fleet.enabled .Values.fleetTriggerServer.enabled }}
-  MCP_SERVER_URL: "http://{{ include "langsmith.fullname" . }}-{{ .Values.fleetToolServer.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.fleetToolServer.service.port }}"
+  MCP_SERVER_URL: {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "fleetToolServer" "name" .Values.fleetToolServer.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.fleetToolServer.service.port) | quote }}
   {{- end }}
   {{- if .Values.config.deployment.enabled }}
-  {{- if not .Values.frontend.enabled }}
-  HOST_LANGCHAIN_API_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.backend.service.port }}/api/v1"
-  {{- else }}
-  {{- if .Values.config.basePath }}
-  HOST_LANGCHAIN_API_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{ .Values.frontend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.frontend.service.httpPort }}/{{ .Values.config.basePath}}/api/v1"
-  {{- else }}
-  HOST_LANGCHAIN_API_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{ .Values.frontend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.frontend.service.httpPort }}/api/v1"
-  {{- end }}
-  {{- end }}
+  HOST_LANGCHAIN_API_ENDPOINT: {{ include "langsmith.internalHostLangchainApiEndpoint" . | quote }}
   {{- end }}
   FF_RUN_STATS_GROUP_BY_ENABLED_ALL: "true"
   SEPARATE_QUEUES_WITH_SINGLE_WORKER: '["host"]'
@@ -108,7 +100,7 @@ data:
   SELF_HOSTED_POLLY_ENABLED: "true"
   {{- end }}
   {{- if .Values.agentGateway.enabled }}
-  AGENT_GATEWAY_URL: "http://{{ include "langsmith.fullname" . }}-{{ .Values.agentGateway.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.agentGateway.service.port }}"
+  AGENT_GATEWAY_URL: {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "agentGateway" "name" .Values.agentGateway.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.agentGateway.service.port) | quote }}
   {{- end }}
   # Usage backfill export gating
   {{- if .Values.config.superAdmins }}

--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -106,7 +106,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /{{ .Values.config.basePath }}/api/v1/playground/experiment {
@@ -115,7 +115,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /{{ .Values.config.basePath }}/api/v1/playground/ {
@@ -124,7 +124,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.playground.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.playground.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "playground" "name" .Values.playground.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.playground.service.port) }};
         }
 
         # Platform Backend Routes
@@ -134,7 +134,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /{{ .Values.config.basePath }}/api/v2/datasets/ {
@@ -143,7 +143,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         {{- if and .Values.smithdb.enabled .Values.smithdb.langsmith.frontend.useSmithDBEndpoints }}
@@ -153,7 +153,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
         {{- end }}
 
@@ -163,7 +163,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         # OIDC hybrid-flow support
@@ -181,7 +181,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /{{ .Values.config.basePath }}/api/v1/agent-builder/ {
@@ -190,7 +190,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /{{ .Values.config.basePath }}/api/v1/fleet/ {
@@ -199,7 +199,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /{{ .Values.config.basePath }}/api/v1/annotation-queues/pairwise {
@@ -208,7 +208,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /{{ .Values.config.basePath }}/api/v1/runs/multipart {
@@ -217,7 +217,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /{{ .Values.config.basePath }}/api/v1/runs/batch {
@@ -226,7 +226,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /{{ .Values.config.basePath }}/api/v1/runs {
@@ -235,7 +235,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /{{ .Values.config.basePath }}/api/v1/info {
@@ -244,7 +244,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /{{ .Values.config.basePath }}/api/v1/me/ {
@@ -253,7 +253,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /{{ .Values.config.basePath }}/api/v1/me {
@@ -262,7 +262,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /{{ .Values.config.basePath }}/api/v1/metadata/submit {
@@ -271,7 +271,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /{{ .Values.config.basePath }}/api/v1/auth {
@@ -280,7 +280,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /{{ .Values.config.basePath }}/scim {
@@ -289,7 +289,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /{{ .Values.config.basePath }}/api/v1/public/download {
@@ -298,7 +298,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /{{ .Values.config.basePath }}/api/public {
@@ -307,7 +307,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /{{ .Values.config.basePath }}/api/commits {
@@ -316,7 +316,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /{{ .Values.config.basePath }}/api/v1/commits {
@@ -325,7 +325,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /{{ .Values.config.basePath }}/api/v1/traces {
@@ -334,7 +334,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
     {{- if .Values.config.hostname }}
@@ -347,7 +347,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         # Path-append form of the authorization-server metadata.
@@ -357,7 +357,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         # Protected-resource metadata (the URL advertised in the MCP 401 WWW-Authenticate header).
@@ -367,7 +367,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         # JWKS advertised under the /api issuer (jwks_uri).
@@ -377,7 +377,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         # OAuth Authorization Server endpoints (authorize, token, register, revoke, device).
@@ -387,7 +387,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         # MCP JSON-RPC endpoint (kept distinct from the root /mcp fleet tool server).
@@ -397,7 +397,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         # The OAuth consent page (SPA at /oauth/consent) submits approval and reads client
@@ -408,14 +408,14 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
         location /oauth/client/ {
             proxy_set_header Connection '';
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
     {{- end }}
 
@@ -426,7 +426,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.backend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "backend" "name" .Values.backend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.backend.service.port) }};
         }
 
     {{- if .Values.config.deployment.enabled }}
@@ -436,7 +436,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.hostBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.hostBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "hostBackend" "name" .Values.hostBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.hostBackend.service.port) }};
         }
     {{- end }}
 
@@ -447,7 +447,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.fleetToolServer.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.fleetToolServer.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "fleetToolServer" "name" .Values.fleetToolServer.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.fleetToolServer.service.port) }};
         }
     {{- end }}
 
@@ -458,7 +458,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.fleetTriggerServer.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.fleetTriggerServer.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "fleetTriggerServer" "name" .Values.fleetTriggerServer.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.fleetTriggerServer.service.port) }};
         }
     {{- end }}
 
@@ -469,7 +469,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "fleet") }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.fleet.apiServer.service.httpPort }};
+            proxy_pass {{ include "langsmith.internalServiceUrl" (dict "root" . "key" "fleetApiServer" "default" (printf "http://%s.%s.svc.%s:%v" (include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "fleet")) (.Values.namespace | default .Release.Namespace) .Values.clusterDomain .Values.fleet.apiServer.service.httpPort)) }};
         }
     {{- end }}
 
@@ -480,7 +480,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "insights") }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.insights.apiServer.service.httpPort }};
+            proxy_pass {{ include "langsmith.internalServiceUrl" (dict "root" . "key" "insightsApiServer" "default" (printf "http://%s.%s.svc.%s:%v" (include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "insights")) (.Values.namespace | default .Release.Namespace) .Values.clusterDomain .Values.insights.apiServer.service.httpPort)) }};
         }
     {{- end }}
 
@@ -491,7 +491,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "polly") }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.polly.apiServer.service.httpPort }};
+            proxy_pass {{ include "langsmith.internalServiceUrl" (dict "root" . "key" "pollyApiServer" "default" (printf "http://%s.%s.svc.%s:%v" (include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "polly")) (.Values.namespace | default .Release.Namespace) .Values.clusterDomain .Values.polly.apiServer.service.httpPort)) }};
         }
     {{- end }}
 
@@ -505,7 +505,7 @@ data:
             proxy_buffering off;
             proxy_cache off;
             proxy_read_timeout 900;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.agentGateway.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.agentGateway.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "agentGateway" "name" .Values.agentGateway.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.agentGateway.service.port) }};
         }
     {{- end }}
 
@@ -515,7 +515,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /{{ .Values.config.basePath }}/api/runs/batch {
@@ -524,7 +524,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /{{ .Values.config.basePath }}/api/runs {
@@ -533,7 +533,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /{{ .Values.config.basePath }}/api/info {
@@ -542,7 +542,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /{{ .Values.config.basePath }}/api/me {
@@ -551,7 +551,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         # Deprecated Backend Routes
@@ -561,7 +561,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.backend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "backend" "name" .Values.backend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.backend.service.port) }};
         }
 
         location = /{{ .Values.config.basePath }}/api/docs {
@@ -569,7 +569,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.backend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "backend" "name" .Values.backend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.backend.service.port) }};
         }
 
         location = /{{ .Values.config.basePath }}/api/redoc {
@@ -577,7 +577,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.backend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "backend" "name" .Values.backend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.backend.service.port) }};
         }
 
         location = /{{ .Values.config.basePath }}/api/openapi.json {
@@ -585,7 +585,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.backend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "backend" "name" .Values.backend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.backend.service.port) }};
         }
 
     {{- if .Values.config.deployment.enabled }}
@@ -594,7 +594,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.hostBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.hostBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "hostBackend" "name" .Values.hostBackend.name "namespace" (.Release.Namespace) "port" .Values.hostBackend.service.port) }};
         }
 
         location = /{{ .Values.config.basePath }}/api-host/redoc {
@@ -602,7 +602,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.hostBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.hostBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "hostBackend" "name" .Values.hostBackend.name "namespace" (.Release.Namespace) "port" .Values.hostBackend.service.port) }};
         }
 
         location = /{{ .Values.config.basePath }}/api-host/openapi.json {
@@ -610,7 +610,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.hostBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.hostBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "hostBackend" "name" .Values.hostBackend.name "namespace" (.Release.Namespace) "port" .Values.hostBackend.service.port) }};
         }
     {{- end }}
 
@@ -740,7 +740,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /api/v1/playground/experiment {
@@ -749,7 +749,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /api/v1/playground/ {
@@ -758,7 +758,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.playground.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.playground.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "playground" "name" .Values.playground.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.playground.service.port) }};
         }
 
         # Platform Backend Routes
@@ -768,7 +768,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /api/v2/datasets/ {
@@ -777,7 +777,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         {{- if and .Values.smithdb.enabled .Values.smithdb.langsmith.frontend.useSmithDBEndpoints }}
@@ -787,7 +787,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
         {{- end }}
 
@@ -797,7 +797,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         # OIDC hybrid-flow support
@@ -815,7 +815,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
          }
 
         location /api/v1/agent-builder/ {
@@ -824,7 +824,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /api/v1/fleet/ {
@@ -833,7 +833,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /api/v1/annotation-queues/pairwise {
@@ -842,7 +842,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /api/v1/runs/multipart {
@@ -851,7 +851,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /api/v1/runs/batch {
@@ -860,7 +860,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /api/v1/runs {
@@ -869,7 +869,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /api/v1/info {
@@ -878,7 +878,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
          }
 
         location /api/v1/me/ {
@@ -887,7 +887,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /api/v1/me {
@@ -896,7 +896,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
          }
 
         location = /api/v1/metadata/submit {
@@ -905,7 +905,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Release.Namespace) "port" .Values.platformBackend.service.port) }};
          }
 
          location /api/v1/auth {
@@ -914,7 +914,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
          }
 
         location /api/public {
@@ -923,7 +923,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /api/v1/public/download {
@@ -932,7 +932,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /scim/ {
@@ -940,7 +940,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /api/commits {
@@ -949,7 +949,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /api/v1/commits {
@@ -958,7 +958,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location /api/v1/traces {
@@ -967,7 +967,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
     {{- if .Values.config.hostname }}
@@ -980,7 +980,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         # Path-append form of the authorization-server metadata.
@@ -990,7 +990,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         # Protected-resource metadata (the URL advertised in the MCP 401 WWW-Authenticate header).
@@ -1000,7 +1000,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         # JWKS advertised under the /api issuer (jwks_uri).
@@ -1010,7 +1010,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         # OAuth Authorization Server endpoints (authorize, token, register, revoke, device).
@@ -1020,7 +1020,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         # MCP JSON-RPC endpoint (kept distinct from the root /mcp fleet tool server).
@@ -1030,7 +1030,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         # The OAuth consent page (SPA at /oauth/consent) submits approval and reads client
@@ -1041,14 +1041,14 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
         location /oauth/client/ {
             proxy_set_header Connection '';
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
     {{- end }}
 
@@ -1058,7 +1058,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.backend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "backend" "name" .Values.backend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.backend.service.port) }};
         }
 
     {{- if .Values.config.deployment.enabled }}
@@ -1068,7 +1068,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.hostBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.hostBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "hostBackend" "name" .Values.hostBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.hostBackend.service.port) }};
         }
     {{- end }}
 
@@ -1078,7 +1078,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /api/runs/batch {
@@ -1087,7 +1087,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /api/runs {
@@ -1096,7 +1096,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /api/info {
@@ -1105,7 +1105,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         location = /api/me {
@@ -1114,7 +1114,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "platformBackend" "name" .Values.platformBackend.name "namespace" (.Release.Namespace) "port" .Values.platformBackend.service.port) }};
         }
 
         # Deprecated Backend Routes To be removed in v8
@@ -1124,7 +1124,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.backend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "backend" "name" .Values.backend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.backend.service.port) }};
        }
 
         location = /api/docs {
@@ -1132,7 +1132,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.backend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "backend" "name" .Values.backend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.backend.service.port) }};
         }
 
         location = /api/redoc {
@@ -1140,7 +1140,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.backend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "backend" "name" .Values.backend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.backend.service.port) }};
         }
 
         location = /api/openapi.json {
@@ -1148,7 +1148,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.backend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "backend" "name" .Values.backend.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.backend.service.port) }};
         }
 
     {{- if .Values.config.deployment.enabled }}
@@ -1157,7 +1157,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.hostBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.hostBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "hostBackend" "name" .Values.hostBackend.name "namespace" (.Release.Namespace) "port" .Values.hostBackend.service.port) }};
         }
 
         location = /api-host/redoc {
@@ -1165,7 +1165,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.hostBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.hostBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "hostBackend" "name" .Values.hostBackend.name "namespace" (.Release.Namespace) "port" .Values.hostBackend.service.port) }};
         }
 
         location = /api-host/openapi.json {
@@ -1173,7 +1173,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.hostBackend.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.hostBackend.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "hostBackend" "name" .Values.hostBackend.name "namespace" (.Release.Namespace) "port" .Values.hostBackend.service.port) }};
         }
     {{- end }}
 
@@ -1183,7 +1183,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.fleetToolServer.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.fleetToolServer.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "fleetToolServer" "name" .Values.fleetToolServer.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.fleetToolServer.service.port) }};
         }
     {{- end }}
 
@@ -1193,7 +1193,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.fleetTriggerServer.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.fleetTriggerServer.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "fleetTriggerServer" "name" .Values.fleetTriggerServer.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.fleetTriggerServer.service.port) }};
         }
     {{- end }}
 
@@ -1204,7 +1204,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "fleet") }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.fleet.apiServer.service.httpPort }};
+            proxy_pass {{ include "langsmith.internalServiceUrl" (dict "root" . "key" "fleetApiServer" "default" (printf "http://%s.%s.svc.%s:%v" (include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "fleet")) (.Values.namespace | default .Release.Namespace) .Values.clusterDomain .Values.fleet.apiServer.service.httpPort)) }};
         }
     {{- end }}
 
@@ -1215,7 +1215,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "insights") }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.insights.apiServer.service.httpPort }};
+            proxy_pass {{ include "langsmith.internalServiceUrl" (dict "root" . "key" "insightsApiServer" "default" (printf "http://%s.%s.svc.%s:%v" (include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "insights")) (.Values.namespace | default .Release.Namespace) .Values.clusterDomain .Values.insights.apiServer.service.httpPort)) }};
         }
     {{- end }}
 
@@ -1226,7 +1226,7 @@ data:
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_cache off;
-            proxy_pass http://{{ include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "polly") }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.polly.apiServer.service.httpPort }};
+            proxy_pass {{ include "langsmith.internalServiceUrl" (dict "root" . "key" "pollyApiServer" "default" (printf "http://%s.%s.svc.%s:%v" (include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "polly")) (.Values.namespace | default .Release.Namespace) .Values.clusterDomain .Values.polly.apiServer.service.httpPort)) }};
         }
     {{- end }}
 
@@ -1240,7 +1240,7 @@ data:
             proxy_buffering off;
             proxy_cache off;
             proxy_read_timeout 900;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.agentGateway.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.agentGateway.service.port }};
+            proxy_pass {{ include "langsmith.internalServiceEndpoint" (dict "root" . "key" "agentGateway" "name" .Values.agentGateway.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.agentGateway.service.port) }};
         }
     {{- end }}
       }

--- a/charts/langsmith/templates/host-backend/deployment.yaml
+++ b/charts/langsmith/templates/host-backend/deployment.yaml
@@ -18,7 +18,7 @@
 {{- end }}
 {{- if .Values.fleetTriggerServer.enabled }}
 - name: AGENT_BUILDER_TRIGGERS_API_URL
-  value: "http://{{ include "langsmith.fullname" . }}-{{ .Values.fleetTriggerServer.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.fleetTriggerServer.service.port }}/v1/triggers"
+  value: {{ printf "%s/v1/triggers" (include "langsmith.internalServiceEndpoint" (dict "root" . "key" "fleetTriggerServer" "name" .Values.fleetTriggerServer.name "namespace" (.Values.namespace | default .Release.Namespace) "port" .Values.fleetTriggerServer.service.port)) | quote }}
 {{- end }}
 {{- include "agentBuilderOAuthEnvVars" . }}
 {{- end }}

--- a/charts/langsmith/tests/internal_service_urls_test.yaml
+++ b/charts/langsmith/tests/internal_service_urls_test.yaml
@@ -1,0 +1,79 @@
+suite: Internal service URL overrides
+templates:
+  - config-map.yaml
+  - frontend/config-map.yaml
+tests:
+  - it: preserves Kubernetes service DNS by default
+    template: config-map.yaml
+    asserts:
+      - equal:
+          path: data.GO_ENDPOINT
+          value: http://RELEASE-NAME-langsmith-platform-backend.NAMESPACE.svc.cluster.local:1986
+      - equal:
+          path: data.SMITH_BACKEND_ENDPOINT
+          value: http://RELEASE-NAME-langsmith-backend.NAMESPACE.svc.cluster.local:1984
+
+  - it: overrides core configuration endpoints
+    template: config-map.yaml
+    set:
+      config.deployment.enabled: true
+      agentGateway.enabled: true
+      internalServiceUrls:
+        platformBackend: http://10.0.0.1:1986
+        aceBackend: http://10.0.0.2:1987
+        playground: http://10.0.0.3:1988
+        backend: http://10.0.0.4:1984
+        hostBackend: http://10.0.0.5:1985
+        frontend: http://10.0.0.6:80
+        agentGateway: http://10.0.0.7:8200
+        hostLangchainApi: http://10.0.0.99:1984/api/v1
+    asserts:
+      - equal:
+          path: data.GO_ENDPOINT
+          value: http://10.0.0.1:1986
+      - equal:
+          path: data.GO_ACE_ENDPOINT
+          value: http://10.0.0.2:1987
+      - equal:
+          path: data.PLAYGROUND_ENDPOINT
+          value: http://10.0.0.3:1988
+      - equal:
+          path: data.SMITH_BACKEND_ENDPOINT
+          value: http://10.0.0.4:1984
+      - equal:
+          path: data.HOST_BACKEND_ENDPOINT
+          value: http://10.0.0.5:1985
+      - equal:
+          path: data.AGENT_GATEWAY_URL
+          value: http://10.0.0.7:8200
+      - equal:
+          path: data.HOST_LANGCHAIN_API_ENDPOINT
+          value: http://10.0.0.99:1984/api/v1
+
+  - it: overrides every frontend proxy upstream
+    template: frontend/config-map.yaml
+    set:
+      fleet.enabled: true
+      insights.enabled: true
+      polly.enabled: true
+      internalServiceUrls:
+        platformBackend: http://10.0.0.1:1986
+        playground: http://10.0.0.3:1988
+        backend: http://10.0.0.4:1984
+        hostBackend: http://10.0.0.5:1985
+        agentGateway: http://10.0.0.7:8200
+        fleetToolServer: http://10.0.0.8:8080
+        fleetTriggerServer: http://10.0.0.9:8081
+        fleetApiServer: http://10.0.0.11:8080
+        insightsApiServer: http://10.0.0.12:8080
+        pollyApiServer: http://10.0.0.13:8080
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "proxy_pass http://10\\.0\\.0\\.1:1986;"
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "proxy_pass http://10\\.0\\.0\\.11:8080;"
+      - notMatchRegex:
+          path: data["nginx.conf"]
+          pattern: "proxy_pass http://[^;]+\\.svc\\."

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -54,6 +54,8 @@ commonDnsConfig:
   options:
     - name: ndots
       value: "4"
+# -- Optional URLs for core internal services. Empty values preserve Kubernetes service DNS.
+internalServiceUrls: {}
 # -- Kubernetes cluster domain. Only change if not using 'cluster.local'
 clusterDomain: "cluster.local"
 


### PR DESCRIPTION
## Summary

Adds opt-in internal service URL overrides for LangSmith's core configuration and frontend reverse-proxy routes.

## Why

The chart currently embeds Kubernetes service FQDNs in core environment variables and NGINX upstreams. This is normally correct, but deployments with custom DNS, service meshes, or alternate internal routing need to direct these calls elsewhere.

## Changes

- Add `internalServiceUrls`, an empty-by-default map of internal endpoint overrides.
- Route core ConfigMap endpoints, frontend NGINX upstreams, agent-feature API routes, and the dependent agent-gateway/host-backend environment variables through shared helpers.
- Preserve each existing Kubernetes service DNS URL when no override is supplied.
- Document the values and add unit coverage for default and override behavior.

## Validation

- `helm lint charts/langsmith -f charts/langsmith/ci/lightweight-config-values.yaml`
- `helm unittest charts/langsmith` (63 tests)
- Rendered with custom URLs and confirmed no frontend `proxy_pass` retains a Kubernetes service FQDN.
- Compared the default render with upstream `main`; outputs are byte-identical.
