### PR TITLE
Increase SmithDB compaction scheduler resources

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -937,9 +937,9 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.compaction.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.compaction.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.compaction.deployment.replicas | int | `1` |  |
-| smithdb.compaction.deployment.resources.limits.cpu | string | `"500m"` |  |
+| smithdb.compaction.deployment.resources.limits.cpu | string | `"2"` |  |
 | smithdb.compaction.deployment.resources.limits.memory | string | `"1Gi"` |  |
-| smithdb.compaction.deployment.resources.requests.cpu | string | `"500m"` |  |
+| smithdb.compaction.deployment.resources.requests.cpu | string | `"2"` |  |
 | smithdb.compaction.deployment.resources.requests.memory | string | `"1Gi"` |  |
 | smithdb.compaction.deployment.securityContext | object | `{}` |  |
 | smithdb.compaction.deployment.sidecars | list | `[]` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -938,9 +938,9 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.compaction.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.compaction.deployment.replicas | int | `1` |  |
 | smithdb.compaction.deployment.resources.limits.cpu | string | `"2"` |  |
-| smithdb.compaction.deployment.resources.limits.memory | string | `"1Gi"` |  |
+| smithdb.compaction.deployment.resources.limits.memory | string | `"4Gi"` |  |
 | smithdb.compaction.deployment.resources.requests.cpu | string | `"2"` |  |
-| smithdb.compaction.deployment.resources.requests.memory | string | `"1Gi"` |  |
+| smithdb.compaction.deployment.resources.requests.memory | string | `"4Gi"` |  |
 | smithdb.compaction.deployment.securityContext | object | `{}` |  |
 | smithdb.compaction.deployment.sidecars | list | `[]` |  |
 | smithdb.compaction.deployment.tolerations | list | `[]` |  |

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1468,10 +1468,10 @@ smithdb:
       securityContext: {}
       resources:
         requests:
-          cpu: "500m"
+          cpu: "2"
           memory: "1Gi"
         limits:
-          cpu: "500m"
+          cpu: "2"
           memory: "1Gi"
       probes:
         startupProbe:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1469,10 +1469,10 @@ smithdb:
       resources:
         requests:
           cpu: "2"
-          memory: "1Gi"
+          memory: "4Gi"
         limits:
           cpu: "2"
-          memory: "1Gi"
+          memory: "4Gi"
       probes:
         startupProbe:
           httpGet:


### PR DESCRIPTION
## Summary
- increase the SmithDB compaction scheduler CPU request and limit from 500m to 2 cores
- increase its memory request and limit from 1Gi to 4Gi
- update the generated chart values documentation

The existing scheduler was continuously CPU-throttled and eventually failed its liveness probe under compaction backlog. Datadog showed the healthy replacement using about 1.28 cores on average and peaking around 1.86 cores during catch-up.

## Test plan
- [x] `helm unittest charts/langsmith -f 'tests/langsmith_smithdb_test.yaml'`
- [x] render `templates/smithdb/compaction-deployment.yaml` and verify requests/limits are `2` CPU and `4Gi` memory