### PR TITLE
feat(langsmith): consolidate non-backend workloads onto the backend image

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -232,6 +232,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | fleetToolServer.containerPort | int | `1989` |  |
 | fleetToolServer.deployment.affinity | object | `{}` |  |
 | fleetToolServer.deployment.annotations | object | `{}` |  |
+| fleetToolServer.deployment.command[0] | string | `"agent_builder_tool_server_entrypoint.sh"` |  |
 | fleetToolServer.deployment.extraContainerConfig | object | `{}` |  |
 | fleetToolServer.deployment.extraEnv | list | `[]` |  |
 | fleetToolServer.deployment.initContainers | list | `[]` |  |
@@ -286,6 +287,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | fleetTriggerServer.containerPort | int | `1990` |  |
 | fleetTriggerServer.deployment.affinity | object | `{}` |  |
 | fleetTriggerServer.deployment.annotations | object | `{}` |  |
+| fleetTriggerServer.deployment.command[0] | string | `"agent_builder_trigger_server_entrypoint.sh"` |  |
 | fleetTriggerServer.deployment.extraContainerConfig | object | `{}` |  |
 | fleetTriggerServer.deployment.extraEnv | list | `[]` |  |
 | fleetTriggerServer.deployment.initContainers | list | `[]` |  |
@@ -351,18 +353,9 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | images.clickhouseImage.pullPolicy | string | `"Always"` |  |
 | images.clickhouseImage.repository | string | `"docker.io/clickhouse/clickhouse-server"` |  |
 | images.clickhouseImage.tag | string | `"25.12"` |  |
-| images.fleetToolServerImage.pullPolicy | string | `"IfNotPresent"` |  |
-| images.fleetToolServerImage.repository | string | `"docker.io/langchain/agent-builder-tool-server"` |  |
-| images.fleetToolServerImage.tag | string | `"0.16.21rc1"` |  |
-| images.fleetTriggerServerImage.pullPolicy | string | `"IfNotPresent"` |  |
-| images.fleetTriggerServerImage.repository | string | `"docker.io/langchain/agent-builder-trigger-server"` |  |
-| images.fleetTriggerServerImage.tag | string | `"0.16.21rc1"` |  |
 | images.frontendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.frontendImage.repository | string | `"docker.io/langchain/langsmith-frontend"` |  |
 | images.frontendImage.tag | string | `"0.16.21rc1"` |  |
-| images.hostBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
-| images.hostBackendImage.repository | string | `"docker.io/langchain/hosted-langserve-backend"` |  |
-| images.hostBackendImage.tag | string | `"0.16.21rc1"` |  |
 | images.imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Specified as name: value. |
 | images.insightsAgentImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.insightsAgentImage.repository | string | `"docker.io/langchain/langsmith-clio"` |  |
@@ -370,12 +363,6 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | images.operatorImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.operatorImage.repository | string | `"docker.io/langchain/langgraph-operator"` |  |
 | images.operatorImage.tag | string | `"0.1.47"` |  |
-| images.platformBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
-| images.platformBackendImage.repository | string | `"docker.io/langchain/langsmith-go-backend"` |  |
-| images.platformBackendImage.tag | string | `"0.16.21rc1"` |  |
-| images.playgroundImage.pullPolicy | string | `"IfNotPresent"` |  |
-| images.playgroundImage.repository | string | `"docker.io/langchain/langsmith-playground"` |  |
-| images.playgroundImage.tag | string | `"0.16.21rc1"` |  |
 | images.pollyAgentImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.pollyAgentImage.repository | string | `"docker.io/langchain/langsmith-polly"` |  |
 | images.pollyAgentImage.tag | string | `"0.16.21rc1"` |  |
@@ -418,7 +405,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | ingestQueue.containerPort | int | `1989` |  |
 | ingestQueue.deployment.affinity | object | `{}` |  |
 | ingestQueue.deployment.annotations | object | `{}` |  |
-| ingestQueue.deployment.command[0] | string | `"./asynq_worker_entrypoint.sh"` |  |
+| ingestQueue.deployment.command[0] | string | `"asynq_worker_entrypoint.sh"` |  |
 | ingestQueue.deployment.extraContainerConfig | object | `{}` |  |
 | ingestQueue.deployment.extraEnv | list | `[]` |  |
 | ingestQueue.deployment.initContainers | list | `[]` |  |
@@ -1024,7 +1011,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.config.objectStore.s3.region | string | `""` | Defaults to the SmithDB S3 client default when empty. |
 | smithdb.config.objectStore.s3.secretAccessKeySecretKey | string | `""` |  |
 | smithdb.config.objectStore.type | string | `"s3"` | Supported values: s3, gcs. |
-| smithdb.enabled | bool | `false` | Please express interest via our Support Portal (https://support.langchain.com) and we will reach out promptly to ensure we can set you up for success with SmithDB. |
+| smithdb.enabled | bool | `false` | Please express interest (https://www.langchain.com/smithdb-early-access-waitlist) and we will reach out promptly to ensure we can set you up for success with SmithDB. |
 | smithdb.ingestion.autoscaling.enabled | bool | `true` |  |
 | smithdb.ingestion.autoscaling.maxReplicas | int | `10` |  |
 | smithdb.ingestion.autoscaling.minReplicas | int | `1` |  |
@@ -1750,7 +1737,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | hostBackend.containerPort | int | `1985` |  |
 | hostBackend.deployment.affinity | object | `{}` |  |
 | hostBackend.deployment.annotations | object | `{}` |  |
-| hostBackend.deployment.command[0] | string | `"./entrypoint.sh"` |  |
+| hostBackend.deployment.command[0] | string | `"host_backend_entrypoint.sh"` |  |
 | hostBackend.deployment.extraContainerConfig | object | `{}` |  |
 | hostBackend.deployment.extraEnv | list | `[]` |  |
 | hostBackend.deployment.initContainers | list | `[]` |  |
@@ -1935,7 +1922,8 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | listener.containerPort | int | `8080` |  |
 | listener.deployment.affinity | object | `{}` |  |
 | listener.deployment.annotations | object | `{}` |  |
-| listener.deployment.command[0] | string | `"./listener_entrypoint.sh"` |  |
+| listener.deployment.command[0] | string | `"host_backend_entrypoint.sh"` |  |
+| listener.deployment.command[1] | string | `"./listener_entrypoint.sh"` |  |
 | listener.deployment.extraContainerConfig | object | `{}` |  |
 | listener.deployment.extraEnv | list | `[]` |  |
 | listener.deployment.initContainers | list | `[]` |  |
@@ -1999,7 +1987,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | agentGateway.containerPort | int | `8083` |  |
 | agentGateway.deployment.affinity | object | `{}` |  |
 | agentGateway.deployment.annotations | object | `{}` |  |
-| agentGateway.deployment.command[0] | string | `"./agent_gateway_entrypoint.sh"` |  |
+| agentGateway.deployment.command[0] | string | `"agent_gateway_entrypoint.sh"` |  |
 | agentGateway.deployment.extraContainerConfig | object | `{}` |  |
 | agentGateway.deployment.extraEnv | list | `[]` |  |
 | agentGateway.deployment.initContainers | list | `[]` |  |
@@ -2178,7 +2166,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | platformBackend.containerPort | int | `1986` |  |
 | platformBackend.deployment.affinity | object | `{}` |  |
 | platformBackend.deployment.annotations | object | `{}` |  |
-| platformBackend.deployment.command[0] | string | `"./entrypoint.sh"` |  |
+| platformBackend.deployment.command[0] | string | `"smith_go_entrypoint.sh"` |  |
 | platformBackend.deployment.extraContainerConfig | object | `{}` |  |
 | platformBackend.deployment.extraEnv | list | `[]` |  |
 | platformBackend.deployment.initContainers | list | `[]` |  |
@@ -2261,7 +2249,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | playground.containerPort | int | `1988` |  |
 | playground.deployment.affinity | object | `{}` |  |
 | playground.deployment.annotations | object | `{}` |  |
-| playground.deployment.command[0] | string | `"./entrypoint.sh"` |  |
+| playground.deployment.command[0] | string | `"smith_playground_entrypoint.sh"` |  |
 | playground.deployment.extraContainerConfig | object | `{}` |  |
 | playground.deployment.extraEnv | list | `[]` |  |
 | playground.deployment.initContainers | list | `[]` |  |

--- a/charts/langsmith/templates/agent-features/fleet/tool-server/deployment.yaml
+++ b/charts/langsmith/templates/agent-features/fleet/tool-server/deployment.yaml
@@ -57,6 +57,10 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Values.fleetToolServer.name }}
+          {{- with .Values.fleetToolServer.deployment.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             {{- with $envVars }}
               {{- toYaml . | nindent 12 }}
@@ -64,8 +68,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "langsmith.fullname" . }}-config
-          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "fleetToolServerImage") | quote }}
-          imagePullPolicy: {{ .Values.images.fleetToolServerImage.pullPolicy }}
+          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "backendImage") | quote }}
+          imagePullPolicy: {{ .Values.images.backendImage.pullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.fleetToolServer.containerPort }}

--- a/charts/langsmith/templates/agent-features/fleet/trigger-server/deployment.yaml
+++ b/charts/langsmith/templates/agent-features/fleet/trigger-server/deployment.yaml
@@ -56,6 +56,10 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Values.fleetTriggerServer.name }}
+          {{- with .Values.fleetTriggerServer.deployment.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             {{- with $envVars }}
               {{- toYaml . | nindent 12 }}
@@ -68,8 +72,8 @@ spec:
                 name: {{ include "langsmith.fullname" . }}-agent-builder-config
                 optional: true
             {{- end }}
-          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "fleetTriggerServerImage") | quote }}
-          imagePullPolicy: {{ .Values.images.fleetTriggerServerImage.pullPolicy }}
+          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "backendImage") | quote }}
+          imagePullPolicy: {{ .Values.images.backendImage.pullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.fleetTriggerServer.containerPort }}

--- a/charts/langsmith/templates/agent-gateway/deployment.yaml
+++ b/charts/langsmith/templates/agent-gateway/deployment.yaml
@@ -75,8 +75,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "langsmith.fullname" . }}-config
-          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "platformBackendImage") | quote }}
-          imagePullPolicy: {{ .Values.images.platformBackendImage.pullPolicy }}
+          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "backendImage") | quote }}
+          imagePullPolicy: {{ .Values.images.backendImage.pullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.agentGateway.containerPort }}

--- a/charts/langsmith/templates/host-backend/deployment.yaml
+++ b/charts/langsmith/templates/host-backend/deployment.yaml
@@ -97,8 +97,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "langsmith.fullname" . }}-config
-          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "hostBackendImage") | quote }}
-          imagePullPolicy: {{ .Values.images.hostBackendImage.pullPolicy }}
+          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "backendImage") | quote }}
+          imagePullPolicy: {{ .Values.images.backendImage.pullPolicy }}
           ports:
             - name: host-backend
               containerPort: {{ .Values.hostBackend.containerPort }}

--- a/charts/langsmith/templates/ingest-queue/deployment.yaml
+++ b/charts/langsmith/templates/ingest-queue/deployment.yaml
@@ -84,8 +84,8 @@ spec:
                 name: {{ include "langsmith.fullname" . }}-agent-builder-config
                 optional: true
             {{- end }}
-          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "platformBackendImage") | quote }}
-          imagePullPolicy: {{ .Values.images.platformBackendImage.pullPolicy }}
+          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "backendImage") | quote }}
+          imagePullPolicy: {{ .Values.images.backendImage.pullPolicy }}
           ports:
             - name: ingest-queue
               containerPort: {{ .Values.ingestQueue.containerPort }}

--- a/charts/langsmith/templates/listener/deployment.yaml
+++ b/charts/langsmith/templates/listener/deployment.yaml
@@ -85,8 +85,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "langsmith.fullname" . }}-config
-          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "hostBackendImage") | quote }}
-          imagePullPolicy: {{ .Values.images.hostBackendImage.pullPolicy }}
+          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "backendImage") | quote }}
+          imagePullPolicy: {{ .Values.images.backendImage.pullPolicy }}
           ports:
             - name: listener
               containerPort: {{ .Values.listener.containerPort }}

--- a/charts/langsmith/templates/platform-backend/deployment.yaml
+++ b/charts/langsmith/templates/platform-backend/deployment.yaml
@@ -87,8 +87,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "langsmith.fullname" . }}-config
-          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "platformBackendImage") | quote }}
-          imagePullPolicy: {{ .Values.images.platformBackendImage.pullPolicy }}
+          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "backendImage") | quote }}
+          imagePullPolicy: {{ .Values.images.backendImage.pullPolicy }}
           ports:
             - name: platform
               containerPort: {{ .Values.platformBackend.containerPort }}

--- a/charts/langsmith/templates/playground/deployment.yaml
+++ b/charts/langsmith/templates/playground/deployment.yaml
@@ -81,8 +81,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "langsmith.fullname" . }}-config
-          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "playgroundImage") | quote }}
-          imagePullPolicy: {{ .Values.images.playgroundImage.pullPolicy }}
+          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "backendImage") | quote }}
+          imagePullPolicy: {{ .Values.images.backendImage.pullPolicy }}
           ports:
             - name: playground
               containerPort: {{ .Values.playground.containerPort }}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -38,11 +38,11 @@ AWS Marketplace Helm template verification).
 {{- if hasKey .Values "agentBuilderTriggerServer" -}}
 {{- fail "agentBuilderTriggerServer is deprecated. Please use fleetTriggerServer." -}}
 {{- end -}}
-{{- if hasKey .Values.images "agentBuilderToolServerImage" -}}
-{{- fail "images.agentBuilderToolServerImage is deprecated. Please use images.fleetToolServerImage." -}}
+{{- /* Deprecated image keys: these workloads now run on the single consolidated backend image */ -}}
+{{- range $key := list "hostBackendImage" "platformBackendImage" "playgroundImage" "fleetToolServerImage" "fleetTriggerServerImage" "agentBuilderToolServerImage" "agentBuilderTriggerServerImage" -}}
+{{- if hasKey $.Values.images $key -}}
+{{- fail (printf "images.%s is deprecated: this workload now runs on the consolidated backend image. Configure images.backendImage instead (and mirror only that image)." $key) -}}
 {{- end -}}
-{{- if hasKey .Values.images "agentBuilderTriggerServerImage" -}}
-{{- fail "images.agentBuilderTriggerServerImage is deprecated. Please use images.fleetTriggerServerImage." -}}
 {{- end -}}
 {{- if hasKey .Values.smithdb.langsmith "dualIngest" -}}
 {{- $legacySmithdbDualIngest := get .Values.smithdb.langsmith "dualIngest" -}}

--- a/charts/langsmith/tests/fleet_server_values_test.yaml
+++ b/charts/langsmith/tests/fleet_server_values_test.yaml
@@ -30,7 +30,7 @@ tests:
       images.agentBuilderToolServerImage.tag: "test"
     asserts:
       - failedTemplate:
-          errorMessage: "images.agentBuilderToolServerImage is deprecated. Please use images.fleetToolServerImage."
+          errorMessage: "images.agentBuilderToolServerImage is deprecated: this workload now runs on the consolidated backend image. Configure images.backendImage instead (and mirror only that image)."
 
   - it: should fail when deprecated agentBuilderTriggerServerImage values are set
     set:
@@ -40,4 +40,54 @@ tests:
       images.agentBuilderTriggerServerImage.tag: "test"
     asserts:
       - failedTemplate:
-          errorMessage: "images.agentBuilderTriggerServerImage is deprecated. Please use images.fleetTriggerServerImage."
+          errorMessage: "images.agentBuilderTriggerServerImage is deprecated: this workload now runs on the consolidated backend image. Configure images.backendImage instead (and mirror only that image)."
+
+  - it: should fail when consolidated hostBackendImage values are set
+    set:
+      config.existingSecretName: "langsmith-secrets"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      images.hostBackendImage.tag: "test"
+    asserts:
+      - failedTemplate:
+          errorMessage: "images.hostBackendImage is deprecated: this workload now runs on the consolidated backend image. Configure images.backendImage instead (and mirror only that image)."
+
+  - it: should fail when consolidated platformBackendImage values are set
+    set:
+      config.existingSecretName: "langsmith-secrets"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      images.platformBackendImage.tag: "test"
+    asserts:
+      - failedTemplate:
+          errorMessage: "images.platformBackendImage is deprecated: this workload now runs on the consolidated backend image. Configure images.backendImage instead (and mirror only that image)."
+
+  - it: should fail when consolidated playgroundImage values are set
+    set:
+      config.existingSecretName: "langsmith-secrets"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      images.playgroundImage.tag: "test"
+    asserts:
+      - failedTemplate:
+          errorMessage: "images.playgroundImage is deprecated: this workload now runs on the consolidated backend image. Configure images.backendImage instead (and mirror only that image)."
+
+  - it: should fail when consolidated fleetToolServerImage values are set
+    set:
+      config.existingSecretName: "langsmith-secrets"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      images.fleetToolServerImage.tag: "test"
+    asserts:
+      - failedTemplate:
+          errorMessage: "images.fleetToolServerImage is deprecated: this workload now runs on the consolidated backend image. Configure images.backendImage instead (and mirror only that image)."
+
+  - it: should fail when consolidated fleetTriggerServerImage values are set
+    set:
+      config.existingSecretName: "langsmith-secrets"
+      config.oauth.enabled: true
+      config.authType: "oauth"
+      images.fleetTriggerServerImage.tag: "test"
+    asserts:
+      - failedTemplate:
+          errorMessage: "images.fleetTriggerServerImage is deprecated: this workload now runs on the consolidated backend image. Configure images.backendImage instead (and mirror only that image)."

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -78,22 +78,10 @@ images:
     repository: "docker.io/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
     tag: "0.16.21rc1"
-  hostBackendImage:
-    repository: "docker.io/langchain/hosted-langserve-backend"
-    pullPolicy: IfNotPresent
-    tag: "0.16.21rc1"
   operatorImage:
     repository: "docker.io/langchain/langgraph-operator"
     pullPolicy: IfNotPresent
     tag: "0.1.47"
-  platformBackendImage:
-    repository: "docker.io/langchain/langsmith-go-backend"
-    pullPolicy: IfNotPresent
-    tag: "0.16.21rc1"
-  playgroundImage:
-    repository: "docker.io/langchain/langsmith-playground"
-    pullPolicy: IfNotPresent
-    tag: "0.16.21rc1"
   # For production environments, we strongly recommend connecting to a managed PostgreSQL instance instead of using the one provided by the chart.
   # Docs: https://docs.langchain.com/langsmith/self-host-external-postgres
   postgresImage:
@@ -110,14 +98,6 @@ images:
     repository: "docker.io/clickhouse/clickhouse-server"
     pullPolicy: Always
     tag: "25.12"
-  fleetToolServerImage:
-    repository: "docker.io/langchain/agent-builder-tool-server"
-    pullPolicy: IfNotPresent
-    tag: "0.16.21rc1"
-  fleetTriggerServerImage:
-    repository: "docker.io/langchain/agent-builder-trigger-server"
-    pullPolicy: IfNotPresent
-    tag: "0.16.21rc1"
   agentBuilderImage:
     repository: "docker.io/langchain/agent-builder-deep-agent"
     pullPolicy: IfNotPresent
@@ -2346,7 +2326,7 @@ hostBackend:
         cpu: 200m
         memory: 1000Mi
     command:
-      - "./entrypoint.sh"
+      - "host_backend_entrypoint.sh"
     startupProbe:
       httpGet:
         path: /ok
@@ -2457,6 +2437,7 @@ listener:
         cpu: 1000m
         memory: 2Gi
     command:
+      - "host_backend_entrypoint.sh"
       - "./listener_entrypoint.sh"
     startupProbe:
       httpGet:
@@ -2568,7 +2549,7 @@ platformBackend:
         cpu: 1000m
         memory: 2Gi
     command:
-      - "./entrypoint.sh"
+      - "smith_go_entrypoint.sh"
     startupProbe:
       httpGet:
         path: /ok
@@ -2865,7 +2846,7 @@ playground:
         cpu: 500m
         memory: 1Gi
     command:
-      - "./entrypoint.sh"
+      - "smith_playground_entrypoint.sh"
     startupProbe:
       httpGet:
         path: /ok
@@ -3189,7 +3170,7 @@ ingestQueue:
         cpu: 1000m
         memory: 2Gi
     command:
-      - "./asynq_worker_entrypoint.sh"
+      - "asynq_worker_entrypoint.sh"
     startupProbe:
       httpGet:
         path: /health
@@ -3385,6 +3366,8 @@ fleetToolServer:
   name: "fleet-tool-server"
   containerPort: 1989
   deployment:
+    command:
+      - "agent_builder_tool_server_entrypoint.sh"
     replicas: 1
     labels: {}
     annotations: {}
@@ -3463,6 +3446,8 @@ fleetTriggerServer:
   name: "fleet-trigger-server"
   containerPort: 1990
   deployment:
+    command:
+      - "agent_builder_trigger_server_entrypoint.sh"
     labels: {}
     annotations: {}
     podSecurityContext: {}
@@ -3542,7 +3527,7 @@ agentGateway:
         cpu: 100m
         memory: 256Mi
     command:
-      - "./agent_gateway_entrypoint.sh"
+      - "agent_gateway_entrypoint.sh"
     startupProbe:
       httpGet:
         path: /health


### PR DESCRIPTION
## What

Consolidates the `langsmith` chart's non-backend workloads onto the single `langsmith-backend` image (the app image already ships every role via snake_case launchers on `PATH`). Each affected workload is repointed from its own `*Image` field to `backendImage` and given the matching launcher command.

| workload (was image) | command |
|---|---|
| platform-backend (`langsmith-go-backend`) | `smith_go_entrypoint.sh` |
| agent-gateway (`langsmith-go-backend`) | `agent_gateway_entrypoint.sh` |
| ingest-queue (`langsmith-go-backend`) | `asynq_worker_entrypoint.sh` |
| playground (`langsmith-playground`) | `smith_playground_entrypoint.sh` |
| host-backend (`hosted-langserve-backend`) | `host_backend_entrypoint.sh` |
| listener (`hosted-langserve-backend`) | `host_backend_entrypoint.sh` + `./listener_entrypoint.sh` |
| fleet tool-server (`agent-builder-tool-server`) | `agent_builder_tool_server_entrypoint.sh` |
| fleet trigger-server (`agent-builder-trigger-server`) | `agent_builder_trigger_server_entrypoint.sh` |

The launchers live in `/usr/local/bin` (WORKDIR is `/code/smith-backend`), so the previous `./entrypoint.sh`-style relative commands no longer resolve — hence both the image **and** command change together. The fleet tool/trigger-server templates didn't render a container `command` at all, so a `command` block was added to each (they'd otherwise fall through to the image's default backend entrypoint).

Unchanged: `backendImage`, `frontendImage`, `aceBackendImage`, `operatorImage`, the LGP agent images (`insightsAgentImage`/clio, `pollyAgentImage`, `agentBuilderImage`/deep-agent), and infra images (postgres/redis/clickhouse/presidio).

## ⚠️ Breaking change

Removes `images.hostBackendImage`, `images.platformBackendImage`, `images.playgroundImage`, `images.fleetToolServerImage`, and `images.fleetTriggerServerImage`. `validate.yaml` now **fails** if any of these (or the older `agentBuilder*Image` aliases) is set, directing operators to configure `images.backendImage` instead. Operators who mirror images to a private registry now mirror **only** `backendImage` for these roles — the hard fail is deliberate so a stale per-service override can't silently send an air-gapped cluster back to `docker.io`.

Timing is fine: `appVersion` is `0.16.19rc1`, whose `langsmith-backend` image already contains all roles + launchers.

## Verification

- `helm lint`: clean.
- `helm unittest`: 116 passed (updated the two stale image-deprecation assertions + added coverage for all 5 newly-consolidated keys).
- `helm template`: rendered all 8 workloads and confirmed each resolves to `langsmith-backend:0.16.19rc1` with the correct launcher (incl. the listener's two-element command).
- README regenerated via helm-docs; chart version `0.16.0-rc.15` → `0.16.0-rc.16`.