### PR TITLE
fix: correct sidecar indentation in e2e-test.yaml

### DIFF
--- a/charts/langsmith/templates/backend/e2e-test.yaml
+++ b/charts/langsmith/templates/backend/e2e-test.yaml
@@ -72,7 +72,7 @@ spec:
             {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- with .Values.backend.e2eTest.sidecars }}
-          {{- toYaml . | nindent 10 }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.backend.e2eTest.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
## Problem

Sidecar containers in `templates/backend/e2e-test.yaml` were rendered with `nindent 10` instead of `nindent 8`. This caused sidecars to be nested as properties of the main container rather than as sibling entries in the `containers` list, producing invalid YAML that fails Helm templating with:

```
YAML parse error on langsmith/templates/backend/e2e-test.yaml: error converting YAML to JSON: yaml: line 255: did not find expected key
```

The same pattern in `templates/backend/deployment.yaml` already correctly uses `nindent 8`.

Reported in INF-1905 / Pylon case 20605.

## Fix

One-line change: `nindent 10` → `nindent 8` on line 75.

## Validation

- Reproduced the bug by rendering the template with sidecars defined (helm template fails with YAML parse error)
- Applied the fix and confirmed the template renders successfully with sidecars as sibling list items under `containers`
- Compared output with `deployment.yaml` to confirm identical sidecar structure
- `helm lint` passes with no errors