### PR TITLE
docs(langsmith): add stable-smithdb example values

### DIFF
--- a/charts/langsmith/examples/stable_smithdb.yaml
+++ b/charts/langsmith/examples/stable_smithdb.yaml
@@ -1,0 +1,78 @@
+# Reference values for a stable SmithDB-only LangSmith deployment.
+#
+# Backend layout:
+#   - ClickHouse fully disabled (no ingestion, no query, no in-chart StatefulSet).
+#   - SmithDB is the sole ingestion and query backend.
+#
+# Feature-flag intent mirrors the "stable-smithdb" column of the internal
+# rollout matrix. Only flags that differ from the LangSmith app code defaults
+# are set here; anything matching the code default is intentionally omitted.
+#
+# Placeholders that operators MUST replace:
+#   - smithdb.config.existingSecretName -> your metastore secret
+#   - smithdb.config.objectStore.bucket -> your S3 (or GCS) bucket
+#
+# Render with:
+#   helm template <rel> charts/langsmith \
+#     -f <your-base-values.yaml> \
+#     -f charts/langsmith/examples/stable_smithdb.yaml
+
+clickhouse:
+  enabled: false
+
+smithdb:
+  enabled: true
+  langsmith:
+    ingestion:
+      enabled: true
+    query:
+      enabled: true
+  config:
+    existingSecretName: smithdb-metastore
+    metastore:
+      hostSecretKey: smithdb_metastore_db_host
+      databaseSecretKey: smithdb_metastore_db_name
+      usernameSecretKey: smithdb_metastore_db_username
+      passwordSecretKey: smithdb_metastore_db_password
+    objectStore:
+      type: s3
+      bucket: SMITHDB_BUCKET
+
+# Feature-flag envs the chart does not natively expose. Injected into each
+# LangSmith app service's Deployment via .deployment.extraEnv. The same set is
+# applied to every service that reads these flags at runtime; SmithDB workloads
+# do not need them (they read their own SMITHDB_* config).
+_smithdbFeatureFlags: &smithdbFeatureFlags
+  - name: SMITHDB_QUERY_SERVICE_MAX_CALL_RECV_MSG_SIZE
+    value: "1073741824"
+  - name: SMITHDB_FEEDBACK_MUTATION_RPS_PER_KEY
+    value: "100"
+  - name: SMITHDB_FEEDBACK_MUTATION_BURST_PER_KEY
+    value: "150"
+  - name: SMITHDB_RULES_REDIS_READ_ENABLED
+    value: "true"
+  - name: SMITHDB_RULES_THREAD_REDIS_READ_ENABLED
+    value: "true"
+  - name: RUN_RULES_SMITHDB_RETRIEVER_TENANTS
+    value: '["*"]'
+  - name: RUN_RULES_SMITHDB_RETRIEVER_PCT
+    value: "100"
+  - name: RUN_RULES_SMITHDB_THREAD_RETRIEVER_TENANTS
+    value: '["*"]'
+  - name: RUN_RULES_SMITHDB_THREAD_RETRIEVER_PCT
+    value: "100"
+  - name: RUN_RULES_TWO_POINTER_BACKFILL_TENANTS
+    value: '["*"]'
+
+backend:
+  deployment:
+    extraEnv: *smithdbFeatureFlags
+hostBackend:
+  deployment:
+    extraEnv: *smithdbFeatureFlags
+queue:
+  deployment:
+    extraEnv: *smithdbFeatureFlags
+ingestQueue:
+  deployment:
+    extraEnv: *smithdbFeatureFlags


### PR DESCRIPTION
## Summary
- Adds `charts/langsmith/examples/stable_smithdb.yaml` documenting the "stable-smithdb" backend configuration: ClickHouse disabled, SmithDB as the sole ingestion/query backend.
- Sets only the flags that differ from LangSmith app code defaults; anything matching a default is intentionally omitted.
- Non-default rollout flags (`SMITHDB_FEEDBACK_MUTATION_*`, `SMITHDB_RULES_*_READ_ENABLED`, `RUN_RULES_SMITHDB_*_RETRIEVER_*`, `RUN_RULES_TWO_POINTER_BACKFILL_TENANTS`, `SMITHDB_QUERY_SERVICE_MAX_CALL_RECV_MSG_SIZE`) are injected via each LangSmith app service's `deployment.extraEnv` slot, since the chart does not natively expose them.

Follow-up PR will add the equivalent `stable_dual` example.

## Test plan
- [x] `helm template audit charts/langsmith -f <base-auth> -f charts/langsmith/examples/stable_smithdb.yaml` renders without error.
- [x] Rendered `-config` ConfigMap contains `SMITHDB_INGESTION_ENABLED=true`, `SMITHDB_QUERY_ENABLED=true`, `CLICKHOUSE_*_ENABLED=false`, `SMITHDB_CLUSTER_MANAGER_ENABLED=true`, and all `SMITHDB_*_SERVICE_URL` values.
- [x] `backend`, `queue`, and `ingestQueue` Deployments carry every FF env from the anchor list; `hostBackend` picks them up when enabled (verified with `--set hostBackend.enabled=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)