### PR TITLE
feat(langsmith): wire SmithDB CM min/max replicas from Helm

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -903,19 +903,18 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.clusterManager.service.annotations | object | `{}` |  |
 | smithdb.clusterManager.service.labels | object | `{}` |  |
 | smithdb.clusterManager.service.port | int | `8091` |  |
-| smithdb.clusterManager.services | object | `{"compaction":{"maxReplicas":"","minReplicas":1,"replicationThreshold":"","sliceReplicationThreshold":""},"ingestion":{"maxReplicas":"","minReplicas":1,"replicationThreshold":"","sliceReplicationThreshold":""},"query":{"maxReplicas":"","minReplicas":1,"replicationThreshold":"","sliceReplicationThreshold":""}}` | Per-service slice replica bounds for the cluster manager. maxReplicas defaults to that service's deployment.replicas when empty. replicationThreshold / sliceReplicationThreshold default to SmithDB None (replication suppression disabled) when empty; set 0 to force distribution. |
-| smithdb.clusterManager.services.compaction.maxReplicas | string | `""` | Maximum number of compaction pods that may own a slice. Empty uses compaction.deployment.replicas. |
-| smithdb.clusterManager.services.compaction.minReplicas | int | `1` | Minimum number of compaction pods that may own a slice. |
-| smithdb.clusterManager.services.compaction.replicationThreshold | string | `""` | Absolute load threshold above which AddRedundant is allowed. Empty = SmithDB default (None). |
-| smithdb.clusterManager.services.compaction.sliceReplicationThreshold | string | `""` | Per-slice load threshold below which AddRedundant is suppressed. Empty = SmithDB default (None). |
-| smithdb.clusterManager.services.ingestion.maxReplicas | string | `""` | Maximum number of ingestion pods that may own a slice. Empty uses ingestion.deployment.replicas. |
-| smithdb.clusterManager.services.ingestion.minReplicas | int | `1` | Minimum number of ingestion pods that may own a slice. |
-| smithdb.clusterManager.services.ingestion.replicationThreshold | string | `""` | Absolute load threshold above which AddRedundant is allowed. Empty = SmithDB default (None). |
-| smithdb.clusterManager.services.ingestion.sliceReplicationThreshold | string | `""` | Per-slice load threshold below which AddRedundant is suppressed. Empty = SmithDB default (None). |
-| smithdb.clusterManager.services.query.maxReplicas | string | `""` | Maximum number of query pods that may own a slice. Empty uses query.deployment.replicas. |
-| smithdb.clusterManager.services.query.minReplicas | int | `1` | Minimum number of query pods that may own a slice. |
-| smithdb.clusterManager.services.query.replicationThreshold | string | `""` | Absolute load threshold above which AddRedundant is allowed. Empty = SmithDB default (None). |
-| smithdb.clusterManager.services.query.sliceReplicationThreshold | string | `""` | Per-slice load threshold below which AddRedundant is suppressed. Empty = SmithDB default (None). |
+| smithdb.clusterManager.services.compaction.maxReplicas | string | `""` |  |
+| smithdb.clusterManager.services.compaction.minReplicas | int | `1` |  |
+| smithdb.clusterManager.services.compaction.replicationThreshold | string | `""` |  |
+| smithdb.clusterManager.services.compaction.sliceReplicationThreshold | string | `""` |  |
+| smithdb.clusterManager.services.ingestion.maxReplicas | string | `""` |  |
+| smithdb.clusterManager.services.ingestion.minReplicas | int | `1` |  |
+| smithdb.clusterManager.services.ingestion.replicationThreshold | string | `""` |  |
+| smithdb.clusterManager.services.ingestion.sliceReplicationThreshold | string | `""` |  |
+| smithdb.clusterManager.services.query.maxReplicas | string | `""` |  |
+| smithdb.clusterManager.services.query.minReplicas | int | `1` |  |
+| smithdb.clusterManager.services.query.replicationThreshold | string | `""` |  |
+| smithdb.clusterManager.services.query.sliceReplicationThreshold | string | `""` |  |
 | smithdb.commonEnv | list | `[]` | Extra env vars for every SmithDB workload. |
 | smithdb.compaction.containerGrpcPort | int | `8071` |  |
 | smithdb.compaction.containerPort | int | `8070` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1105,10 +1105,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.query.deployment.command[0] | string | `"./smithdb"` |  |
 | smithdb.query.deployment.command[1] | string | `"query"` |  |
 | smithdb.query.deployment.extraContainerConfig | object | `{}` |  |
-| smithdb.query.deployment.extraEnv[0].name | string | `"SMITHDB_QUERY__VORTEX_CACHE__SEGMENT_CACHE__DISK_PATH"` |  |
-| smithdb.query.deployment.extraEnv[0].value | string | `"/data/segment"` |  |
-| smithdb.query.deployment.extraEnv[1].name | string | `"SMITHDB_QUERY__VORTEX_CACHE__FILTER_CACHE__DISK_PATH"` |  |
-| smithdb.query.deployment.extraEnv[1].value | string | `"/data/filter"` |  |
+| smithdb.query.deployment.extraEnv | list | `[]` |  |
 | smithdb.query.deployment.initContainers | list | `[]` |  |
 | smithdb.query.deployment.labels | object | `{}` |  |
 | smithdb.query.deployment.nodeSelector | object | `{}` |  |
@@ -1142,10 +1139,8 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.query.deployment.strategy.type | string | `"RollingUpdate"` |  |
 | smithdb.query.deployment.tolerations | list | `[]` |  |
 | smithdb.query.deployment.topologySpreadConstraints | list | `[]` |  |
-| smithdb.query.deployment.volumeMounts[0].mountPath | string | `"/data"` |  |
-| smithdb.query.deployment.volumeMounts[0].name | string | `"local-ssd-storage"` |  |
-| smithdb.query.deployment.volumes[0].emptyDir.sizeLimit | string | `"200Gi"` |  |
-| smithdb.query.deployment.volumes[0].name | string | `"local-ssd-storage"` |  |
+| smithdb.query.deployment.volumeMounts | list | `[]` |  |
+| smithdb.query.deployment.volumes | list | `[]` |  |
 | smithdb.query.name | string | `"query"` |  |
 | smithdb.query.pdb.annotations | object | `{}` |  |
 | smithdb.query.pdb.enabled | bool | `false` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -906,14 +906,6 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.clusterManager.service.annotations | object | `{}` |  |
 | smithdb.clusterManager.service.labels | object | `{}` |  |
 | smithdb.clusterManager.service.port | int | `8091` |  |
-| smithdb.clusterManager.services.ingestion.maxReplicas | string | `""` |  |
-| smithdb.clusterManager.services.ingestion.minReplicas | int | `1` |  |
-| smithdb.clusterManager.services.ingestion.replicationThreshold | int | `0` |  |
-| smithdb.clusterManager.services.ingestion.sliceReplicationThreshold | int | `0` |  |
-| smithdb.clusterManager.services.query.maxReplicas | string | `""` |  |
-| smithdb.clusterManager.services.query.minReplicas | int | `1` |  |
-| smithdb.clusterManager.services.query.replicationThreshold | int | `0` |  |
-| smithdb.clusterManager.services.query.sliceReplicationThreshold | int | `0` |  |
 | smithdb.commonEnv | list | `[]` | Extra env vars for every SmithDB workload. |
 | smithdb.compaction.containerGrpcPort | int | `8071` |  |
 | smithdb.compaction.containerPort | int | `8070` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -891,7 +891,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.clusterManager.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.clusterManager.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.clusterManager.deployment.replicas | int | `1` |  |
-| smithdb.clusterManager.deployment.resources | object | `{"limits":{"cpu":"250m","memory":"256Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | Small-tier baseline. Override for larger deployments. |
+| smithdb.clusterManager.deployment.resources | object | `{"limits":{"cpu":"250m","memory":"256Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | Starting baseline. |
 | smithdb.clusterManager.deployment.securityContext | object | `{}` |  |
 | smithdb.clusterManager.deployment.sidecars | list | `[]` |  |
 | smithdb.clusterManager.deployment.tolerations | list | `[]` |  |
@@ -941,7 +941,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.compaction.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.compaction.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.compaction.deployment.replicas | int | `1` |  |
-| smithdb.compaction.deployment.resources | object | `{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}` | Small-tier baseline. Override for larger deployments. |
+| smithdb.compaction.deployment.resources | object | `{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}` | Starting baseline. |
 | smithdb.compaction.deployment.securityContext | object | `{}` |  |
 | smithdb.compaction.deployment.sidecars | list | `[]` |  |
 | smithdb.compaction.deployment.tolerations | list | `[]` |  |
@@ -984,7 +984,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.compactionWorker.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.compactionWorker.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.compactionWorker.deployment.replicas | int | `2` |  |
-| smithdb.compactionWorker.deployment.resources | object | `{"limits":{"cpu":"4","ephemeral-storage":"100Gi","memory":"8Gi"},"requests":{"cpu":"4","ephemeral-storage":"100Gi","memory":"8Gi"}}` | Small-tier baseline. Override for larger deployments. |
+| smithdb.compactionWorker.deployment.resources | object | `{"limits":{"cpu":"4","ephemeral-storage":"100Gi","memory":"8Gi"},"requests":{"cpu":"4","ephemeral-storage":"100Gi","memory":"8Gi"}}` | Starting baseline. |
 | smithdb.compactionWorker.deployment.securityContext | object | `{}` |  |
 | smithdb.compactionWorker.deployment.sidecars | list | `[]` |  |
 | smithdb.compactionWorker.deployment.terminationGracePeriodSeconds | int | `120` |  |
@@ -1049,7 +1049,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.ingestion.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.ingestion.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.ingestion.deployment.replicas | int | `1` |  |
-| smithdb.ingestion.deployment.resources | object | `{"limits":{"cpu":"4","ephemeral-storage":"100Gi","memory":"8Gi"},"requests":{"cpu":"4","ephemeral-storage":"100Gi","memory":"8Gi"}}` | Small-tier baseline. Override for larger deployments. |
+| smithdb.ingestion.deployment.resources | object | `{"limits":{"cpu":"4","ephemeral-storage":"100Gi","memory":"8Gi"},"requests":{"cpu":"4","ephemeral-storage":"100Gi","memory":"8Gi"}}` | Starting baseline. |
 | smithdb.ingestion.deployment.securityContext | object | `{}` |  |
 | smithdb.ingestion.deployment.sidecars | list | `[]` |  |
 | smithdb.ingestion.deployment.strategy.rollingUpdate.maxSurge | int | `1` |  |
@@ -1121,7 +1121,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.query.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.query.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.query.deployment.replicas | int | `1` |  |
-| smithdb.query.deployment.resources | object | `{"limits":{"cpu":"4","ephemeral-storage":"200Gi","memory":"8Gi"},"requests":{"cpu":"4","ephemeral-storage":"200Gi","memory":"8Gi"}}` | Small-tier baseline. Override for larger deployments. |
+| smithdb.query.deployment.resources | object | `{"limits":{"cpu":"4","ephemeral-storage":"200Gi","memory":"8Gi"},"requests":{"cpu":"4","ephemeral-storage":"200Gi","memory":"8Gi"}}` | Starting baseline. |
 | smithdb.query.deployment.securityContext | object | `{}` |  |
 | smithdb.query.deployment.sidecars | list | `[]` |  |
 | smithdb.query.deployment.strategy.rollingUpdate.maxSurge | int | `1` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -891,7 +891,10 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.clusterManager.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.clusterManager.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.clusterManager.deployment.replicas | int | `1` |  |
-| smithdb.clusterManager.deployment.resources | object | `{"limits":{"cpu":"250m","memory":"256Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | Starting baseline. |
+| smithdb.clusterManager.deployment.resources.limits.cpu | string | `"250m"` |  |
+| smithdb.clusterManager.deployment.resources.limits.memory | string | `"256Mi"` |  |
+| smithdb.clusterManager.deployment.resources.requests.cpu | string | `"250m"` |  |
+| smithdb.clusterManager.deployment.resources.requests.memory | string | `"256Mi"` |  |
 | smithdb.clusterManager.deployment.securityContext | object | `{}` |  |
 | smithdb.clusterManager.deployment.sidecars | list | `[]` |  |
 | smithdb.clusterManager.deployment.tolerations | list | `[]` |  |
@@ -941,7 +944,10 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.compaction.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.compaction.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.compaction.deployment.replicas | int | `1` |  |
-| smithdb.compaction.deployment.resources | object | `{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}` | Starting baseline. |
+| smithdb.compaction.deployment.resources.limits.cpu | string | `"500m"` |  |
+| smithdb.compaction.deployment.resources.limits.memory | string | `"1Gi"` |  |
+| smithdb.compaction.deployment.resources.requests.cpu | string | `"500m"` |  |
+| smithdb.compaction.deployment.resources.requests.memory | string | `"1Gi"` |  |
 | smithdb.compaction.deployment.securityContext | object | `{}` |  |
 | smithdb.compaction.deployment.sidecars | list | `[]` |  |
 | smithdb.compaction.deployment.tolerations | list | `[]` |  |
@@ -984,7 +990,12 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.compactionWorker.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.compactionWorker.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.compactionWorker.deployment.replicas | int | `2` |  |
-| smithdb.compactionWorker.deployment.resources | object | `{"limits":{"cpu":"4","ephemeral-storage":"100Gi","memory":"8Gi"},"requests":{"cpu":"4","ephemeral-storage":"100Gi","memory":"8Gi"}}` | Starting baseline. |
+| smithdb.compactionWorker.deployment.resources.limits.cpu | string | `"4"` |  |
+| smithdb.compactionWorker.deployment.resources.limits.ephemeral-storage | string | `"100Gi"` |  |
+| smithdb.compactionWorker.deployment.resources.limits.memory | string | `"8Gi"` |  |
+| smithdb.compactionWorker.deployment.resources.requests.cpu | string | `"4"` |  |
+| smithdb.compactionWorker.deployment.resources.requests.ephemeral-storage | string | `"100Gi"` |  |
+| smithdb.compactionWorker.deployment.resources.requests.memory | string | `"8Gi"` |  |
 | smithdb.compactionWorker.deployment.securityContext | object | `{}` |  |
 | smithdb.compactionWorker.deployment.sidecars | list | `[]` |  |
 | smithdb.compactionWorker.deployment.terminationGracePeriodSeconds | int | `120` |  |
@@ -1049,7 +1060,12 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.ingestion.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.ingestion.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.ingestion.deployment.replicas | int | `1` |  |
-| smithdb.ingestion.deployment.resources | object | `{"limits":{"cpu":"4","ephemeral-storage":"100Gi","memory":"8Gi"},"requests":{"cpu":"4","ephemeral-storage":"100Gi","memory":"8Gi"}}` | Starting baseline. |
+| smithdb.ingestion.deployment.resources.limits.cpu | string | `"4"` |  |
+| smithdb.ingestion.deployment.resources.limits.ephemeral-storage | string | `"100Gi"` |  |
+| smithdb.ingestion.deployment.resources.limits.memory | string | `"8Gi"` |  |
+| smithdb.ingestion.deployment.resources.requests.cpu | string | `"4"` |  |
+| smithdb.ingestion.deployment.resources.requests.ephemeral-storage | string | `"100Gi"` |  |
+| smithdb.ingestion.deployment.resources.requests.memory | string | `"8Gi"` |  |
 | smithdb.ingestion.deployment.securityContext | object | `{}` |  |
 | smithdb.ingestion.deployment.sidecars | list | `[]` |  |
 | smithdb.ingestion.deployment.strategy.rollingUpdate.maxSurge | int | `1` |  |
@@ -1121,7 +1137,12 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.query.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.query.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.query.deployment.replicas | int | `1` |  |
-| smithdb.query.deployment.resources | object | `{"limits":{"cpu":"4","ephemeral-storage":"200Gi","memory":"8Gi"},"requests":{"cpu":"4","ephemeral-storage":"200Gi","memory":"8Gi"}}` | Starting baseline. |
+| smithdb.query.deployment.resources.limits.cpu | string | `"4"` |  |
+| smithdb.query.deployment.resources.limits.ephemeral-storage | string | `"200Gi"` |  |
+| smithdb.query.deployment.resources.limits.memory | string | `"8Gi"` |  |
+| smithdb.query.deployment.resources.requests.cpu | string | `"4"` |  |
+| smithdb.query.deployment.resources.requests.ephemeral-storage | string | `"200Gi"` |  |
+| smithdb.query.deployment.resources.requests.memory | string | `"8Gi"` |  |
 | smithdb.query.deployment.securityContext | object | `{}` |  |
 | smithdb.query.deployment.sidecars | list | `[]` |  |
 | smithdb.query.deployment.strategy.rollingUpdate.maxSurge | int | `1` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -903,6 +903,19 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.clusterManager.service.annotations | object | `{}` |  |
 | smithdb.clusterManager.service.labels | object | `{}` |  |
 | smithdb.clusterManager.service.port | int | `8091` |  |
+| smithdb.clusterManager.services | object | `{"compaction":{"maxReplicas":"","minReplicas":1,"replicationThreshold":"","sliceReplicationThreshold":""},"ingestion":{"maxReplicas":"","minReplicas":1,"replicationThreshold":"","sliceReplicationThreshold":""},"query":{"maxReplicas":"","minReplicas":1,"replicationThreshold":"","sliceReplicationThreshold":""}}` | Per-service slice replica bounds for the cluster manager. maxReplicas defaults to that service's deployment.replicas when empty. replicationThreshold / sliceReplicationThreshold default to SmithDB None (replication suppression disabled) when empty; set 0 to force distribution. |
+| smithdb.clusterManager.services.compaction.maxReplicas | string | `""` | Maximum number of compaction pods that may own a slice. Empty uses compaction.deployment.replicas. |
+| smithdb.clusterManager.services.compaction.minReplicas | int | `1` | Minimum number of compaction pods that may own a slice. |
+| smithdb.clusterManager.services.compaction.replicationThreshold | string | `""` | Absolute load threshold above which AddRedundant is allowed. Empty = SmithDB default (None). |
+| smithdb.clusterManager.services.compaction.sliceReplicationThreshold | string | `""` | Per-slice load threshold below which AddRedundant is suppressed. Empty = SmithDB default (None). |
+| smithdb.clusterManager.services.ingestion.maxReplicas | string | `""` | Maximum number of ingestion pods that may own a slice. Empty uses ingestion.deployment.replicas. |
+| smithdb.clusterManager.services.ingestion.minReplicas | int | `1` | Minimum number of ingestion pods that may own a slice. |
+| smithdb.clusterManager.services.ingestion.replicationThreshold | string | `""` | Absolute load threshold above which AddRedundant is allowed. Empty = SmithDB default (None). |
+| smithdb.clusterManager.services.ingestion.sliceReplicationThreshold | string | `""` | Per-slice load threshold below which AddRedundant is suppressed. Empty = SmithDB default (None). |
+| smithdb.clusterManager.services.query.maxReplicas | string | `""` | Maximum number of query pods that may own a slice. Empty uses query.deployment.replicas. |
+| smithdb.clusterManager.services.query.minReplicas | int | `1` | Minimum number of query pods that may own a slice. |
+| smithdb.clusterManager.services.query.replicationThreshold | string | `""` | Absolute load threshold above which AddRedundant is allowed. Empty = SmithDB default (None). |
+| smithdb.clusterManager.services.query.sliceReplicationThreshold | string | `""` | Per-slice load threshold below which AddRedundant is suppressed. Empty = SmithDB default (None). |
 | smithdb.commonEnv | list | `[]` | Extra env vars for every SmithDB workload. |
 | smithdb.compaction.containerGrpcPort | int | `8071` |  |
 | smithdb.compaction.containerPort | int | `8070` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -903,10 +903,6 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.clusterManager.service.annotations | object | `{}` |  |
 | smithdb.clusterManager.service.labels | object | `{}` |  |
 | smithdb.clusterManager.service.port | int | `8091` |  |
-| smithdb.clusterManager.services.compaction.maxReplicas | string | `""` |  |
-| smithdb.clusterManager.services.compaction.minReplicas | int | `1` |  |
-| smithdb.clusterManager.services.compaction.replicationThreshold | int | `0` |  |
-| smithdb.clusterManager.services.compaction.sliceReplicationThreshold | int | `0` |  |
 | smithdb.clusterManager.services.ingestion.maxReplicas | string | `""` |  |
 | smithdb.clusterManager.services.ingestion.minReplicas | int | `1` |  |
 | smithdb.clusterManager.services.ingestion.replicationThreshold | int | `0` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -905,16 +905,16 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.clusterManager.service.port | int | `8091` |  |
 | smithdb.clusterManager.services.compaction.maxReplicas | string | `""` |  |
 | smithdb.clusterManager.services.compaction.minReplicas | int | `1` |  |
-| smithdb.clusterManager.services.compaction.replicationThreshold | string | `""` |  |
-| smithdb.clusterManager.services.compaction.sliceReplicationThreshold | string | `""` |  |
+| smithdb.clusterManager.services.compaction.replicationThreshold | int | `0` |  |
+| smithdb.clusterManager.services.compaction.sliceReplicationThreshold | int | `0` |  |
 | smithdb.clusterManager.services.ingestion.maxReplicas | string | `""` |  |
 | smithdb.clusterManager.services.ingestion.minReplicas | int | `1` |  |
-| smithdb.clusterManager.services.ingestion.replicationThreshold | string | `""` |  |
-| smithdb.clusterManager.services.ingestion.sliceReplicationThreshold | string | `""` |  |
+| smithdb.clusterManager.services.ingestion.replicationThreshold | int | `0` |  |
+| smithdb.clusterManager.services.ingestion.sliceReplicationThreshold | int | `0` |  |
 | smithdb.clusterManager.services.query.maxReplicas | string | `""` |  |
 | smithdb.clusterManager.services.query.minReplicas | int | `1` |  |
-| smithdb.clusterManager.services.query.replicationThreshold | string | `""` |  |
-| smithdb.clusterManager.services.query.sliceReplicationThreshold | string | `""` |  |
+| smithdb.clusterManager.services.query.replicationThreshold | int | `0` |  |
+| smithdb.clusterManager.services.query.sliceReplicationThreshold | int | `0` |  |
 | smithdb.commonEnv | list | `[]` | Extra env vars for every SmithDB workload. |
 | smithdb.compaction.containerGrpcPort | int | `8071` |  |
 | smithdb.compaction.containerPort | int | `8070` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1102,12 +1102,10 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.query.deployment.command[0] | string | `"./smithdb"` |  |
 | smithdb.query.deployment.command[1] | string | `"query"` |  |
 | smithdb.query.deployment.extraContainerConfig | object | `{}` |  |
-| smithdb.query.deployment.extraEnv[0].name | string | `"SMITHDB_QUERY__EXECUTION_CONFIG__QUERY_TIMEOUT"` |  |
-| smithdb.query.deployment.extraEnv[0].value | string | `"30s"` |  |
-| smithdb.query.deployment.extraEnv[1].name | string | `"SMITHDB_QUERY__VORTEX_CACHE__SEGMENT_CACHE__DISK_PATH"` |  |
-| smithdb.query.deployment.extraEnv[1].value | string | `"/data/segment"` |  |
-| smithdb.query.deployment.extraEnv[2].name | string | `"SMITHDB_QUERY__VORTEX_CACHE__FILTER_CACHE__DISK_PATH"` |  |
-| smithdb.query.deployment.extraEnv[2].value | string | `"/data/filter"` |  |
+| smithdb.query.deployment.extraEnv[0].name | string | `"SMITHDB_QUERY__VORTEX_CACHE__SEGMENT_CACHE__DISK_PATH"` |  |
+| smithdb.query.deployment.extraEnv[0].value | string | `"/data/segment"` |  |
+| smithdb.query.deployment.extraEnv[1].name | string | `"SMITHDB_QUERY__VORTEX_CACHE__FILTER_CACHE__DISK_PATH"` |  |
+| smithdb.query.deployment.extraEnv[1].value | string | `"/data/filter"` |  |
 | smithdb.query.deployment.initContainers | list | `[]` |  |
 | smithdb.query.deployment.labels | object | `{}` |  |
 | smithdb.query.deployment.nodeSelector | object | `{}` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -891,7 +891,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.clusterManager.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.clusterManager.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.clusterManager.deployment.replicas | int | `1` |  |
-| smithdb.clusterManager.deployment.resources | object | `{}` |  |
+| smithdb.clusterManager.deployment.resources | object | `{"limits":{"cpu":"250m","memory":"256Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | Small-tier baseline. Override for larger deployments. |
 | smithdb.clusterManager.deployment.securityContext | object | `{}` |  |
 | smithdb.clusterManager.deployment.sidecars | list | `[]` |  |
 | smithdb.clusterManager.deployment.tolerations | list | `[]` |  |
@@ -946,7 +946,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.compaction.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.compaction.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.compaction.deployment.replicas | int | `1` |  |
-| smithdb.compaction.deployment.resources | object | `{}` |  |
+| smithdb.compaction.deployment.resources | object | `{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}` | Small-tier baseline. Override for larger deployments. |
 | smithdb.compaction.deployment.securityContext | object | `{}` |  |
 | smithdb.compaction.deployment.sidecars | list | `[]` |  |
 | smithdb.compaction.deployment.tolerations | list | `[]` |  |
@@ -988,15 +988,17 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.compactionWorker.deployment.probes.startupProbe.httpGet.port | string | `"http"` |  |
 | smithdb.compactionWorker.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.compactionWorker.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
-| smithdb.compactionWorker.deployment.replicas | int | `1` |  |
-| smithdb.compactionWorker.deployment.resources | object | `{}` |  |
+| smithdb.compactionWorker.deployment.replicas | int | `2` |  |
+| smithdb.compactionWorker.deployment.resources | object | `{"limits":{"cpu":"4","ephemeral-storage":"100Gi","memory":"8Gi"},"requests":{"cpu":"4","ephemeral-storage":"100Gi","memory":"8Gi"}}` | Small-tier baseline. Override for larger deployments. |
 | smithdb.compactionWorker.deployment.securityContext | object | `{}` |  |
 | smithdb.compactionWorker.deployment.sidecars | list | `[]` |  |
 | smithdb.compactionWorker.deployment.terminationGracePeriodSeconds | int | `120` |  |
 | smithdb.compactionWorker.deployment.tolerations | list | `[]` |  |
 | smithdb.compactionWorker.deployment.topologySpreadConstraints | list | `[]` |  |
-| smithdb.compactionWorker.deployment.volumeMounts | list | `[]` |  |
-| smithdb.compactionWorker.deployment.volumes | list | `[]` |  |
+| smithdb.compactionWorker.deployment.volumeMounts[0].mountPath | string | `"/data"` |  |
+| smithdb.compactionWorker.deployment.volumeMounts[0].name | string | `"local-ssd-storage"` |  |
+| smithdb.compactionWorker.deployment.volumes[0].emptyDir.sizeLimit | string | `"100Gi"` |  |
+| smithdb.compactionWorker.deployment.volumes[0].name | string | `"local-ssd-storage"` |  |
 | smithdb.compactionWorker.maxConcurrentJobs | string | `""` | Maximum concurrent jobs per compaction worker. Empty uses the SmithDB default. |
 | smithdb.compactionWorker.name | string | `"compaction-worker"` |  |
 | smithdb.compactionWorker.pdb.annotations | object | `{}` |  |
@@ -1028,7 +1030,10 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.ingestion.deployment.command[0] | string | `"./smithdb"` |  |
 | smithdb.ingestion.deployment.command[1] | string | `"ingestion"` |  |
 | smithdb.ingestion.deployment.extraContainerConfig | object | `{}` |  |
-| smithdb.ingestion.deployment.extraEnv | list | `[]` |  |
+| smithdb.ingestion.deployment.extraEnv[0].name | string | `"SMITHDB_INGESTION__PROCESSOR__FLUSH__DATA_DIR"` |  |
+| smithdb.ingestion.deployment.extraEnv[0].value | string | `"/data"` |  |
+| smithdb.ingestion.deployment.extraEnv[1].name | string | `"SMITHDB_INGESTION__RUN_SEGMENT_MANAGER__FLUSH__DATA_DIR"` |  |
+| smithdb.ingestion.deployment.extraEnv[1].value | string | `"/data"` |  |
 | smithdb.ingestion.deployment.initContainers | list | `[]` |  |
 | smithdb.ingestion.deployment.labels | object | `{}` |  |
 | smithdb.ingestion.deployment.nodeSelector | object | `{}` |  |
@@ -1049,7 +1054,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.ingestion.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.ingestion.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.ingestion.deployment.replicas | int | `1` |  |
-| smithdb.ingestion.deployment.resources | object | `{}` |  |
+| smithdb.ingestion.deployment.resources | object | `{"limits":{"cpu":"4","ephemeral-storage":"100Gi","memory":"8Gi"},"requests":{"cpu":"4","ephemeral-storage":"100Gi","memory":"8Gi"}}` | Small-tier baseline. Override for larger deployments. |
 | smithdb.ingestion.deployment.securityContext | object | `{}` |  |
 | smithdb.ingestion.deployment.sidecars | list | `[]` |  |
 | smithdb.ingestion.deployment.strategy.rollingUpdate.maxSurge | int | `1` |  |
@@ -1058,8 +1063,10 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.ingestion.deployment.terminationGracePeriodSeconds | int | `300` |  |
 | smithdb.ingestion.deployment.tolerations | list | `[]` |  |
 | smithdb.ingestion.deployment.topologySpreadConstraints | list | `[]` |  |
-| smithdb.ingestion.deployment.volumeMounts | list | `[]` |  |
-| smithdb.ingestion.deployment.volumes | list | `[]` |  |
+| smithdb.ingestion.deployment.volumeMounts[0].mountPath | string | `"/data"` |  |
+| smithdb.ingestion.deployment.volumeMounts[0].name | string | `"local-ssd-storage"` |  |
+| smithdb.ingestion.deployment.volumes[0].emptyDir.sizeLimit | string | `"100Gi"` |  |
+| smithdb.ingestion.deployment.volumes[0].name | string | `"local-ssd-storage"` |  |
 | smithdb.ingestion.name | string | `"ingestion"` |  |
 | smithdb.ingestion.pdb.annotations | object | `{}` |  |
 | smithdb.ingestion.pdb.enabled | bool | `false` |  |
@@ -1095,7 +1102,12 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.query.deployment.command[0] | string | `"./smithdb"` |  |
 | smithdb.query.deployment.command[1] | string | `"query"` |  |
 | smithdb.query.deployment.extraContainerConfig | object | `{}` |  |
-| smithdb.query.deployment.extraEnv | list | `[]` |  |
+| smithdb.query.deployment.extraEnv[0].name | string | `"SMITHDB_QUERY__EXECUTION_CONFIG__QUERY_TIMEOUT"` |  |
+| smithdb.query.deployment.extraEnv[0].value | string | `"30s"` |  |
+| smithdb.query.deployment.extraEnv[1].name | string | `"SMITHDB_QUERY__VORTEX_CACHE__SEGMENT_CACHE__DISK_PATH"` |  |
+| smithdb.query.deployment.extraEnv[1].value | string | `"/data/segment"` |  |
+| smithdb.query.deployment.extraEnv[2].name | string | `"SMITHDB_QUERY__VORTEX_CACHE__FILTER_CACHE__DISK_PATH"` |  |
+| smithdb.query.deployment.extraEnv[2].value | string | `"/data/filter"` |  |
 | smithdb.query.deployment.initContainers | list | `[]` |  |
 | smithdb.query.deployment.labels | object | `{}` |  |
 | smithdb.query.deployment.nodeSelector | object | `{}` |  |
@@ -1116,7 +1128,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.query.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.query.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.query.deployment.replicas | int | `1` |  |
-| smithdb.query.deployment.resources | object | `{}` |  |
+| smithdb.query.deployment.resources | object | `{"limits":{"cpu":"4","ephemeral-storage":"200Gi","memory":"8Gi"},"requests":{"cpu":"4","ephemeral-storage":"200Gi","memory":"8Gi"}}` | Small-tier baseline. Override for larger deployments. |
 | smithdb.query.deployment.securityContext | object | `{}` |  |
 | smithdb.query.deployment.sidecars | list | `[]` |  |
 | smithdb.query.deployment.strategy.rollingUpdate.maxSurge | int | `1` |  |
@@ -1124,8 +1136,10 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.query.deployment.strategy.type | string | `"RollingUpdate"` |  |
 | smithdb.query.deployment.tolerations | list | `[]` |  |
 | smithdb.query.deployment.topologySpreadConstraints | list | `[]` |  |
-| smithdb.query.deployment.volumeMounts | list | `[]` |  |
-| smithdb.query.deployment.volumes | list | `[]` |  |
+| smithdb.query.deployment.volumeMounts[0].mountPath | string | `"/data"` |  |
+| smithdb.query.deployment.volumeMounts[0].name | string | `"local-ssd-storage"` |  |
+| smithdb.query.deployment.volumes[0].emptyDir.sizeLimit | string | `"200Gi"` |  |
+| smithdb.query.deployment.volumes[0].name | string | `"local-ssd-storage"` |  |
 | smithdb.query.name | string | `"query"` |  |
 | smithdb.query.pdb.annotations | object | `{}` |  |
 | smithdb.query.pdb.enabled | bool | `false` |  |

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -572,15 +572,14 @@ SmithDB cluster-manager client env vars. Args: root, service.
 {{/*
 SmithDB cluster-manager per-service replica / replication env vars.
 
-Emits min/max replica bounds for query, ingestion, and compaction. When
+Emits min/max replica bounds for query and ingestion. When
 maxReplicas is empty, defaults to that service's deployment.replicas so
-horizontally scaled pods can own the same slice. Optional replication
-thresholds are omitted when empty (SmithDB defaults them to None, which
-disables replication suppression).
+horizontally scaled pods can own the same slice. Replication thresholds
+are emitted when set (chart default is 0).
 */}}
 {{- define "langsmith.smithdb.clusterManagerServicesEnv" -}}
 {{- $root := . -}}
-{{- $services := list (dict "key" "query" "env" "QUERY" "component" "query") (dict "key" "ingestion" "env" "INGESTION" "component" "ingestion") (dict "key" "compaction" "env" "COMPACTION" "component" "compaction") -}}
+{{- $services := list (dict "key" "query" "env" "QUERY" "component" "query") (dict "key" "ingestion" "env" "INGESTION" "component" "ingestion") -}}
 {{- range $svc := $services }}
 {{- $cfg := index $root.Values.smithdb.clusterManager.services $svc.key -}}
 {{- $component := index $root.Values.smithdb $svc.component -}}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -570,6 +570,39 @@ SmithDB cluster-manager client env vars. Args: root, service.
 {{- end }}
 
 {{/*
+SmithDB cluster-manager per-service replica / replication env vars.
+
+Emits min/max replica bounds for query, ingestion, and compaction. When
+maxReplicas is empty, defaults to that service's deployment.replicas so
+horizontally scaled pods can own the same slice. Optional replication
+thresholds are omitted when empty (SmithDB defaults them to None, which
+disables replication suppression).
+*/}}
+{{- define "langsmith.smithdb.clusterManagerServicesEnv" -}}
+{{- $root := . -}}
+{{- $services := list (dict "key" "query" "env" "QUERY" "component" "query") (dict "key" "ingestion" "env" "INGESTION" "component" "ingestion") (dict "key" "compaction" "env" "COMPACTION" "component" "compaction") -}}
+{{- range $svc := $services }}
+{{- $cfg := index $root.Values.smithdb.clusterManager.services $svc.key -}}
+{{- $component := index $root.Values.smithdb $svc.component -}}
+{{- $minReplicas := default 1 $cfg.minReplicas -}}
+{{- $maxReplicas := default $component.deployment.replicas $cfg.maxReplicas -}}
+{{- $prefix := printf "SMITHDB_CLUSTERMANAGER__SERVICES__%s" $svc.env }}
+- name: {{ $prefix }}__MIN_REPLICAS
+  value: {{ $minReplicas | quote }}
+- name: {{ $prefix }}__MAX_REPLICAS
+  value: {{ $maxReplicas | quote }}
+{{- if ne (toString $cfg.replicationThreshold) "" }}
+- name: {{ $prefix }}__REPLICATION_THRESHOLD
+  value: {{ $cfg.replicationThreshold | quote }}
+{{- end }}
+{{- if ne (toString $cfg.sliceReplicationThreshold) "" }}
+- name: {{ $prefix }}__SLICE_REPLICATION_THRESHOLD
+  value: {{ $cfg.sliceReplicationThreshold | quote }}
+{{- end }}
+{{ end -}}
+{{- end }}
+
+{{/*
 SmithDB component env vars.
 Args: root, service, displayName.
 */}}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -570,31 +570,6 @@ SmithDB cluster-manager client env vars. Args: root, service.
 {{- end }}
 
 {{/*
-SmithDB cluster-manager per-service ownership bounds.
-
-MAX_REPLICAS (max pods that may own a slice) is derived directly from each
-service's deployment.replicas so it cannot drift from the actual pod count.
-MIN_REPLICAS is fixed at 1, and replication thresholds are fixed at 0 so slices
-distribute across all owning nodes.
-*/}}
-{{- define "langsmith.smithdb.clusterManagerServicesEnv" -}}
-{{- $root := . -}}
-{{- $services := list (dict "env" "QUERY" "component" "query") (dict "env" "INGESTION" "component" "ingestion") -}}
-{{- range $svc := $services }}
-{{- $component := index $root.Values.smithdb $svc.component -}}
-{{- $prefix := printf "SMITHDB_CLUSTERMANAGER__SERVICES__%s" $svc.env }}
-- name: {{ $prefix }}__MIN_REPLICAS
-  value: "1"
-- name: {{ $prefix }}__MAX_REPLICAS
-  value: {{ $component.deployment.replicas | quote }}
-- name: {{ $prefix }}__REPLICATION_THRESHOLD
-  value: "0"
-- name: {{ $prefix }}__SLICE_REPLICATION_THRESHOLD
-  value: "0"
-{{ end -}}
-{{- end }}
-
-{{/*
 SmithDB component env vars.
 Args: root, service, displayName.
 */}}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -570,34 +570,27 @@ SmithDB cluster-manager client env vars. Args: root, service.
 {{- end }}
 
 {{/*
-SmithDB cluster-manager per-service replica / replication env vars.
+SmithDB cluster-manager per-service ownership bounds.
 
-Emits min/max replica bounds for query and ingestion. When
-maxReplicas is empty, defaults to that service's deployment.replicas so
-horizontally scaled pods can own the same slice. Replication thresholds
-are emitted when set (chart default is 0).
+MAX_REPLICAS (max pods that may own a slice) is derived directly from each
+service's deployment.replicas so it cannot drift from the actual pod count.
+MIN_REPLICAS is fixed at 1, and replication thresholds are fixed at 0 so slices
+distribute across all owning nodes.
 */}}
 {{- define "langsmith.smithdb.clusterManagerServicesEnv" -}}
 {{- $root := . -}}
-{{- $services := list (dict "key" "query" "env" "QUERY" "component" "query") (dict "key" "ingestion" "env" "INGESTION" "component" "ingestion") -}}
+{{- $services := list (dict "env" "QUERY" "component" "query") (dict "env" "INGESTION" "component" "ingestion") -}}
 {{- range $svc := $services }}
-{{- $cfg := index $root.Values.smithdb.clusterManager.services $svc.key -}}
 {{- $component := index $root.Values.smithdb $svc.component -}}
-{{- $minReplicas := default 1 $cfg.minReplicas -}}
-{{- $maxReplicas := default $component.deployment.replicas $cfg.maxReplicas -}}
 {{- $prefix := printf "SMITHDB_CLUSTERMANAGER__SERVICES__%s" $svc.env }}
 - name: {{ $prefix }}__MIN_REPLICAS
-  value: {{ $minReplicas | quote }}
+  value: "1"
 - name: {{ $prefix }}__MAX_REPLICAS
-  value: {{ $maxReplicas | quote }}
-{{- if ne (toString $cfg.replicationThreshold) "" }}
+  value: {{ $component.deployment.replicas | quote }}
 - name: {{ $prefix }}__REPLICATION_THRESHOLD
-  value: {{ $cfg.replicationThreshold | quote }}
-{{- end }}
-{{- if ne (toString $cfg.sliceReplicationThreshold) "" }}
+  value: "0"
 - name: {{ $prefix }}__SLICE_REPLICATION_THRESHOLD
-  value: {{ $cfg.sliceReplicationThreshold | quote }}
-{{- end }}
+  value: "0"
 {{ end -}}
 {{- end }}
 

--- a/charts/langsmith/templates/smithdb/cluster-manager-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/cluster-manager-deployment.yaml
@@ -61,7 +61,28 @@ spec:
             - name: SMITHDB_CLUSTERMANAGER__GRPC_PORT
               value: {{ .Values.smithdb.clusterManager.containerGrpcPort | quote }}
             {{- include "langsmith.smithdb.baseEnv" (dict "root" . "service" "CLUSTERMANAGER" "displayName" "smithdb-clustermanager") | nindent 12 }}
-            {{- include "langsmith.smithdb.clusterManagerServicesEnv" . | nindent 12 }}
+            {{/*
+            Per-service cluster-manager ownership bounds. MAX_REPLICAS is derived
+            from each service's replica settings so it cannot drift from the actual
+            pod count: autoscaling.maxReplicas when that service's HPA is enabled,
+            otherwise deployment.replicas. MIN_REPLICAS is fixed at 1, and
+            replication thresholds are fixed at 0 so slices distribute across all
+            owning nodes.
+            */}}
+            {{- range $svc := list (dict "env" "QUERY" "component" "query") (dict "env" "INGESTION" "component" "ingestion") }}
+            {{- $component := index $.Values.smithdb $svc.component }}
+            {{- $hpaEnabled := dig "autoscaling" "enabled" false $component }}
+            {{- $maxReplicas := ternary (dig "autoscaling" "maxReplicas" $component.deployment.replicas $component) $component.deployment.replicas $hpaEnabled }}
+            {{- $prefix := printf "SMITHDB_CLUSTERMANAGER__SERVICES__%s" $svc.env }}
+            - name: {{ $prefix }}__MIN_REPLICAS
+              value: "1"
+            - name: {{ $prefix }}__MAX_REPLICAS
+              value: {{ $maxReplicas | quote }}
+            - name: {{ $prefix }}__REPLICATION_THRESHOLD
+              value: "0"
+            - name: {{ $prefix }}__SLICE_REPLICATION_THRESHOLD
+              value: "0"
+            {{- end }}
             {{- with $envVars }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/langsmith/templates/smithdb/cluster-manager-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/cluster-manager-deployment.yaml
@@ -61,6 +61,7 @@ spec:
             - name: SMITHDB_CLUSTERMANAGER__GRPC_PORT
               value: {{ .Values.smithdb.clusterManager.containerGrpcPort | quote }}
             {{- include "langsmith.smithdb.baseEnv" (dict "root" . "service" "CLUSTERMANAGER" "displayName" "smithdb-clustermanager") | nindent 12 }}
+            {{- include "langsmith.smithdb.clusterManagerServicesEnv" . | nindent 12 }}
             {{- with $envVars }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -76,17 +76,6 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.ephemeral-storage
           value: "200Gi"
-      - contains:
-          path: spec.template.spec.volumes
-          content:
-            name: local-ssd-storage
-            emptyDir:
-              sizeLimit: 200Gi
-      - contains:
-          path: spec.template.spec.containers[0].volumeMounts
-          content:
-            name: local-ssd-storage
-            mountPath: /data
 
   - it: should size the SmithDB query disk cache from its ephemeral storage limit
     values:

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -311,38 +311,6 @@ tests:
           content:
             name: SMITHDB_CLUSTERMANAGER__SERVICES__COMPACTION__MAX_REPLICAS
 
-  - it: should allow overriding cluster-manager service replica and replication settings
-    values:
-      - ./values/smithdb-enabled.yaml
-    set:
-      smithdb.query.deployment.replicas: 4
-      smithdb.clusterManager.services.query.minReplicas: 2
-      smithdb.clusterManager.services.query.maxReplicas: 3
-      smithdb.clusterManager.services.query.replicationThreshold: 0
-      smithdb.clusterManager.services.query.sliceReplicationThreshold: 0.5
-    template: smithdb/cluster-manager-deployment.yaml
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__MIN_REPLICAS
-            value: "2"
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__MAX_REPLICAS
-            value: "3"
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__REPLICATION_THRESHOLD
-            value: "0"
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__SLICE_REPLICATION_THRESHOLD
-            value: "0.5"
-
   - it: should default smithdb compaction-worker to two replicas
     values:
       - ./values/smithdb-enabled.yaml

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -242,6 +242,82 @@ tests:
             name: SMITHDB_CLUSTERMANAGER__LOGGING__FORMAT
             value: console
 
+  - it: should default cluster-manager service max replicas to deployment replicas
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.query.deployment.replicas: 4
+      smithdb.ingestion.deployment.replicas: 2
+      smithdb.compaction.deployment.replicas: 3
+    template: smithdb/cluster-manager-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__MIN_REPLICAS
+            value: "1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__MAX_REPLICAS
+            value: "4"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_CLUSTERMANAGER__SERVICES__INGESTION__MIN_REPLICAS
+            value: "1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_CLUSTERMANAGER__SERVICES__INGESTION__MAX_REPLICAS
+            value: "2"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_CLUSTERMANAGER__SERVICES__COMPACTION__MIN_REPLICAS
+            value: "1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_CLUSTERMANAGER__SERVICES__COMPACTION__MAX_REPLICAS
+            value: "3"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__REPLICATION_THRESHOLD
+
+  - it: should allow overriding cluster-manager service replica and replication settings
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.query.deployment.replicas: 4
+      smithdb.clusterManager.services.query.minReplicas: 2
+      smithdb.clusterManager.services.query.maxReplicas: 3
+      smithdb.clusterManager.services.query.replicationThreshold: 0
+      smithdb.clusterManager.services.query.sliceReplicationThreshold: 0.5
+    template: smithdb/cluster-manager-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__MIN_REPLICAS
+            value: "2"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__MAX_REPLICAS
+            value: "3"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__REPLICATION_THRESHOLD
+            value: "0"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__SLICE_REPLICATION_THRESHOLD
+            value: "0.5"
+
   - it: should expose compaction worker concurrency as a value
     values:
       - ./values/smithdb-enabled.yaml

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -307,10 +307,16 @@ tests:
           content:
             name: SMITHDB_CLUSTERMANAGER__SERVICES__COMPACTION__MAX_REPLICAS
             value: "3"
-      - notContains:
+      - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__REPLICATION_THRESHOLD
+            value: "0"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__SLICE_REPLICATION_THRESHOLD
+            value: "0"
 
   - it: should allow overriding cluster-manager service replica and replication settings
     values:

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -274,7 +274,6 @@ tests:
     set:
       smithdb.query.deployment.replicas: 4
       smithdb.ingestion.deployment.replicas: 2
-      smithdb.compaction.deployment.replicas: 3
     template: smithdb/cluster-manager-deployment.yaml
     asserts:
       - contains:
@@ -300,16 +299,6 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: SMITHDB_CLUSTERMANAGER__SERVICES__COMPACTION__MIN_REPLICAS
-            value: "1"
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: SMITHDB_CLUSTERMANAGER__SERVICES__COMPACTION__MAX_REPLICAS
-            value: "3"
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
             name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__REPLICATION_THRESHOLD
             value: "0"
       - contains:
@@ -317,6 +306,10 @@ tests:
           content:
             name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__SLICE_REPLICATION_THRESHOLD
             value: "0"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_CLUSTERMANAGER__SERVICES__COMPACTION__MAX_REPLICAS
 
   - it: should allow overriding cluster-manager service replica and replication settings
     values:

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -53,14 +53,45 @@ tests:
           content:
             name: RUST_LOG
             value: INFO,vortex=WARN
-      - notContains:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_QUERY__EXECUTION_CONFIG__QUERY_TIMEOUT
+            value: "30s"
+      - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: SMITHDB_QUERY__VORTEX_CACHE__DISK__LIMIT
-      - notContains:
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.ephemeral-storage
+      - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: SMITHDB_QUERY__VORTEX_CACHE__MEMORY__LIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: "4"
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: "8Gi"
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.ephemeral-storage
+          value: "200Gi"
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: local-ssd-storage
+            emptyDir:
+              sizeLimit: 200Gi
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: local-ssd-storage
+            mountPath: /data
 
   - it: should size the SmithDB query disk cache from its ephemeral storage limit
     values:
@@ -317,6 +348,21 @@ tests:
           content:
             name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__SLICE_REPLICATION_THRESHOLD
             value: "0.5"
+
+  - it: should default smithdb compaction-worker to two replicas
+    values:
+      - ./values/smithdb-enabled.yaml
+    template: smithdb/compaction-worker-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: "4"
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.ephemeral-storage
+          value: "100Gi"
 
   - it: should expose compaction worker concurrency as a value
     values:

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -56,11 +56,6 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: SMITHDB_QUERY__EXECUTION_CONFIG__QUERY_TIMEOUT
-            value: "30s"
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
             name: SMITHDB_QUERY__VORTEX_CACHE__DISK__LIMIT
             valueFrom:
               resourceFieldRef:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1298,7 +1298,16 @@ smithdb:
       annotations: {}
       podSecurityContext: {}
       securityContext: {}
-      resources: {}
+      # -- Small-tier baseline. Override for larger deployments.
+      resources:
+        requests:
+          cpu: "4"
+          memory: "8Gi"
+          ephemeral-storage: "200Gi"
+        limits:
+          cpu: "4"
+          memory: "8Gi"
+          ephemeral-storage: "200Gi"
       probes:
         startupProbe:
           httpGet:
@@ -1324,15 +1333,26 @@ smithdb:
       command:
         - "./smithdb"
         - "query"
-      extraEnv: []
+      extraEnv:
+        - name: SMITHDB_QUERY__EXECUTION_CONFIG__QUERY_TIMEOUT
+          value: "30s"
+        - name: SMITHDB_QUERY__VORTEX_CACHE__SEGMENT_CACHE__DISK_PATH
+          value: "/data/segment"
+        - name: SMITHDB_QUERY__VORTEX_CACHE__FILTER_CACHE__DISK_PATH
+          value: "/data/filter"
       extraContainerConfig: {}
       sidecars: []
       nodeSelector: {}
       tolerations: []
       affinity: {}
       topologySpreadConstraints: []
-      volumes: []
-      volumeMounts: []
+      volumes:
+        - name: local-ssd-storage
+          emptyDir:
+            sizeLimit: 200Gi
+      volumeMounts:
+        - name: local-ssd-storage
+          mountPath: /data
       initContainers: []
     service:
       port: 8080
@@ -1359,7 +1379,16 @@ smithdb:
       annotations: {}
       podSecurityContext: {}
       securityContext: {}
-      resources: {}
+      # -- Small-tier baseline. Override for larger deployments.
+      resources:
+        requests:
+          cpu: "4"
+          memory: "8Gi"
+          ephemeral-storage: "100Gi"
+        limits:
+          cpu: "4"
+          memory: "8Gi"
+          ephemeral-storage: "100Gi"
       probes:
         startupProbe:
           httpGet:
@@ -1386,15 +1415,24 @@ smithdb:
         - "./smithdb"
         - "ingestion"
       terminationGracePeriodSeconds: 300
-      extraEnv: []
+      extraEnv:
+        - name: SMITHDB_INGESTION__PROCESSOR__FLUSH__DATA_DIR
+          value: "/data"
+        - name: SMITHDB_INGESTION__RUN_SEGMENT_MANAGER__FLUSH__DATA_DIR
+          value: "/data"
       extraContainerConfig: {}
       sidecars: []
       nodeSelector: {}
       tolerations: []
       affinity: {}
       topologySpreadConstraints: []
-      volumes: []
-      volumeMounts: []
+      volumes:
+        - name: local-ssd-storage
+          emptyDir:
+            sizeLimit: 100Gi
+      volumeMounts:
+        - name: local-ssd-storage
+          mountPath: /data
       initContainers: []
     service:
       port: 8082
@@ -1416,7 +1454,14 @@ smithdb:
       annotations: {}
       podSecurityContext: {}
       securityContext: {}
-      resources: {}
+      # -- Small-tier baseline. Override for larger deployments.
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "1Gi"
+        limits:
+          cpu: "500m"
+          memory: "1Gi"
       probes:
         startupProbe:
           httpGet:
@@ -1469,13 +1514,22 @@ smithdb:
     # -- Maximum concurrent jobs per compaction worker. Empty uses the SmithDB default.
     maxConcurrentJobs: ""
     deployment:
-      replicas: 1
+      replicas: 2
       labels: {}
       annotations: {}
       podSecurityContext: {}
       securityContext: {}
       terminationGracePeriodSeconds: 120
-      resources: {}
+      # -- Small-tier baseline. Override for larger deployments.
+      resources:
+        requests:
+          cpu: "4"
+          memory: "8Gi"
+          ephemeral-storage: "100Gi"
+        limits:
+          cpu: "4"
+          memory: "8Gi"
+          ephemeral-storage: "100Gi"
       probes:
         startupProbe:
           httpGet:
@@ -1509,8 +1563,13 @@ smithdb:
       tolerations: []
       affinity: {}
       topologySpreadConstraints: []
-      volumes: []
-      volumeMounts: []
+      volumes:
+        - name: local-ssd-storage
+          emptyDir:
+            sizeLimit: 100Gi
+      volumeMounts:
+        - name: local-ssd-storage
+          mountPath: /data
       initContainers: []
     pdb:
       enabled: false
@@ -1560,7 +1619,14 @@ smithdb:
       annotations: {}
       podSecurityContext: {}
       securityContext: {}
-      resources: {}
+      # -- Small-tier baseline. Override for larger deployments.
+      resources:
+        requests:
+          cpu: "250m"
+          memory: "256Mi"
+        limits:
+          cpu: "250m"
+          memory: "256Mi"
       probes:
         startupProbe:
           httpGet:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1298,7 +1298,6 @@ smithdb:
       annotations: {}
       podSecurityContext: {}
       securityContext: {}
-      # -- Starting baseline.
       resources:
         requests:
           cpu: "4"
@@ -1377,7 +1376,6 @@ smithdb:
       annotations: {}
       podSecurityContext: {}
       securityContext: {}
-      # -- Starting baseline.
       resources:
         requests:
           cpu: "4"
@@ -1452,7 +1450,6 @@ smithdb:
       annotations: {}
       podSecurityContext: {}
       securityContext: {}
-      # -- Starting baseline.
       resources:
         requests:
           cpu: "500m"
@@ -1518,7 +1515,6 @@ smithdb:
       podSecurityContext: {}
       securityContext: {}
       terminationGracePeriodSeconds: 120
-      # -- Starting baseline.
       resources:
         requests:
           cpu: "4"
@@ -1596,7 +1592,6 @@ smithdb:
       annotations: {}
       podSecurityContext: {}
       securityContext: {}
-      # -- Starting baseline.
       resources:
         requests:
           cpu: "250m"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1579,37 +1579,21 @@ smithdb:
     name: "cluster-manager"
     containerPort: 8090
     containerGrpcPort: 8091
-    # -- Per-service slice replica bounds for the cluster manager.
-    # maxReplicas defaults to that service's deployment.replicas when empty.
-    # replicationThreshold / sliceReplicationThreshold default to SmithDB None
-    # (replication suppression disabled) when empty; set 0 to force distribution.
     services:
       query:
-        # -- Minimum number of query pods that may own a slice.
         minReplicas: 1
-        # -- Maximum number of query pods that may own a slice. Empty uses query.deployment.replicas.
         maxReplicas: ""
-        # -- Absolute load threshold above which AddRedundant is allowed. Empty = SmithDB default (None).
         replicationThreshold: ""
-        # -- Per-slice load threshold below which AddRedundant is suppressed. Empty = SmithDB default (None).
         sliceReplicationThreshold: ""
       ingestion:
-        # -- Minimum number of ingestion pods that may own a slice.
         minReplicas: 1
-        # -- Maximum number of ingestion pods that may own a slice. Empty uses ingestion.deployment.replicas.
         maxReplicas: ""
-        # -- Absolute load threshold above which AddRedundant is allowed. Empty = SmithDB default (None).
         replicationThreshold: ""
-        # -- Per-slice load threshold below which AddRedundant is suppressed. Empty = SmithDB default (None).
         sliceReplicationThreshold: ""
       compaction:
-        # -- Minimum number of compaction pods that may own a slice.
         minReplicas: 1
-        # -- Maximum number of compaction pods that may own a slice. Empty uses compaction.deployment.replicas.
         maxReplicas: ""
-        # -- Absolute load threshold above which AddRedundant is allowed. Empty = SmithDB default (None).
         replicationThreshold: ""
-        # -- Per-slice load threshold below which AddRedundant is suppressed. Empty = SmithDB default (None).
         sliceReplicationThreshold: ""
     deployment:
       replicas: 1

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1575,17 +1575,6 @@ smithdb:
     name: "cluster-manager"
     containerPort: 8090
     containerGrpcPort: 8091
-    services:
-      query:
-        minReplicas: 1
-        maxReplicas: ""
-        replicationThreshold: 0
-        sliceReplicationThreshold: 0
-      ingestion:
-        minReplicas: 1
-        maxReplicas: ""
-        replicationThreshold: 0
-        sliceReplicationThreshold: 0
     deployment:
       replicas: 1
       labels: {}

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1332,24 +1332,15 @@ smithdb:
       command:
         - "./smithdb"
         - "query"
-      extraEnv:
-        - name: SMITHDB_QUERY__VORTEX_CACHE__SEGMENT_CACHE__DISK_PATH
-          value: "/data/segment"
-        - name: SMITHDB_QUERY__VORTEX_CACHE__FILTER_CACHE__DISK_PATH
-          value: "/data/filter"
+      extraEnv: []
       extraContainerConfig: {}
       sidecars: []
       nodeSelector: {}
       tolerations: []
       affinity: {}
       topologySpreadConstraints: []
-      volumes:
-        - name: local-ssd-storage
-          emptyDir:
-            sizeLimit: 200Gi
-      volumeMounts:
-        - name: local-ssd-storage
-          mountPath: /data
+      volumes: []
+      volumeMounts: []
       initContainers: []
     service:
       port: 8080

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1298,7 +1298,7 @@ smithdb:
       annotations: {}
       podSecurityContext: {}
       securityContext: {}
-      # -- Small-tier baseline. Override for larger deployments.
+      # -- Starting baseline.
       resources:
         requests:
           cpu: "4"
@@ -1377,7 +1377,7 @@ smithdb:
       annotations: {}
       podSecurityContext: {}
       securityContext: {}
-      # -- Small-tier baseline. Override for larger deployments.
+      # -- Starting baseline.
       resources:
         requests:
           cpu: "4"
@@ -1452,7 +1452,7 @@ smithdb:
       annotations: {}
       podSecurityContext: {}
       securityContext: {}
-      # -- Small-tier baseline. Override for larger deployments.
+      # -- Starting baseline.
       resources:
         requests:
           cpu: "500m"
@@ -1518,7 +1518,7 @@ smithdb:
       podSecurityContext: {}
       securityContext: {}
       terminationGracePeriodSeconds: 120
-      # -- Small-tier baseline. Override for larger deployments.
+      # -- Starting baseline.
       resources:
         requests:
           cpu: "4"
@@ -1596,7 +1596,7 @@ smithdb:
       annotations: {}
       podSecurityContext: {}
       securityContext: {}
-      # -- Small-tier baseline. Override for larger deployments.
+      # -- Starting baseline.
       resources:
         requests:
           cpu: "250m"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1334,8 +1334,6 @@ smithdb:
         - "./smithdb"
         - "query"
       extraEnv:
-        - name: SMITHDB_QUERY__EXECUTION_CONFIG__QUERY_TIMEOUT
-          value: "30s"
         - name: SMITHDB_QUERY__VORTEX_CACHE__SEGMENT_CACHE__DISK_PATH
           value: "/data/segment"
         - name: SMITHDB_QUERY__VORTEX_CACHE__FILTER_CACHE__DISK_PATH

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1583,18 +1583,18 @@ smithdb:
       query:
         minReplicas: 1
         maxReplicas: ""
-        replicationThreshold: ""
-        sliceReplicationThreshold: ""
+        replicationThreshold: 0
+        sliceReplicationThreshold: 0
       ingestion:
         minReplicas: 1
         maxReplicas: ""
-        replicationThreshold: ""
-        sliceReplicationThreshold: ""
+        replicationThreshold: 0
+        sliceReplicationThreshold: 0
       compaction:
         minReplicas: 1
         maxReplicas: ""
-        replicationThreshold: ""
-        sliceReplicationThreshold: ""
+        replicationThreshold: 0
+        sliceReplicationThreshold: 0
     deployment:
       replicas: 1
       labels: {}

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1522,6 +1522,38 @@ smithdb:
     name: "cluster-manager"
     containerPort: 8090
     containerGrpcPort: 8091
+    # -- Per-service slice replica bounds for the cluster manager.
+    # maxReplicas defaults to that service's deployment.replicas when empty.
+    # replicationThreshold / sliceReplicationThreshold default to SmithDB None
+    # (replication suppression disabled) when empty; set 0 to force distribution.
+    services:
+      query:
+        # -- Minimum number of query pods that may own a slice.
+        minReplicas: 1
+        # -- Maximum number of query pods that may own a slice. Empty uses query.deployment.replicas.
+        maxReplicas: ""
+        # -- Absolute load threshold above which AddRedundant is allowed. Empty = SmithDB default (None).
+        replicationThreshold: ""
+        # -- Per-slice load threshold below which AddRedundant is suppressed. Empty = SmithDB default (None).
+        sliceReplicationThreshold: ""
+      ingestion:
+        # -- Minimum number of ingestion pods that may own a slice.
+        minReplicas: 1
+        # -- Maximum number of ingestion pods that may own a slice. Empty uses ingestion.deployment.replicas.
+        maxReplicas: ""
+        # -- Absolute load threshold above which AddRedundant is allowed. Empty = SmithDB default (None).
+        replicationThreshold: ""
+        # -- Per-slice load threshold below which AddRedundant is suppressed. Empty = SmithDB default (None).
+        sliceReplicationThreshold: ""
+      compaction:
+        # -- Minimum number of compaction pods that may own a slice.
+        minReplicas: 1
+        # -- Maximum number of compaction pods that may own a slice. Empty uses compaction.deployment.replicas.
+        maxReplicas: ""
+        # -- Absolute load threshold above which AddRedundant is allowed. Empty = SmithDB default (None).
+        replicationThreshold: ""
+        # -- Per-slice load threshold below which AddRedundant is suppressed. Empty = SmithDB default (None).
+        sliceReplicationThreshold: ""
     deployment:
       replicas: 1
       labels: {}

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1590,11 +1590,6 @@ smithdb:
         maxReplicas: ""
         replicationThreshold: 0
         sliceReplicationThreshold: 0
-      compaction:
-        minReplicas: 1
-        maxReplicas: ""
-        replicationThreshold: 0
-        sliceReplicationThreshold: 0
     deployment:
       replicas: 1
       labels: {}


### PR DESCRIPTION
New values under smithdb.clusterManager.services.{query,ingestion}:
- minReplicas (default 1)
- maxReplicas (helper to set max rep value)
- replicationThreshold (default 0)
-sliceReplicationThreshold (default 0)

Small-tier resource defaults
- disk path defaults 