### PR TITLE
feat(langsmith): add configurable SmithDB metrics scraping

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1027,7 +1027,6 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.config.observability.logging.level | string | `""` | Optional SmithDB log filter. Empty uses the chart default: INFO,vortex=WARN. |
 | smithdb.config.observability.metrics.annotations | object | `{}` | Additional annotations for SmithDB component pods when metrics are enabled. Values and keys are evaluated as templates with component, containerName, metricsPath, and metricsPort in scope. |
 | smithdb.config.observability.metrics.enabled | bool | `false` | Add Prometheus scrape annotations to SmithDB component pods. |
-| smithdb.config.observability.metrics.path | string | `"/metrics"` | HTTP path where SmithDB components expose Prometheus metrics. |
 | smithdb.config.observability.tracing.enabled | bool | `false` | Enable OpenTelemetry tracing/log export for SmithDB components. SmithDB supports exporting OTLP over gRPC only. |
 | smithdb.config.observability.tracing.endpoint | string | `""` | OTLP gRPC collector endpoint for SmithDB traces/logs. |
 | smithdb.config.observability.tracing.extraResourceAttributes | object | `{}` | Extra OpenTelemetry resource attributes appended to SmithDB traces/logs. |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1025,6 +1025,9 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.config.objectStore.s3.secretAccessKeySecretKey | string | `""` |  |
 | smithdb.config.objectStore.type | string | `"s3"` | Supported values: s3, gcs. |
 | smithdb.config.observability.logging.level | string | `""` | Optional SmithDB log filter. Empty uses the chart default: INFO,vortex=WARN. |
+| smithdb.config.observability.metrics.annotations | object | `{}` | Additional annotations for SmithDB component pods when metrics are enabled. Values and keys are evaluated as templates with component, containerName, metricsPath, and metricsPort in scope. |
+| smithdb.config.observability.metrics.enabled | bool | `false` | Add Prometheus scrape annotations to SmithDB component pods. |
+| smithdb.config.observability.metrics.path | string | `"/metrics"` | HTTP path where SmithDB components expose Prometheus metrics. |
 | smithdb.config.observability.tracing.enabled | bool | `false` | Enable OpenTelemetry tracing/log export for SmithDB components. SmithDB supports exporting OTLP over gRPC only. |
 | smithdb.config.observability.tracing.endpoint | string | `""` | OTLP gRPC collector endpoint for SmithDB traces/logs. |
 | smithdb.config.observability.tracing.extraResourceAttributes | object | `{}` | Extra OpenTelemetry resource attributes appended to SmithDB traces/logs. |

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -608,6 +608,35 @@ Args: root, service, displayName.
 {{- end }}
 
 {{/*
+SmithDB pod annotations, including optional Prometheus scraping.
+Metrics annotations are evaluated as templates with component, containerName,
+metricsPath, and metricsPort in scope.
+Args: root, component.
+*/}}
+{{- define "langsmith.smithdb.podAnnotations" -}}
+{{- $root := .root -}}
+{{- $component := .component -}}
+{{- $componentValues := index $root.Values.smithdb $component -}}
+{{- $metrics := $root.Values.smithdb.config.observability.metrics -}}
+{{- $annotations := deepCopy (default (dict) $root.Values.commonPodAnnotations) -}}
+{{- if $metrics.enabled }}
+{{- $_ := set $annotations "prometheus.io/scrape" "true" -}}
+{{- $_ := set $annotations "prometheus.io/path" $metrics.path -}}
+{{- $_ := set $annotations "prometheus.io/port" (toString $componentValues.containerPort) -}}
+{{- $templateContext := merge (dict
+      "component" $component
+      "containerName" $componentValues.name
+      "metricsPath" $metrics.path
+      "metricsPort" $componentValues.containerPort
+    ) $root -}}
+{{- $metricsAnnotations := tpl (toYaml $metrics.annotations) $templateContext | fromYaml -}}
+{{- $annotations = mergeOverwrite $annotations (default (dict) $metricsAnnotations) -}}
+{{- end }}
+{{- $annotations = mergeOverwrite $annotations (default (dict) $componentValues.deployment.annotations) -}}
+{{- toYaml $annotations -}}
+{{- end }}
+
+{{/*
 SmithDB OTEL resource attributes.
 */}}
 {{- define "langsmith.smithdb.otelResourceAttributes" -}}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -621,12 +621,12 @@ Args: root, component.
 {{- $annotations := deepCopy (default (dict) $root.Values.commonPodAnnotations) -}}
 {{- if $metrics.enabled }}
 {{- $_ := set $annotations "prometheus.io/scrape" "true" -}}
-{{- $_ := set $annotations "prometheus.io/path" $metrics.path -}}
+{{- $_ := set $annotations "prometheus.io/path" "/metrics" -}}
 {{- $_ := set $annotations "prometheus.io/port" (toString $componentValues.containerPort) -}}
 {{- $templateContext := merge (dict
       "component" $component
       "containerName" $componentValues.name
-      "metricsPath" $metrics.path
+      "metricsPath" "/metrics"
       "metricsPort" $componentValues.containerPort
     ) $root -}}
 {{- $metricsAnnotations := tpl (toYaml $metrics.annotations) $templateContext | fromYaml -}}

--- a/charts/langsmith/templates/smithdb/cluster-manager-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/cluster-manager-deployment.yaml
@@ -26,10 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- include "langsmith.commonPodAnnotations" . | nindent 8 }}
-        {{- with .Values.smithdb.clusterManager.deployment.annotations }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "langsmith.smithdb.podAnnotations" (dict "root" . "component" "clusterManager") | nindent 8 }}
       labels:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "clusterManager") }}

--- a/charts/langsmith/templates/smithdb/compaction-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-deployment.yaml
@@ -26,10 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- include "langsmith.commonPodAnnotations" . | nindent 8 }}
-        {{- with .Values.smithdb.compaction.deployment.annotations }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "langsmith.smithdb.podAnnotations" (dict "root" . "component" "compaction") | nindent 8 }}
       labels:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compaction") }}

--- a/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
@@ -28,10 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- include "langsmith.commonPodAnnotations" . | nindent 8 }}
-        {{- with .Values.smithdb.compactionWorker.deployment.annotations }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "langsmith.smithdb.podAnnotations" (dict "root" . "component" "compactionWorker") | nindent 8 }}
       labels:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compactionWorker") }}

--- a/charts/langsmith/templates/smithdb/ingestion-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/ingestion-deployment.yaml
@@ -30,10 +30,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- include "langsmith.commonPodAnnotations" . | nindent 8 }}
-        {{- with .Values.smithdb.ingestion.deployment.annotations }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "langsmith.smithdb.podAnnotations" (dict "root" . "component" "ingestion") | nindent 8 }}
       labels:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "ingestion") }}

--- a/charts/langsmith/templates/smithdb/query-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/query-deployment.yaml
@@ -30,10 +30,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- include "langsmith.commonPodAnnotations" . | nindent 8 }}
-        {{- with .Values.smithdb.query.deployment.annotations }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "langsmith.smithdb.podAnnotations" (dict "root" . "component" "query") | nindent 8 }}
       labels:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "query") }}

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -127,6 +127,88 @@ tests:
             name: RUST_LOG
             value: warn,smithdb_query=debug,vortex=warn
 
+  - it: should not add SmithDB metrics annotations by default
+    values:
+      - ./values/smithdb-enabled.yaml
+    template: smithdb/query-deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+
+  - it: should configure query metrics scraping and render custom annotations
+    values:
+      - ./values/smithdb-enabled.yaml
+      - ./values/smithdb-metrics.yaml
+    template: smithdb/query-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/path"]
+          value: "/query-metrics"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/port"]
+          value: "8060"
+      - equal:
+          path: spec.template.metadata.annotations["example.com/query"]
+          value: "query:8060/metrics"
+
+  - it: should configure ingestion metrics scraping
+    values:
+      - ./values/smithdb-enabled.yaml
+      - ./values/smithdb-metrics.yaml
+    template: smithdb/ingestion-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/path"]
+          value: "/metrics"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/port"]
+          value: "8050"
+      - equal:
+          path: spec.template.metadata.annotations["example.com/ingestion"]
+          value: "ingestion:8050/metrics"
+
+  - it: should configure compaction metrics scraping
+    values:
+      - ./values/smithdb-enabled.yaml
+      - ./values/smithdb-metrics.yaml
+    template: smithdb/compaction-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/port"]
+          value: "8070"
+      - equal:
+          path: spec.template.metadata.annotations["example.com/compaction"]
+          value: "compaction:8070/metrics"
+
+  - it: should configure compaction worker metrics scraping
+    values:
+      - ./values/smithdb-enabled.yaml
+      - ./values/smithdb-metrics.yaml
+    template: smithdb/compaction-worker-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/port"]
+          value: "9000"
+      - equal:
+          path: spec.template.metadata.annotations["example.com/compaction-worker"]
+          value: "compactionWorker:9000/metrics"
+
+  - it: should configure cluster manager metrics scraping
+    values:
+      - ./values/smithdb-enabled.yaml
+      - ./values/smithdb-metrics.yaml
+    template: smithdb/cluster-manager-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/port"]
+          value: "8090"
+      - equal:
+          path: spec.template.metadata.annotations["example.com/cluster-manager"]
+          value: "clusterManager:8090/metrics"
+
   - it: should keep smithdb services internal
     values:
       - ./values/smithdb-enabled.yaml

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -143,10 +143,10 @@ tests:
     asserts:
       - equal:
           path: spec.template.metadata.annotations["prometheus.io/scrape"]
-          value: "true"
+          value: "false"
       - equal:
           path: spec.template.metadata.annotations["prometheus.io/path"]
-          value: "/query-metrics"
+          value: "/metrics"
       - equal:
           path: spec.template.metadata.annotations["prometheus.io/port"]
           value: "8060"

--- a/charts/langsmith/tests/values/smithdb-metrics.yaml
+++ b/charts/langsmith/tests/values/smithdb-metrics.yaml
@@ -3,10 +3,9 @@ smithdb:
     observability:
       metrics:
         enabled: true
-        path: "/metrics"
         annotations:
           "example.com/{{ .containerName }}": "{{ .component }}:{{ .metricsPort }}{{ .metricsPath }}"
   query:
     deployment:
       annotations:
-        prometheus.io/path: "/query-metrics"
+        prometheus.io/scrape: "false"

--- a/charts/langsmith/tests/values/smithdb-metrics.yaml
+++ b/charts/langsmith/tests/values/smithdb-metrics.yaml
@@ -1,0 +1,12 @@
+smithdb:
+  config:
+    observability:
+      metrics:
+        enabled: true
+        path: "/metrics"
+        annotations:
+          "example.com/{{ .containerName }}": "{{ .component }}:{{ .metricsPort }}{{ .metricsPath }}"
+  query:
+    deployment:
+      annotations:
+        prometheus.io/path: "/query-metrics"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1271,6 +1271,15 @@ smithdb:
       logging:
         # -- Optional SmithDB log filter. Empty uses the chart default: INFO,vortex=WARN.
         level: ""
+      metrics:
+        # -- Add Prometheus scrape annotations to SmithDB component pods.
+        enabled: false
+        # -- HTTP path where SmithDB components expose Prometheus metrics.
+        path: "/metrics"
+        # -- Additional annotations for SmithDB component pods when metrics are enabled.
+        # Values and keys are evaluated as templates with component, containerName,
+        # metricsPath, and metricsPort in scope.
+        annotations: {}
       tracing:
         # -- Enable OpenTelemetry tracing/log export for SmithDB components.
         # SmithDB supports exporting OTLP over gRPC only.

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1274,8 +1274,6 @@ smithdb:
       metrics:
         # -- Add Prometheus scrape annotations to SmithDB component pods.
         enabled: false
-        # -- HTTP path where SmithDB components expose Prometheus metrics.
-        path: "/metrics"
         # -- Additional annotations for SmithDB component pods when metrics are enabled.
         # Values and keys are evaluated as templates with component, containerName,
         # metricsPath, and metricsPort in scope.


### PR DESCRIPTION
## Summary
- add opt-in Prometheus scrape annotations for all five SmithDB services
- support templated custom annotations for provider-specific integrations without duplicating component configuration
- keep the SmithDB metrics endpoint fixed at `/metrics` while preserving component annotation overrides

## Test Plan
- [x] Render metrics annotations for query, ingestion, compaction, compaction worker, and cluster manager with their component ports
- [x] Verify metrics annotations are absent by default and custom/component annotations render with the documented precedence


Made with [Cursor](https://cursor.com)