### PR TITLE
fix: retry smithdb migration job

### DIFF
--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -316,6 +316,10 @@ tests:
           value: Never
       - template: smithdb/migration-job.yaml
         equal:
+          path: spec.backoffLimit
+          value: 3
+      - template: smithdb/migration-job.yaml
+        equal:
           path: spec.template.spec.containers[0].command
           value:
             - "/usr/local/bin/smithdb-with-taskdb-migrations-entrypoint.sh"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1587,8 +1587,8 @@ smithdb:
     job:
       # -- Keep finished migrate-all Jobs around for a day so operators can inspect status/logs.
       ttlSecondsAfterFinished: 86400
-      # -- Do not retry a failed migrate-all; failures should be inspected and re-run deliberately.
-      backoffLimit: 0
+      # -- Retry transient migration Job failures, including taskdb startup races.
+      backoffLimit: 3
       # -- Optional hard deadline for the Job. Leave unset for long-running full migrations.
       activeDeadlineSeconds: null
       restartPolicy: Never


### PR DESCRIPTION
## Description
Raises the SmithDB migration Job default `backoffLimit` to 3 so transient taskdb startup races and other short-lived failures get retried by Kubernetes.

## Test Plan
- [x] `git diff --check`
- [ ] Helm render/unit tests not run locally: `helm` is not installed in the sandbox

Made by [Open SWE](https://openswe.vercel.app/agents/fc89d435-23b4-24ce-8ba6-6d9fc4e0fae4)