### PR TITLE
feat(langsmith): add optional SmithDB CPU HPA

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -955,6 +955,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.compaction.service.annotations | object | `{}` |  |
 | smithdb.compaction.service.labels | object | `{}` |  |
 | smithdb.compaction.service.port | int | `8071` |  |
+| smithdb.compactionWorker.autoscaling | object | `{"enabled":false,"maxReplicas":10,"minReplicas":1,"scaleDownStabilizationWindowSeconds":300,"scalePodCount":1,"scaleUpStabilizationWindowSeconds":120,"targetCPUUtilizationPercentage":60}` | CPU-based HPA for smithdb-compaction-worker. When enabled, omit deployment.replicas from the Deployment. Compaction is queue-driven; CPU is a coarse proxy (bursty jobs may not sustain utilization long enough to scale). Prefer tuning after observing backlog under your workload. |
 | smithdb.compactionWorker.containerPort | int | `9000` |  |
 | smithdb.compactionWorker.deployment.affinity | object | `{}` |  |
 | smithdb.compactionWorker.deployment.annotations | object | `{}` |  |
@@ -1022,6 +1023,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.config.observability.tracing.endpoint | string | `""` | OTLP gRPC collector endpoint for SmithDB traces/logs. |
 | smithdb.config.observability.tracing.extraResourceAttributes | object | `{}` | Extra OpenTelemetry resource attributes appended to SmithDB traces/logs. |
 | smithdb.enabled | bool | `false` | Deploy the in-chart SmithDB workloads. |
+| smithdb.ingestion.autoscaling | object | `{"enabled":false,"maxReplicas":5,"minReplicas":1,"scaleDownStabilizationWindowSeconds":900,"scalePodCount":1,"scaleUpStabilizationWindowSeconds":300,"targetCPUUtilizationPercentage":45}` | CPU-based HPA for smithdb-ingestion. When enabled, omit deployment.replicas from the Deployment; the cluster manager's ingestion MAX_REPLICAS is derived from autoscaling.maxReplicas. Default target is above typical single-pod baseline utilization so HPA can consolidate to minReplicas at idle. |
 | smithdb.ingestion.containerGrpcPort | int | `8082` |  |
 | smithdb.ingestion.containerPort | int | `8050` |  |
 | smithdb.ingestion.deployment.affinity | object | `{}` |  |
@@ -1177,6 +1179,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.migration.taskdb.postgres.statefulSet.volumeMounts | list | `[]` |  |
 | smithdb.migration.taskdb.postgres.statefulSet.volumes | list | `[]` |  |
 | smithdb.name | string | `"smithdb"` | Name segment used for SmithDB resources. |
+| smithdb.query.autoscaling | object | `{"enabled":false,"maxReplicas":5,"minReplicas":1,"scaleDownStabilizationWindowSeconds":900,"scalePodCount":1,"scaleUpStabilizationWindowSeconds":300,"targetCPUUtilizationPercentage":40}` | CPU-based HPA for smithdb-query. When enabled, omit deployment.replicas from the Deployment; the cluster manager's query MAX_REPLICAS is derived from autoscaling.maxReplicas. |
 | smithdb.query.containerGrpcPort | int | `8080` |  |
 | smithdb.query.containerPort | int | `8060` |  |
 | smithdb.query.deployment.affinity | object | `{}` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1023,7 +1023,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.config.observability.tracing.endpoint | string | `""` | OTLP gRPC collector endpoint for SmithDB traces/logs. |
 | smithdb.config.observability.tracing.extraResourceAttributes | object | `{}` | Extra OpenTelemetry resource attributes appended to SmithDB traces/logs. |
 | smithdb.enabled | bool | `false` | Deploy the in-chart SmithDB workloads. |
-| smithdb.ingestion.autoscaling | object | `{"enabled":false,"maxReplicas":10,"minReplicas":1,"scaleDownStabilizationWindowSeconds":900,"scalePodCount":1,"scaleUpStabilizationWindowSeconds":300,"targetCPUUtilizationPercentage":45}` |  |
+| smithdb.ingestion.autoscaling | object | `{"enabled":true,"maxReplicas":10,"minReplicas":1,"scaleDownStabilizationWindowSeconds":900,"scalePodCount":1,"scaleUpStabilizationWindowSeconds":300,"targetCPUUtilizationPercentage":45}` |  |
 | smithdb.ingestion.containerGrpcPort | int | `8082` |  |
 | smithdb.ingestion.containerPort | int | `8050` |  |
 | smithdb.ingestion.deployment.affinity | object | `{}` |  |
@@ -1179,7 +1179,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.migration.taskdb.postgres.statefulSet.volumeMounts | list | `[]` |  |
 | smithdb.migration.taskdb.postgres.statefulSet.volumes | list | `[]` |  |
 | smithdb.name | string | `"smithdb"` | Name segment used for SmithDB resources. |
-| smithdb.query.autoscaling | object | `{"enabled":false,"maxReplicas":10,"minReplicas":1,"scaleDownStabilizationWindowSeconds":900,"scalePodCount":1,"scaleUpStabilizationWindowSeconds":300,"targetCPUUtilizationPercentage":40}` |  |
+| smithdb.query.autoscaling | object | `{"enabled":true,"maxReplicas":10,"minReplicas":1,"scaleDownStabilizationWindowSeconds":900,"scalePodCount":1,"scaleUpStabilizationWindowSeconds":300,"targetCPUUtilizationPercentage":40}` |  |
 | smithdb.query.containerGrpcPort | int | `8080` |  |
 | smithdb.query.containerPort | int | `8060` |  |
 | smithdb.query.deployment.affinity | object | `{}` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -955,7 +955,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.compaction.service.annotations | object | `{}` |  |
 | smithdb.compaction.service.labels | object | `{}` |  |
 | smithdb.compaction.service.port | int | `8071` |  |
-| smithdb.compactionWorker.autoscaling | object | `{"enabled":false,"maxReplicas":10,"minReplicas":1,"scaleDownStabilizationWindowSeconds":300,"scalePodCount":1,"scaleUpStabilizationWindowSeconds":120,"targetCPUUtilizationPercentage":60}` | CPU-based HPA for smithdb-compaction-worker. When enabled, omit deployment.replicas from the Deployment. Compaction is queue-driven; CPU is a coarse proxy (bursty jobs may not sustain utilization long enough to scale). Prefer tuning after observing backlog under your workload. |
+| smithdb.compactionWorker.autoscaling | object | `{"enabled":true,"maxReplicas":10,"minReplicas":1,"scaleDownStabilizationWindowSeconds":300,"scalePodCount":1,"scaleUpStabilizationWindowSeconds":120,"targetCPUUtilizationPercentage":60}` |  |
 | smithdb.compactionWorker.containerPort | int | `9000` |  |
 | smithdb.compactionWorker.deployment.affinity | object | `{}` |  |
 | smithdb.compactionWorker.deployment.annotations | object | `{}` |  |
@@ -1023,7 +1023,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.config.observability.tracing.endpoint | string | `""` | OTLP gRPC collector endpoint for SmithDB traces/logs. |
 | smithdb.config.observability.tracing.extraResourceAttributes | object | `{}` | Extra OpenTelemetry resource attributes appended to SmithDB traces/logs. |
 | smithdb.enabled | bool | `false` | Deploy the in-chart SmithDB workloads. |
-| smithdb.ingestion.autoscaling | object | `{"enabled":false,"maxReplicas":5,"minReplicas":1,"scaleDownStabilizationWindowSeconds":900,"scalePodCount":1,"scaleUpStabilizationWindowSeconds":300,"targetCPUUtilizationPercentage":45}` | CPU-based HPA for smithdb-ingestion. When enabled, omit deployment.replicas from the Deployment; the cluster manager's ingestion MAX_REPLICAS is derived from autoscaling.maxReplicas. Default target is above typical single-pod baseline utilization so HPA can consolidate to minReplicas at idle. |
+| smithdb.ingestion.autoscaling | object | `{"enabled":false,"maxReplicas":10,"minReplicas":1,"scaleDownStabilizationWindowSeconds":900,"scalePodCount":1,"scaleUpStabilizationWindowSeconds":300,"targetCPUUtilizationPercentage":45}` |  |
 | smithdb.ingestion.containerGrpcPort | int | `8082` |  |
 | smithdb.ingestion.containerPort | int | `8050` |  |
 | smithdb.ingestion.deployment.affinity | object | `{}` |  |
@@ -1179,7 +1179,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.migration.taskdb.postgres.statefulSet.volumeMounts | list | `[]` |  |
 | smithdb.migration.taskdb.postgres.statefulSet.volumes | list | `[]` |  |
 | smithdb.name | string | `"smithdb"` | Name segment used for SmithDB resources. |
-| smithdb.query.autoscaling | object | `{"enabled":false,"maxReplicas":5,"minReplicas":1,"scaleDownStabilizationWindowSeconds":900,"scalePodCount":1,"scaleUpStabilizationWindowSeconds":300,"targetCPUUtilizationPercentage":40}` | CPU-based HPA for smithdb-query. When enabled, omit deployment.replicas from the Deployment; the cluster manager's query MAX_REPLICAS is derived from autoscaling.maxReplicas. |
+| smithdb.query.autoscaling | object | `{"enabled":false,"maxReplicas":10,"minReplicas":1,"scaleDownStabilizationWindowSeconds":900,"scalePodCount":1,"scaleUpStabilizationWindowSeconds":300,"targetCPUUtilizationPercentage":40}` |  |
 | smithdb.query.containerGrpcPort | int | `8080` |  |
 | smithdb.query.containerPort | int | `8060` |  |
 | smithdb.query.deployment.affinity | object | `{}` |  |

--- a/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
@@ -18,7 +18,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if not (dig "autoscaling" "enabled" false .Values.smithdb.compactionWorker) }}
   replicas: {{ .Values.smithdb.compactionWorker.deployment.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "langsmith.selectorLabels" . | nindent 6 }}

--- a/charts/langsmith/templates/smithdb/compaction-worker-hpa.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-hpa.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.smithdb.enabled (dig "autoscaling" "enabled" false .Values.smithdb.compactionWorker) }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compactionWorker") }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "langsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compactionWorker") }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compactionWorker") }}
+  minReplicas: {{ .Values.smithdb.compactionWorker.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.smithdb.compactionWorker.autoscaling.maxReplicas }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleUpStabilizationWindowSeconds }}
+      policies:
+        - type: Pods
+          value: {{ .Values.smithdb.compactionWorker.autoscaling.scalePodCount }}
+          periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleUpStabilizationWindowSeconds }}
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleDownStabilizationWindowSeconds }}
+      policies:
+        - type: Pods
+          value: {{ .Values.smithdb.compactionWorker.autoscaling.scalePodCount }}
+          periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleDownStabilizationWindowSeconds }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.smithdb.compactionWorker.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/charts/langsmith/templates/smithdb/ingestion-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/ingestion-deployment.yaml
@@ -18,7 +18,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if not (dig "autoscaling" "enabled" false .Values.smithdb.ingestion) }}
   replicas: {{ .Values.smithdb.ingestion.deployment.replicas }}
+  {{- end }}
   strategy:
     {{- toYaml .Values.smithdb.ingestion.deployment.strategy | nindent 4 }}
   selector:

--- a/charts/langsmith/templates/smithdb/ingestion-hpa.yaml
+++ b/charts/langsmith/templates/smithdb/ingestion-hpa.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.smithdb.enabled (dig "autoscaling" "enabled" false .Values.smithdb.ingestion) }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "ingestion") }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "langsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "ingestion") }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "ingestion") }}
+  minReplicas: {{ .Values.smithdb.ingestion.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.smithdb.ingestion.autoscaling.maxReplicas }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.smithdb.ingestion.autoscaling.scaleUpStabilizationWindowSeconds }}
+      policies:
+        - type: Pods
+          value: {{ .Values.smithdb.ingestion.autoscaling.scalePodCount }}
+          periodSeconds: {{ .Values.smithdb.ingestion.autoscaling.scaleUpStabilizationWindowSeconds }}
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.smithdb.ingestion.autoscaling.scaleDownStabilizationWindowSeconds }}
+      policies:
+        - type: Pods
+          value: {{ .Values.smithdb.ingestion.autoscaling.scalePodCount }}
+          periodSeconds: {{ .Values.smithdb.ingestion.autoscaling.scaleDownStabilizationWindowSeconds }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.smithdb.ingestion.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/charts/langsmith/templates/smithdb/query-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/query-deployment.yaml
@@ -18,7 +18,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if not (dig "autoscaling" "enabled" false .Values.smithdb.query) }}
   replicas: {{ .Values.smithdb.query.deployment.replicas }}
+  {{- end }}
   strategy:
     {{- toYaml .Values.smithdb.query.deployment.strategy | nindent 4 }}
   selector:

--- a/charts/langsmith/templates/smithdb/query-hpa.yaml
+++ b/charts/langsmith/templates/smithdb/query-hpa.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.smithdb.enabled (dig "autoscaling" "enabled" false .Values.smithdb.query) }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "query") }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "langsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "query") }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "query") }}
+  minReplicas: {{ .Values.smithdb.query.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.smithdb.query.autoscaling.maxReplicas }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.smithdb.query.autoscaling.scaleUpStabilizationWindowSeconds }}
+      policies:
+        - type: Pods
+          value: {{ .Values.smithdb.query.autoscaling.scalePodCount }}
+          periodSeconds: {{ .Values.smithdb.query.autoscaling.scaleUpStabilizationWindowSeconds }}
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.smithdb.query.autoscaling.scaleDownStabilizationWindowSeconds }}
+      policies:
+        - type: Pods
+          value: {{ .Values.smithdb.query.autoscaling.scalePodCount }}
+          periodSeconds: {{ .Values.smithdb.query.autoscaling.scaleDownStabilizationWindowSeconds }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.smithdb.query.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -334,6 +334,22 @@ AWS Marketplace Helm template verification).
 {{- if and .Values.smithdb.enabled (ne (toString .Values.smithdb.compactionWorker.maxConcurrentJobs) "") (lt (int .Values.smithdb.compactionWorker.maxConcurrentJobs) 1) -}}
 {{- fail "smithdb.compactionWorker.maxConcurrentJobs must be greater than 0 when set." -}}
 {{- end -}}
+{{- $smithdbAutoscalingWorkloads := dict
+  "query" .Values.smithdb.query
+  "ingestion" .Values.smithdb.ingestion
+  "compactionWorker" .Values.smithdb.compactionWorker
+-}}
+{{- range $workloadName, $workload := $smithdbAutoscalingWorkloads -}}
+{{- $autoscaling := dig "autoscaling" (dict) $workload -}}
+{{- if and $.Values.smithdb.enabled (dig "enabled" false $autoscaling) -}}
+{{- if lt (int $autoscaling.minReplicas) 1 -}}
+{{- fail (printf "smithdb.%s.autoscaling.minReplicas must be greater than 0 when autoscaling is enabled." $workloadName) -}}
+{{- end -}}
+{{- if lt (int $autoscaling.maxReplicas) (int $autoscaling.minReplicas) -}}
+{{- fail (printf "smithdb.%s.autoscaling.maxReplicas must be >= minReplicas when autoscaling is enabled." $workloadName) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 {{- if and .Values.smithdb.langsmith.migration.enabled (not .Values.smithdb.enabled) -}}
 {{- fail "smithdb.enabled must be true when smithdb.langsmith.migration.enabled is true." -}}

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -388,14 +388,28 @@ tests:
       - notExists:
           path: spec.replicas
 
-  - it: should default smithdb compaction-worker to two replicas
+  - it: should enable compaction-worker HPA by default
+    values:
+      - ./values/smithdb-enabled.yaml
+    template: smithdb/compaction-worker-hpa.yaml
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 1
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 60
+
+  - it: should omit compaction-worker deployment replicas when HPA enabled by default
     values:
       - ./values/smithdb-enabled.yaml
     template: smithdb/compaction-worker-deployment.yaml
     asserts:
-      - equal:
+      - notExists:
           path: spec.replicas
-          value: 2
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
           value: "4"

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -9,9 +9,12 @@ templates:
   - clickhouse/secrets.yaml
   - frontend/config-map.yaml
   - smithdb/query-deployment.yaml
+  - smithdb/query-hpa.yaml
   - smithdb/ingestion-deployment.yaml
+  - smithdb/ingestion-hpa.yaml
   - smithdb/compaction-deployment.yaml
   - smithdb/compaction-worker-deployment.yaml
+  - smithdb/compaction-worker-hpa.yaml
   - smithdb/cluster-manager-deployment.yaml
   - smithdb/migration-job.yaml
   - smithdb/taskdb-postgres-secret.yaml
@@ -332,6 +335,58 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: SMITHDB_CLUSTERMANAGER__SERVICES__COMPACTION__MAX_REPLICAS
+
+
+  - it: should derive cluster-manager service max replicas from autoscaling max when HPA enabled
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.query.deployment.replicas: 1
+      smithdb.query.autoscaling.enabled: true
+      smithdb.query.autoscaling.minReplicas: 2
+      smithdb.query.autoscaling.maxReplicas: 6
+    template: smithdb/cluster-manager-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__MIN_REPLICAS
+            value: "1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__MAX_REPLICAS
+            value: "6"
+
+  - it: should render query HPA when autoscaling enabled
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.query.autoscaling.enabled: true
+      smithdb.query.autoscaling.minReplicas: 1
+      smithdb.query.autoscaling.maxReplicas: 5
+      smithdb.query.autoscaling.targetCPUUtilizationPercentage: 40
+    template: smithdb/query-hpa.yaml
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 1
+      - equal:
+          path: spec.maxReplicas
+          value: 5
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 40
+
+  - it: should omit query deployment replicas when autoscaling enabled
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.query.autoscaling.enabled: true
+    template: smithdb/query-deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.replicas
 
   - it: should default smithdb compaction-worker to two replicas
     values:

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -297,6 +297,8 @@ tests:
     values:
       - ./values/smithdb-enabled.yaml
     set:
+      smithdb.query.autoscaling.enabled: false
+      smithdb.ingestion.autoscaling.enabled: false
       smithdb.query.deployment.replicas: 4
       smithdb.ingestion.deployment.replicas: 2
     template: smithdb/cluster-manager-deployment.yaml
@@ -358,14 +360,9 @@ tests:
             name: SMITHDB_CLUSTERMANAGER__SERVICES__QUERY__MAX_REPLICAS
             value: "6"
 
-  - it: should render query HPA when autoscaling enabled
+  - it: should enable query HPA by default
     values:
       - ./values/smithdb-enabled.yaml
-    set:
-      smithdb.query.autoscaling.enabled: true
-      smithdb.query.autoscaling.minReplicas: 1
-      smithdb.query.autoscaling.maxReplicas: 5
-      smithdb.query.autoscaling.targetCPUUtilizationPercentage: 40
     template: smithdb/query-hpa.yaml
     asserts:
       - equal:
@@ -373,17 +370,38 @@ tests:
           value: 1
       - equal:
           path: spec.maxReplicas
-          value: 5
+          value: 10
       - equal:
           path: spec.metrics[0].resource.target.averageUtilization
           value: 40
 
-  - it: should omit query deployment replicas when autoscaling enabled
+  - it: should omit query deployment replicas when HPA enabled by default
     values:
       - ./values/smithdb-enabled.yaml
-    set:
-      smithdb.query.autoscaling.enabled: true
     template: smithdb/query-deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.replicas
+
+  - it: should enable ingestion HPA by default
+    values:
+      - ./values/smithdb-enabled.yaml
+    template: smithdb/ingestion-hpa.yaml
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 1
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 45
+
+  - it: should omit ingestion deployment replicas when HPA enabled by default
+    values:
+      - ./values/smithdb-enabled.yaml
+    template: smithdb/ingestion-deployment.yaml
     asserts:
       - notExists:
           path: spec.replicas

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1358,13 +1358,10 @@ smithdb:
       minAvailable: 1
       labels: {}
       annotations: {}
-    # -- CPU-based HPA for smithdb-query. When enabled, omit deployment.replicas
-    # from the Deployment; the cluster manager's query MAX_REPLICAS is derived
-    # from autoscaling.maxReplicas.
     autoscaling:
       enabled: false
       minReplicas: 1
-      maxReplicas: 5
+      maxReplicas: 10
       targetCPUUtilizationPercentage: 40
       scaleUpStabilizationWindowSeconds: 300
       scaleDownStabilizationWindowSeconds: 900
@@ -1448,14 +1445,10 @@ smithdb:
       minAvailable: 1
       labels: {}
       annotations: {}
-    # -- CPU-based HPA for smithdb-ingestion. When enabled, omit deployment.replicas
-    # from the Deployment; the cluster manager's ingestion MAX_REPLICAS is derived
-    # from autoscaling.maxReplicas. Default target is above typical single-pod
-    # baseline utilization so HPA can consolidate to minReplicas at idle.
     autoscaling:
       enabled: false
       minReplicas: 1
-      maxReplicas: 5
+      maxReplicas: 10
       targetCPUUtilizationPercentage: 45
       scaleUpStabilizationWindowSeconds: 300
       scaleDownStabilizationWindowSeconds: 900
@@ -1591,12 +1584,8 @@ smithdb:
       minAvailable: 1
       labels: {}
       annotations: {}
-    # -- CPU-based HPA for smithdb-compaction-worker. When enabled, omit
-    # deployment.replicas from the Deployment. Compaction is queue-driven; CPU
-    # is a coarse proxy (bursty jobs may not sustain utilization long enough to
-    # scale). Prefer tuning after observing backlog under your workload.
     autoscaling:
-      enabled: false
+      enabled: true
       minReplicas: 1
       maxReplicas: 10
       targetCPUUtilizationPercentage: 60

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1358,6 +1358,17 @@ smithdb:
       minAvailable: 1
       labels: {}
       annotations: {}
+    # -- CPU-based HPA for smithdb-query. When enabled, omit deployment.replicas
+    # from the Deployment; the cluster manager's query MAX_REPLICAS is derived
+    # from autoscaling.maxReplicas.
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 40
+      scaleUpStabilizationWindowSeconds: 300
+      scaleDownStabilizationWindowSeconds: 900
+      scalePodCount: 1
 
   ingestion:
     name: "ingestion"
@@ -1437,6 +1448,18 @@ smithdb:
       minAvailable: 1
       labels: {}
       annotations: {}
+    # -- CPU-based HPA for smithdb-ingestion. When enabled, omit deployment.replicas
+    # from the Deployment; the cluster manager's ingestion MAX_REPLICAS is derived
+    # from autoscaling.maxReplicas. Default target is above typical single-pod
+    # baseline utilization so HPA can consolidate to minReplicas at idle.
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 45
+      scaleUpStabilizationWindowSeconds: 300
+      scaleDownStabilizationWindowSeconds: 900
+      scalePodCount: 1
 
   compaction:
     name: "compaction"
@@ -1568,6 +1591,18 @@ smithdb:
       minAvailable: 1
       labels: {}
       annotations: {}
+    # -- CPU-based HPA for smithdb-compaction-worker. When enabled, omit
+    # deployment.replicas from the Deployment. Compaction is queue-driven; CPU
+    # is a coarse proxy (bursty jobs may not sustain utilization long enough to
+    # scale). Prefer tuning after observing backlog under your workload.
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 60
+      scaleUpStabilizationWindowSeconds: 120
+      scaleDownStabilizationWindowSeconds: 300
+      scalePodCount: 1
 
   clusterManager:
     name: "cluster-manager"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1359,7 +1359,7 @@ smithdb:
       labels: {}
       annotations: {}
     autoscaling:
-      enabled: false
+      enabled: true
       minReplicas: 1
       maxReplicas: 10
       targetCPUUtilizationPercentage: 40
@@ -1446,7 +1446,7 @@ smithdb:
       labels: {}
       annotations: {}
     autoscaling:
-      enabled: false
+      enabled: true
       minReplicas: 1
       maxReplicas: 10
       targetCPUUtilizationPercentage: 45


### PR DESCRIPTION
## Summary
- Add optional CPU HPAs for smithdb.query, smithdb.ingestion, and smithdb.compactionWorker