### PR TITLE
fix: refresh dataplane image defaults [closes LSD-1638]

### DIFF
--- a/charts/langgraph-dataplane/Chart.yaml
+++ b/charts/langgraph-dataplane/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy a langgraph dataplane on kubernetes.
 type: application
-version: 0.2.21
-appVersion: "0.13.9"
+version: 0.2.22
+appVersion: "0.13.44"

--- a/charts/langgraph-dataplane/README.md
+++ b/charts/langgraph-dataplane/README.md
@@ -1,6 +1,6 @@
 # langgraph-dataplane
 
-![Version: 0.2.21](https://img.shields.io/badge/Version-0.2.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.9](https://img.shields.io/badge/AppVersion-0.13.9-informational?style=flat-square)
+![Version: 0.2.22](https://img.shields.io/badge/Version-0.2.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.44](https://img.shields.io/badge/AppVersion-0.13.44-informational?style=flat-square)
 
 Helm chart to deploy a langgraph dataplane on kubernetes.
 
@@ -30,10 +30,10 @@ You can find the guide to deploy a LangGraph Dataplane [here](https://langchain-
 | images.imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Specified as name: value. |
 | images.listenerImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.listenerImage.repository | string | `"docker.io/langchain/hosted-langserve-backend"` |  |
-| images.listenerImage.tag | string | `"0.13.9"` |  |
+| images.listenerImage.tag | string | `"0.13.44"` |  |
 | images.operatorImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.operatorImage.repository | string | `"docker.io/langchain/langgraph-operator"` |  |
-| images.operatorImage.tag | string | `"0.1.36"` |  |
+| images.operatorImage.tag | string | `"0.1.55"` |  |
 | images.redisImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.redisImage.repository | string | `"docker.io/redis"` |  |
 | images.redisImage.tag | string | `"7"` |  |

--- a/charts/langgraph-dataplane/values.yaml
+++ b/charts/langgraph-dataplane/values.yaml
@@ -34,7 +34,7 @@ images:
   listenerImage:
     repository: "docker.io/langchain/hosted-langserve-backend"
     pullPolicy: IfNotPresent
-    tag: "0.13.9"
+    tag: "0.13.44"
   redisImage:
     repository: "docker.io/redis"
     pullPolicy: IfNotPresent
@@ -42,7 +42,7 @@ images:
   operatorImage:
     repository: "docker.io/langchain/langgraph-operator"
     pullPolicy: IfNotPresent
-    tag: "0.1.36"
+    tag: "0.1.55"
 
 ingress:
   enabled: true


### PR DESCRIPTION
## Description
Refresh the deprecated `langgraph-dataplane` chart to listener `0.13.44` and operator `0.1.55`, and release it as chart `0.2.22`. This fixes missing `secret_references` injection for users still on this deployment model.

## Test Plan
- [x] Render the chart and confirm the updated default images are accepted

Made by [Open SWE](https://openswe.vercel.app/agents/3891f64e-ba4e-9056-36a7-6403f11bdc29)