### PR TITLE
feat(langsmith): expire ClickHouse system log tables

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.0-rc.17
+version: 0.16.0-rc.20
 appVersion: "0.16.21rc1"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1619,6 +1619,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 |-----|------|---------|-------------|
 | clickhouse.config.allowSimdjson | bool | `true` |  |
 | clickhouse.config.logLevel | string | `"warning"` |  |
+| clickhouse.config.systemLogTtlDays | int | `30` |  |
 | clickhouse.containerHttpPort | int | `8123` |  |
 | clickhouse.containerNativePort | int | `9000` |  |
 | clickhouse.disableSecretCreation | bool | `false` |  |
@@ -1705,6 +1706,16 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | clickhouse.statefulSet.updateStrategy | object | `{}` | Leave unset to keep the Kubernetes default RollingUpdate behavior. |
 | clickhouse.statefulSet.volumeMounts | list | `[]` |  |
 | clickhouse.statefulSet.volumes | list | `[]` |  |
+| clickhouse.systemLogTtlJob.affinity | object | `{}` |  |
+| clickhouse.systemLogTtlJob.annotations | object | `{}` |  |
+| clickhouse.systemLogTtlJob.labels | object | `{}` |  |
+| clickhouse.systemLogTtlJob.nodeSelector | object | `{}` |  |
+| clickhouse.systemLogTtlJob.resources.limits.cpu | string | `"200m"` |  |
+| clickhouse.systemLogTtlJob.resources.limits.memory | string | `"256Mi"` |  |
+| clickhouse.systemLogTtlJob.resources.requests.cpu | string | `"50m"` |  |
+| clickhouse.systemLogTtlJob.resources.requests.memory | string | `"128Mi"` |  |
+| clickhouse.systemLogTtlJob.tolerations | list | `[]` |  |
+| clickhouse.systemLogTtlJob.ttlSecondsAfterFinished | int | `600` |  |
 
 ## E2E Test
 

--- a/charts/langsmith/templates/clickhouse/config-map.yaml
+++ b/charts/langsmith/templates/clickhouse/config-map.yaml
@@ -78,9 +78,19 @@ data:
         <ttl>event_date + INTERVAL {{ $.Values.clickhouse.config.systemLogTtlDays }} DAY DELETE</ttl>
       </{{ $log }}>
       {{- end }}
-      {{- /* opentelemetry_span_log has no event_date column; it dates on finish_date. */}}
+      {{- /* opentelemetry_span_log is the one log table ClickHouse ships an <engine>
+             for, and it rejects <ttl> alongside <engine> ("TTL parameters should be
+             specified directly inside 'engine'") by refusing to start. So restate the
+             stock engine with the TTL folded in. It has no event_date column and
+             sorts on finish time, which is why its engine is special in the first
+             place. Keep partition/order by in sync with ClickHouse's config.xml. */}}
       <opentelemetry_span_log>
-        <ttl>finish_date + INTERVAL {{ .Values.clickhouse.config.systemLogTtlDays }} DAY DELETE</ttl>
+        <engine>
+            engine MergeTree
+            partition by toYYYYMM(finish_date)
+            order by (finish_date, finish_time_us)
+            ttl finish_date + INTERVAL {{ .Values.clickhouse.config.systemLogTtlDays }} DAY DELETE
+        </engine>
       </opentelemetry_span_log>
     </clickhouse>
 {{- end }}

--- a/charts/langsmith/templates/clickhouse/config-map.yaml
+++ b/charts/langsmith/templates/clickhouse/config-map.yaml
@@ -67,4 +67,21 @@ data:
         <errors>true</errors>
       </prometheus>
     </clickhouse>
+{{- if .Values.clickhouse.config.systemLogTtlDays }}
+
+  system_logs.xml: |
+    <clickhouse>
+      {{- /* ClickHouse never expires its own log tables by default, so they grow
+             without bound until they fill the volume. */}}
+      {{- range $log := list "asynchronous_insert_log" "asynchronous_metric_log" "backup_log" "background_schedule_pool_log" "blob_storage_log" "error_log" "latency_log" "metric_log" "part_log" "processors_profile_log" "query_log" "query_metric_log" "query_thread_log" "query_views_log" "text_log" "trace_log" }}
+      <{{ $log }}>
+        <ttl>event_date + INTERVAL {{ $.Values.clickhouse.config.systemLogTtlDays }} DAY DELETE</ttl>
+      </{{ $log }}>
+      {{- end }}
+      {{- /* opentelemetry_span_log has no event_date column; it dates on finish_date. */}}
+      <opentelemetry_span_log>
+        <ttl>finish_date + INTERVAL {{ .Values.clickhouse.config.systemLogTtlDays }} DAY DELETE</ttl>
+      </opentelemetry_span_log>
+    </clickhouse>
+{{- end }}
 {{- end }}

--- a/charts/langsmith/templates/clickhouse/stateful-set.yaml
+++ b/charts/langsmith/templates/clickhouse/stateful-set.yaml
@@ -137,6 +137,11 @@ spec:
             - mountPath: /etc/clickhouse-server/config.d/metrics_config.xml
               name: clickhouse-conf
               subPath: metrics_config.xml
+          {{- if .Values.clickhouse.config.systemLogTtlDays }}
+            - mountPath: /etc/clickhouse-server/config.d/system_logs.xml
+              name: clickhouse-conf
+              subPath: system_logs.xml
+          {{- end }}
           {{- with .Values.clickhouse.statefulSet.extraContainerConfig }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
@@ -170,6 +175,10 @@ spec:
                 path: logging_config.xml
               - key: metrics_config.xml
                 path: metrics_config.xml
+              {{- if .Values.clickhouse.config.systemLogTtlDays }}
+              - key: system_logs.xml
+                path: system_logs.xml
+              {{- end }}
       {{- with $volumes }}
           {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/langsmith/templates/clickhouse/system-log-ttl-job.yaml
+++ b/charts/langsmith/templates/clickhouse/system-log-ttl-job.yaml
@@ -1,0 +1,110 @@
+{{- if and .Values.clickhouse.enabled .Values.clickhouse.config.systemLogTtlDays }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "langsmith.fullname" . }}-{{ .Values.clickhouse.name }}-log-ttl
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "langsmith.labels" . | nindent 4 }}
+    {{- with .Values.clickhouse.systemLogTtlJob.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    # Runs after ClickHouse is serving. The server-side <ttl> config only takes
+    # effect for tables ClickHouse creates, so tables that already exist keep
+    # growing forever. This applies the same TTL to them retroactively.
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "argocd.argoproj.io/hook": "PostSync"
+    "argocd.argoproj.io/hook-delete-policy": "BeforeHookCreation"
+    {{- include "langsmith.annotations" . | nindent 4 }}
+    {{- with .Values.clickhouse.systemLogTtlJob.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: {{ .Values.clickhouse.systemLogTtlJob.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- with .Values.clickhouse.systemLogTtlJob.labels }}
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- include "langsmith.labels" . | nindent 8 }}
+        app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.clickhouse.name }}-log-ttl
+    spec:
+      restartPolicy: Never
+      {{- with .Values.images.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: log-ttl
+          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "clickhouseImage") | quote }}
+          imagePullPolicy: {{ .Values.images.clickhouseImage.pullPolicy }}
+          env:
+            - name: CLICKHOUSE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "langsmith.clickhouseSecretsName" . }}
+                  key: clickhouse_host
+            - name: CLICKHOUSE_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "langsmith.clickhouseSecretsName" . }}
+                  key: clickhouse_native_port
+            - name: CLICKHOUSE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "langsmith.clickhouseSecretsName" . }}
+                  key: clickhouse_user
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "langsmith.clickhouseSecretsName" . }}
+                  key: clickhouse_password
+            - name: TTL_DAYS
+              value: {{ .Values.clickhouse.config.systemLogTtlDays | quote }}
+          resources:
+            {{- toYaml .Values.clickhouse.systemLogTtlJob.resources | nindent 12 }}
+          command:
+            - /bin/bash
+            - -c
+            - |
+              # Deliberately never fails the release. A TTL that did not apply is
+              # a disk-space problem to chase later, not a reason to block an
+              # upgrade or leave the release in a failed state.
+              set -u
+              ch() {
+                clickhouse-client --host "$CLICKHOUSE_HOST" --port "$CLICKHOUSE_PORT" \
+                  --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" "$@"
+              }
+              tables=$(ch --query "SELECT name FROM system.tables WHERE database='system' AND engine LIKE '%MergeTree' AND match(name, '_log\$') FORMAT TabSeparated" 2>/dev/null)
+              if [ -z "$tables" ]; then
+                echo "no system log tables found (ClickHouse unreachable or none present); nothing to do"
+                exit 0
+              fi
+              for t in $tables; do
+                # opentelemetry_span_log has no event_date column; it dates on finish_date.
+                col=event_date
+                [ "$t" = "opentelemetry_span_log" ] && col=finish_date
+                if ch --query "ALTER TABLE system.\`$t\` MODIFY TTL ${col} + INTERVAL ${TTL_DAYS} DAY DELETE" >/dev/null 2>&1; then
+                  echo "ttl applied: system.$t (${col} + ${TTL_DAYS}d)"
+                else
+                  echo "ttl skipped: system.$t"
+                fi
+              done
+              exit 0
+      {{- with .Values.clickhouse.systemLogTtlJob.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.clickhouse.systemLogTtlJob.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.clickhouse.systemLogTtlJob.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/langsmith/tests/clickhouse_system_log_ttl_test.yaml
+++ b/charts/langsmith/tests/clickhouse_system_log_ttl_test.yaml
@@ -1,0 +1,84 @@
+suite: ClickHouse system log TTL
+templates:
+  - clickhouse/config-map.yaml
+  - clickhouse/system-log-ttl-job.yaml
+  - clickhouse/stateful-set.yaml
+tests:
+  - it: renders system_logs.xml with the configured retention
+    template: clickhouse/config-map.yaml
+    asserts:
+      - matchRegex:
+          path: data["system_logs.xml"]
+          pattern: "<query_log>\\s*<ttl>event_date \\+ INTERVAL 30 DAY DELETE</ttl>"
+
+  - it: dates opentelemetry_span_log on finish_date, not event_date
+    template: clickhouse/config-map.yaml
+    asserts:
+      - matchRegex:
+          path: data["system_logs.xml"]
+          pattern: "<opentelemetry_span_log>\\s*<ttl>finish_date \\+ INTERVAL 30 DAY DELETE</ttl>"
+
+  - it: honours a custom retention
+    template: clickhouse/config-map.yaml
+    set:
+      clickhouse.config.systemLogTtlDays: 7
+    asserts:
+      - matchRegex:
+          path: data["system_logs.xml"]
+          pattern: "<ttl>event_date \\+ INTERVAL 7 DAY DELETE</ttl>"
+
+  - it: omits system_logs.xml when retention is unset
+    template: clickhouse/config-map.yaml
+    set:
+      clickhouse.config.systemLogTtlDays: 0
+    asserts:
+      - notExists:
+          path: data["system_logs.xml"]
+
+  - it: mounts system_logs.xml into the ClickHouse container
+    template: clickhouse/stateful-set.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /etc/clickhouse-server/config.d/system_logs.xml
+            name: clickhouse-conf
+            subPath: system_logs.xml
+
+  - it: does not mount system_logs.xml when retention is unset
+    template: clickhouse/stateful-set.yaml
+    set:
+      clickhouse.config.systemLogTtlDays: 0
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /etc/clickhouse-server/config.d/system_logs.xml
+            name: clickhouse-conf
+            subPath: system_logs.xml
+
+  - it: renders the retroactive TTL job as a post-install/post-upgrade hook
+    template: clickhouse/system-log-ttl-job.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install, post-upgrade
+      - equal:
+          path: spec.template.spec.containers[0].env[4].value
+          value: "30"
+
+  - it: omits the retroactive TTL job when retention is unset
+    template: clickhouse/system-log-ttl-job.yaml
+    set:
+      clickhouse.config.systemLogTtlDays: 0
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: omits the retroactive TTL job when clickhouse is disabled
+    template: clickhouse/system-log-ttl-job.yaml
+    set:
+      clickhouse.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/langsmith/tests/clickhouse_system_log_ttl_test.yaml
+++ b/charts/langsmith/tests/clickhouse_system_log_ttl_test.yaml
@@ -11,12 +11,23 @@ tests:
           path: data["system_logs.xml"]
           pattern: "<query_log>\\s*<ttl>event_date \\+ INTERVAL 30 DAY DELETE</ttl>"
 
-  - it: dates opentelemetry_span_log on finish_date, not event_date
+  # ClickHouse ships an <engine> for this table and refuses to start if <ttl> is
+  # set alongside it, so the TTL has to live inside the engine spec.
+  - it: folds the TTL into the opentelemetry_span_log engine, dating on finish_date
     template: clickhouse/config-map.yaml
     asserts:
       - matchRegex:
           path: data["system_logs.xml"]
-          pattern: "<opentelemetry_span_log>\\s*<ttl>finish_date \\+ INTERVAL 30 DAY DELETE</ttl>"
+          pattern: "<opentelemetry_span_log>\\s*<engine>"
+      - matchRegex:
+          path: data["system_logs.xml"]
+          pattern: "ttl finish_date \\+ INTERVAL 30 DAY DELETE\\s*</engine>"
+      - matchRegex:
+          path: data["system_logs.xml"]
+          pattern: "partition by toYYYYMM\\(finish_date\\)"
+      - notMatchRegex:
+          path: data["system_logs.xml"]
+          pattern: "<opentelemetry_span_log>\\s*<ttl>"
 
   - it: honours a custom retention
     template: clickhouse/config-map.yaml

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -2048,6 +2048,27 @@ clickhouse:
   config:
     allowSimdjson: true
     logLevel: "warning"
+    # Retention for ClickHouse's own system.*_log tables. ClickHouse does not
+    # expire them by default, so they grow until they fill the data volume.
+    # Applied to new tables via server config and to existing tables by the
+    # systemLogTtlJob below. Set to 0/null to leave retention unmanaged.
+    systemLogTtlDays: 30
+  # Post-install/upgrade Job that applies systemLogTtlDays to system log tables
+  # that already exist. It never fails the release.
+  systemLogTtlJob:
+    ttlSecondsAfterFinished: 600
+    labels: {}
+    annotations: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    resources:
+      limits:
+        cpu: 200m
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 128Mi
   external:
     # If enabled, use the following values to connect to an external database. This will also disable the
     # creation of a clickhouse stateful-set and service.


### PR DESCRIPTION
## Problem

ClickHouse does not expire its own `system.*_log` tables. On a long-lived install they grow until they fill the data volume.

Measured on one cluster that hit **96% disk**:

| | On disk |
|---|---|
| `system` (ClickHouse's own logs) | **413.78 GiB** |
| `default` (actual application data) | 48.44 GiB |

`system.opentelemetry_span_log` alone was 154 GiB, with entries dating back 11 months. On top of that, 27 orphaned `*_log_N` tables held another 134 GiB — ClickHouse renames a log table to `<name>_N` when its definition changes on upgrade and then never writes to or cleans up the old one. One cluster had eight generations of `trace_log`.

## Fix

New value `clickhouse.config.systemLogTtlDays`, default `30`, applied through two mechanisms:

- **`system_logs.xml`** sets `<ttl>` per log table. ClickHouse honours this for tables it creates — fresh installs, and tables recreated on upgrade.
- **A post-install/post-upgrade Job** runs `ALTER TABLE ... MODIFY TTL` against tables that already exist.

Both are required. The server config is not retroactive: it only takes effect at table creation, so an existing install would keep its unbounded tables indefinitely. Conversely the Job alone would be undone whenever ClickHouse recreates a table.

`opentelemetry_span_log` is special-cased — it has no `event_date` column and dates on `finish_date`.

Set the value to `0` to opt out entirely; the config file, the mount, and the Job all disappear.

## The Job cannot fail a release

It always `exit 0`, and each `ALTER` is individually tolerated. A TTL that did not apply is a disk-space problem to chase later, not a reason to block an upgrade or strand a release in a failed state. It also no-ops cleanly when ClickHouse is unreachable.

## Test Plan

- [x] New `tests/clickhouse_system_log_ttl_test.yaml` — 9 cases: config rendering, the `finish_date` special case, custom retention, the STS mount, and that config/mount/Job all vanish when the value is `0` or ClickHouse is disabled
- [x] Full chart suite green — 126 tests, 11 suites
- [x] `helm lint` clean against a real production values file
- [x] The Job's discovery query run against a live ClickHouse 25.12 returns exactly the 14 active log tables and no orphans
- [x] The Job's script executed end-to-end against that live instance: all 14 tables altered, and idempotent on re-run
- [x] README regenerated with `helm-docs` (+11 lines, no unrelated churn)


---

### Correction after CI

The first push used a plain `<ttl>` element for every log table. `ct install` caught that this makes **ClickHouse refuse to start**:

```
Code: 36. DB::Exception: If 'engine' is specified for system table, TTL parameters
should be specified directly inside 'engine' and 'ttl' setting doesn't make sense
  createSystemLog<DB::OpenTelemetrySpanLog>
```

`opentelemetry_span_log` is the one log table ClickHouse ships an `<engine>` for — it has no `event_date` column and sorts on finish time, so stock `config.xml` overrides its engine and notes "the default table creation code is insufficient". A sibling `<ttl>` is rejected outright.

Fixed by restating that engine with the TTL folded in, preserving the stock partition and ordering. Every other log table keeps the plain `<ttl>` form. Verified the resulting DDL against a live ClickHouse 25.12, which normalises it to `TTL finish_date + toIntervalDay(30)`.
