### PR TITLE
Feat/engine self hosted

### DIFF
--- a/charts/langsmith/templates/agent-features/insights/api-server/deployment.yaml
+++ b/charts/langsmith/templates/agent-features/insights/api-server/deployment.yaml
@@ -69,8 +69,9 @@ spec:
             {{- with .Values.insights.apiServer.deployment.envFrom }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "insightsAgentImage") | quote }}
-          imagePullPolicy: {{ .Values.images.insightsAgentImage.pullPolicy }}
+          {{- $imageComponent := ternary "insightsEngineImage" "insightsAgentImage" (default false .Values.engine.enabled) }}
+          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" $imageComponent) | quote }}
+          imagePullPolicy: {{ (index .Values.images $imageComponent).pullPolicy }}
           ports:
             - name: api-server
               containerPort: {{ .Values.insights.apiServer.containerPort }}

--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -36,6 +36,12 @@ data:
   LANGCHAIN_ENV: "local_kubernetes"
   LANGCHAIN_ENDPOINT: "/{{ if .Values.config.basePath }}{{ .Values.config.basePath }}/{{ end }}api/v1"
   GO_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }}"
+  {{- if .Values.engine.enabled }}
+  # Engine (co-hosted) model access + orchestration. Model calls route to hosted LSI;
+  # smith-go dispatches Engine runs to the in-cluster co-hosted deployment.
+  ENGINE_INTELLIGENCE_BASE_URL: {{ .Values.engine.intelligenceBaseUrl | quote }}
+  FORGE_AGENT_LANGGRAPH_URL: "http://{{ include "langsmith.agentFeatures.fullname" (dict "root" . "product" "insights") }}-{{ .Values.insights.apiServer.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.insights.apiServer.service.httpPort }}"
+  {{- end }}
   GO_ACE_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.aceBackend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.aceBackend.service.port }}"
   PLAYGROUND_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.playground.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.playground.service.port }}"
   SMITH_BACKEND_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.backend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.backend.service.port }}"

--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -37,8 +37,6 @@ data:
   LANGCHAIN_ENDPOINT: "/{{ if .Values.config.basePath }}{{ .Values.config.basePath }}/{{ end }}api/v1"
   GO_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }}"
   {{- if .Values.engine.enabled }}
-  # Engine (co-hosted) model access + orchestration. Model calls route to hosted LSI;
-  # smith-go dispatches Engine runs to the in-cluster co-hosted deployment.
   ENGINE_INTELLIGENCE_BASE_URL: {{ .Values.engine.intelligenceBaseUrl | quote }}
   FORGE_AGENT_LANGGRAPH_URL: "http://{{ include "langsmith.agentFeatures.fullname" (dict "root" . "product" "insights") }}-{{ .Values.insights.apiServer.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.insights.apiServer.service.httpPort }}"
   {{- end }}

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -74,6 +74,13 @@ images:
     repository: "docker.io/langchain/langsmith-clio"
     pullPolicy: IfNotPresent
     tag: "0.16.19rc1"
+  # Co-hosted Insights+Engine image (serves both the `insights` and `engine` graphs).
+  # Used by the insights api-server when `engine.enabled=true`. Built by langchainplus
+  # CI (langsmith-insights-engine); see PR #31682.
+  insightsEngineImage:
+    repository: "docker.io/langchain/langsmith-insights-engine"
+    pullPolicy: IfNotPresent
+    tag: "0.16.19rc1"
   frontendImage:
     repository: "docker.io/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
@@ -407,6 +414,22 @@ fleet:
     pdb:
       enabled: false
       minAvailable: 1
+# Engine (Issues Agent) co-hosted with Insights in one deployment. When enabled, the
+# insights api-server runs the combined `insightsEngineImage` (serving both the
+# `insights` and `engine` graphs) instead of the clio-only image. Requires the
+# in-cluster sandbox runtime (config.sandboxes.enabled) and a LangSmith license
+# (Engine routes model calls to the hosted LSI service).
+engine:
+  enabled: false
+  # Hosted LangSmith Intelligence (LSI) base URL the Engine graph routes model calls to.
+  intelligenceBaseUrl: ""
+  # TODO(secret wiring — coordinate with the sandbox team's chart "service-auth secret
+  # references" work): ISSUES_AGENT_ENCRYPTION_KEY (must match platform-backend), the
+  # per-service X-Service-Key JWT secrets combined_auth verifies
+  # (SMITH_BACKEND_SERVICE_JWT_SECRET / SMITH_GO_SERVICE_JWT_SECRET), and
+  # FORGE_AGENT_LANGSMITH_API_KEY (smith-go -> deployment). Also open: snapshot
+  # provisioning (ISSUES_AGENT_SNAPSHOT_ID) and sandbox-client auth scheme.
+
 insights:
   enabled: true
   namePrefix: "standalone-insights"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -74,9 +74,6 @@ images:
     repository: "docker.io/langchain/langsmith-clio"
     pullPolicy: IfNotPresent
     tag: "0.16.19rc1"
-  # Co-hosted Insights+Engine image (serves both the `insights` and `engine` graphs).
-  # Used by the insights api-server when `engine.enabled=true`. Built by langchainplus
-  # CI (langsmith-insights-engine); see PR #31682.
   insightsEngineImage:
     repository: "docker.io/langchain/langsmith-insights-engine"
     pullPolicy: IfNotPresent
@@ -414,14 +411,8 @@ fleet:
     pdb:
       enabled: false
       minAvailable: 1
-# Engine (Issues Agent) co-hosted with Insights in one deployment. When enabled, the
-# insights api-server runs the combined `insightsEngineImage` (serving both the
-# `insights` and `engine` graphs) instead of the clio-only image. Requires the
-# in-cluster sandbox runtime (config.sandboxes.enabled) and a LangSmith license
-# (Engine routes model calls to the hosted LSI service).
 engine:
   enabled: false
-  # Hosted LangSmith Intelligence (LSI) base URL the Engine graph routes model calls to.
   intelligenceBaseUrl: ""
   # TODO(secret wiring — coordinate with the sandbox team's chart "service-auth secret
   # references" work): ISSUES_AGENT_ENCRYPTION_KEY (must match platform-backend), the


### PR DESCRIPTION
slop:
Engine-side Helm wiring to run the co-hosted Insights+Engine deployment
self-hosted. Gated behind `engine.enabled` (default false), so Insights-only
installs are byte-identical to today.

When engine.enabled=true:
- the insights api-server runs the combined `langsmith-insights-engine` image
  (serves both the `insights` and `engine` LangGraph graphs), instead of the
  clio-only image. The insights queue stays on the clio image (it's clio's
  Insights SAQ worker; the co-hosted LGP server is the api-server).
- config-map gains `ENGINE_INTELLIGENCE_BASE_URL` (Engine routes model calls to
  the hosted LSI service) and `FORGE_AGENT_LANGGRAPH_URL` (smith-go dispatches
  Engine runs to the in-cluster co-hosted deployment).

Aligns with langchainplus PR #31682 (builds `langsmith-insights-engine`) and
deployments PR #34249 (ECR repo). clio's existing env (LANGCHAIN_ENV=
local_kubernetes, in-cluster GO_ENDPOINT) is inherited via the shared config-map,
so it also satisfies the combined image's clio settings.

Validated: `helm lint` clean; `helm template` renders correctly with engine
off (clio image, no engine env) and on (combined image + engine env, service
port 80).

TODO (deferred / needs coordination):
- Secret wiring — ISSUES_AGENT_ENCRYPTION_KEY (must match platform-backend), the
  per-service X-Service-Key JWT secrets combined_auth verifies, and
  FORGE_AGENT_LANGSMITH_API_KEY. Overlaps the sandbox team's chart "service-auth
  secret references" work; reconcile rather than duplicate.
- Consumes the sandbox runtime surface (config.sandboxes.enabled) — Engine needs
  in-cluster sandboxes; that runtime is the sandbox team's chart deliverable.
- Snapshot provisioning (ISSUES_AGENT_SNAPSHOT_ID) and the sandbox-client auth
  scheme self-hosted are still open.