### PR TITLE
feat(langsmith): bake stable-smithdb flag defaults into config-map

### DIFF
--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -56,6 +56,15 @@ data:
   {{- if .Values.smithdb.enabled }}
   SMITHDB_CLUSTER_MANAGER_ENABLED: "true"
   SMITHDB_CLUSTER_MANAGER_URL: {{ include "langsmith.smithdb.grpcServiceUrl" (dict "root" . "component" "clusterManager" "port" .Values.smithdb.clusterManager.service.port) | quote }}
+  SMITHDB_QUERY_SERVICE_MAX_CALL_RECV_MSG_SIZE: "1073741824"
+  SMITHDB_FEEDBACK_MUTATION_RPS_PER_KEY: "100"
+  SMITHDB_FEEDBACK_MUTATION_BURST_PER_KEY: "150"
+  SMITHDB_RULES_REDIS_READ_ENABLED: "true"
+  SMITHDB_RULES_THREAD_REDIS_READ_ENABLED: "true"
+  RUN_RULES_SMITHDB_RETRIEVER_TENANTS: '["*"]'
+  RUN_RULES_SMITHDB_RETRIEVER_PCT: "100"
+  RUN_RULES_SMITHDB_THREAD_RETRIEVER_TENANTS: '["*"]'
+  RUN_RULES_SMITHDB_THREAD_RETRIEVER_PCT: "100"
   {{- end }}
   {{- if .Values.config.hostname }}
   # Remote MCP server / OAuth Authorization Server (served under /api). The AS only
@@ -83,6 +92,8 @@ data:
   {{- end }}
   FF_RUN_STATS_GROUP_BY_ENABLED_ALL: "true"
   SEPARATE_QUEUES_WITH_SINGLE_WORKER: '["host"]'
+  RUN_RULES_REDIS_DEDUP_TENANTS: '["*"]'
+  RUN_RULES_LIMIT_RRA_RECORDS_PER_BATCH_TENANTS: '["*"]'
   {{- if .Values.config.observability.tracing.enabled }}
   OTEL_TRACING_ENABLED: "{{ .Values.config.observability.tracing.enabled }}"
   OTLP_ENDPOINT: "{{ .Values.config.observability.tracing.endpoint }}"

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -252,6 +252,39 @@ tests:
       - equal:
           path: data.SMITHDB_MUTATIONS_SERVICE_URL
           value: RELEASE-NAME-langsmith-smithdb-query.NAMESPACE.svc.cluster.local:8080
+      - equal:
+          path: data.SMITHDB_QUERY_SERVICE_MAX_CALL_RECV_MSG_SIZE
+          value: "1073741824"
+      - equal:
+          path: data.SMITHDB_FEEDBACK_MUTATION_RPS_PER_KEY
+          value: "100"
+      - equal:
+          path: data.SMITHDB_FEEDBACK_MUTATION_BURST_PER_KEY
+          value: "150"
+      - equal:
+          path: data.SMITHDB_RULES_REDIS_READ_ENABLED
+          value: "true"
+      - equal:
+          path: data.SMITHDB_RULES_THREAD_REDIS_READ_ENABLED
+          value: "true"
+      - equal:
+          path: data.RUN_RULES_SMITHDB_RETRIEVER_TENANTS
+          value: '["*"]'
+      - equal:
+          path: data.RUN_RULES_SMITHDB_RETRIEVER_PCT
+          value: "100"
+      - equal:
+          path: data.RUN_RULES_SMITHDB_THREAD_RETRIEVER_TENANTS
+          value: '["*"]'
+      - equal:
+          path: data.RUN_RULES_SMITHDB_THREAD_RETRIEVER_PCT
+          value: "100"
+      - equal:
+          path: data.RUN_RULES_REDIS_DEDUP_TENANTS
+          value: '["*"]'
+      - equal:
+          path: data.RUN_RULES_LIMIT_RRA_RECORDS_PER_BATCH_TENANTS
+          value: '["*"]'
 
   - it: should configure SmithDB ingestion without SmithDB query endpoints
     values:
@@ -330,6 +363,26 @@ tests:
           path: data.SMITHDB_CLUSTER_MANAGER_ENABLED
       - notExists:
           path: data.SMITHDB_CLUSTER_MANAGER_URL
+      - notExists:
+          path: data.SMITHDB_QUERY_SERVICE_MAX_CALL_RECV_MSG_SIZE
+      - notExists:
+          path: data.SMITHDB_FEEDBACK_MUTATION_RPS_PER_KEY
+      - notExists:
+          path: data.SMITHDB_RULES_REDIS_READ_ENABLED
+      - notExists:
+          path: data.RUN_RULES_SMITHDB_RETRIEVER_TENANTS
+      - notExists:
+          path: data.RUN_RULES_SMITHDB_RETRIEVER_PCT
+      - notExists:
+          path: data.RUN_RULES_SMITHDB_THREAD_RETRIEVER_TENANTS
+      - notExists:
+          path: data.RUN_RULES_SMITHDB_THREAD_RETRIEVER_PCT
+      - equal:
+          path: data.RUN_RULES_REDIS_DEDUP_TENANTS
+          value: '["*"]'
+      - equal:
+          path: data.RUN_RULES_LIMIT_RRA_RECORDS_PER_BATCH_TENANTS
+          value: '["*"]'
 
   - it: should omit frontend SmithDB v2 endpoint flag when disabled
     values:


### PR DESCRIPTION
## Summary
- Extends `templates/config-map.yaml` to emit the LangSmith app feature-flag envs that differ from code defaults for a stable SmithDB-backed deployment.
- **SMITHDB-named keys** (`SMITHDB_QUERY_SERVICE_MAX_CALL_RECV_MSG_SIZE`, `SMITHDB_FEEDBACK_MUTATION_{RPS,BURST}_PER_KEY`, `SMITHDB_RULES_{,THREAD_}REDIS_READ_ENABLED`, `RUN_RULES_SMITHDB_{,THREAD_}RETRIEVER_{TENANTS,PCT}`) are gated on `.Values.smithdb.enabled`.
- **`RUN_RULES_TWO_POINTER_BACKFILL_TENANTS`** is enabled unconditionally with `["*"]`