### PR TITLE
Redact JWK private key material in get_k8s_debugging_info.sh --redact

### DIFF
--- a/charts/langsmith/scripts/get_k8s_debugging_info.sh
+++ b/charts/langsmith/scripts/get_k8s_debugging_info.sh
@@ -61,6 +61,11 @@ SED_ARGS=(
   # Env-var / kv / JSON sensitive assignments
   -e 's/((PASSWORD|PASSWD|TOKEN|SECRET|API[_-]?KEY|APIKEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|CREDENTIAL|AUTH)[A-Z0-9_-]*[[:space:]]*=[[:space:]]*)[^[:space:]"'"'"']+/\1***REDACTED***/gi'
   -e 's/("(password|passwd|token|secret|api[_-]?key|apikey|access[_-]?key|private[_-]?key|credential|auth)[A-Za-z0-9_-]*"[[:space:]]*:[[:space:]]*")[^"]+/\1***REDACTED***/gi'
+  # JWK/JOSE private key material (RFC 7518 short field names — "d", and the
+  # RSA CRT components — don't match the key-name patterns above). Scoped to
+  # lines that also contain "kty" so a JWK's own key set isn't confused with
+  # unrelated short field names elsewhere in the bundle.
+  -e '/"kty"/ s/("(d|p|q|dp|dq|qi)"[[:space:]]*:[[:space:]]*")[^"]+/\1***REDACTED***/gi'
   # Sensitive HTTP headers
   -e 's/("(x-service-key|x-api-key|x-auth-token|x-access-token|x-authorization|x-csrf-token|cookie|set-cookie)"[[:space:]]*:[[:space:]]*")[^"]+/\1***REDACTED***/gi'
   # Tenant / user / customer / patient identifiers in headers


### PR DESCRIPTION
## Summary
- I found this bug via a customer diagnostic bundle where `config.signingJwks` leaked in plaintext despite `--redact` being used; customer was already notified and asked to rotate the key.
- The signingJwks JSON blobs (chart values.yaml / helm-values dumps) leak their private key component under `--redact`, this is because JWK/JOSE field names (`d`, and RSA CRT components `p`/`q`/`dp`/`dq`/`qi`) are too short to match the existing key-name allowlist in the redaction sed pipeline.
- This PR adds a new sed rule scoped to lines containing `"kty"` (a required JWK member) so only JWK-shaped content is redacted, leaving public fields (`kid`, `crv`, `x`, `use`, `alg`) intact for debugging.

## Test plan
- [x] Verified locally with a sample JWKS line matching the customer's actual leaked format — `"d"` gets redacted, `"kid"`/`"crv"`/`"x"`/`"use"`/`"alg"` are preserved.
- [x] Team review before merge