### PR TITLE
feat: backport agent IAM providers to v16-stable

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.0-rc.17
+version: 0.16.0-rc.18
 appVersion: "0.16.22rc1"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.16.0-rc.17](https://img.shields.io/badge/Version-0.16.0--rc.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.22rc1](https://img.shields.io/badge/AppVersion-0.16.22rc1-informational?style=flat-square)
+![Version: 0.16.0-rc.18](https://img.shields.io/badge/Version-0.16.0--rc.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.22rc1](https://img.shields.io/badge/AppVersion-0.16.22rc1-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -96,11 +96,11 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | fleet.postgres.external.enabled | bool | `false` |  |
 | fleet.postgres.external.existingSecretName | string | `""` |  |
 | fleet.postgres.external.host | string | `""` |  |
+| fleet.postgres.external.iamProvider | string | `""` |  |
 | fleet.postgres.external.password | string | `"postgres"` |  |
 | fleet.postgres.external.port | string | `"5432"` |  |
 | fleet.postgres.external.schema | string | `"public"` |  |
 | fleet.postgres.external.user | string | `"postgres"` |  |
-| fleet.postgres.iamProvider | string | `""` |  |
 | fleet.postgres.name | string | `"postgres"` |  |
 | fleet.postgres.pdb.enabled | bool | `false` |  |
 | fleet.postgres.pdb.minAvailable | int | `1` |  |
@@ -190,7 +190,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | fleet.redis.external.connectionUrl | string | `""` |  |
 | fleet.redis.external.enabled | bool | `false` |  |
 | fleet.redis.external.existingSecretName | string | `""` |  |
-| fleet.redis.iamProvider | string | `""` |  |
+| fleet.redis.external.iamProvider | string | `""` |  |
 | fleet.redis.name | string | `"redis"` |  |
 | fleet.redis.pdb.enabled | bool | `false` |  |
 | fleet.redis.pdb.minAvailable | int | `1` |  |
@@ -526,11 +526,11 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | insights.postgres.external.enabled | bool | `false` |  |
 | insights.postgres.external.existingSecretName | string | `""` |  |
 | insights.postgres.external.host | string | `""` |  |
+| insights.postgres.external.iamProvider | string | `""` |  |
 | insights.postgres.external.password | string | `"postgres"` |  |
 | insights.postgres.external.port | string | `"5432"` |  |
 | insights.postgres.external.schema | string | `"public"` |  |
 | insights.postgres.external.user | string | `"postgres"` |  |
-| insights.postgres.iamProvider | string | `""` |  |
 | insights.postgres.name | string | `"postgres"` |  |
 | insights.postgres.pdb.enabled | bool | `false` |  |
 | insights.postgres.pdb.minAvailable | int | `1` |  |
@@ -620,7 +620,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | insights.redis.external.connectionUrl | string | `""` |  |
 | insights.redis.external.enabled | bool | `false` |  |
 | insights.redis.external.existingSecretName | string | `""` |  |
-| insights.redis.iamProvider | string | `""` |  |
+| insights.redis.external.iamProvider | string | `""` |  |
 | insights.redis.name | string | `"redis"` |  |
 | insights.redis.pdb.enabled | bool | `false` |  |
 | insights.redis.pdb.minAvailable | int | `1` |  |
@@ -726,11 +726,11 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | polly.postgres.external.enabled | bool | `false` |  |
 | polly.postgres.external.existingSecretName | string | `""` |  |
 | polly.postgres.external.host | string | `""` |  |
+| polly.postgres.external.iamProvider | string | `""` |  |
 | polly.postgres.external.password | string | `"postgres"` |  |
 | polly.postgres.external.port | string | `"5432"` |  |
 | polly.postgres.external.schema | string | `"public"` |  |
 | polly.postgres.external.user | string | `"postgres"` |  |
-| polly.postgres.iamProvider | string | `""` |  |
 | polly.postgres.name | string | `"postgres"` |  |
 | polly.postgres.pdb.enabled | bool | `false` |  |
 | polly.postgres.pdb.minAvailable | int | `1` |  |
@@ -820,7 +820,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | polly.redis.external.connectionUrl | string | `""` |  |
 | polly.redis.external.enabled | bool | `false` |  |
 | polly.redis.external.existingSecretName | string | `""` |  |
-| polly.redis.iamProvider | string | `""` |  |
+| polly.redis.external.iamProvider | string | `""` |  |
 | polly.redis.name | string | `"redis"` |  |
 | polly.redis.pdb.enabled | bool | `false` |  |
 | polly.redis.pdb.minAvailable | int | `1` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -100,6 +100,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | fleet.postgres.external.port | string | `"5432"` |  |
 | fleet.postgres.external.schema | string | `"public"` |  |
 | fleet.postgres.external.user | string | `"postgres"` |  |
+| fleet.postgres.iamProvider | string | `""` |  |
 | fleet.postgres.name | string | `"postgres"` |  |
 | fleet.postgres.pdb.enabled | bool | `false` |  |
 | fleet.postgres.pdb.minAvailable | int | `1` |  |
@@ -189,6 +190,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | fleet.redis.external.connectionUrl | string | `""` |  |
 | fleet.redis.external.enabled | bool | `false` |  |
 | fleet.redis.external.existingSecretName | string | `""` |  |
+| fleet.redis.iamProvider | string | `""` |  |
 | fleet.redis.name | string | `"redis"` |  |
 | fleet.redis.pdb.enabled | bool | `false` |  |
 | fleet.redis.pdb.minAvailable | int | `1` |  |
@@ -528,6 +530,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | insights.postgres.external.port | string | `"5432"` |  |
 | insights.postgres.external.schema | string | `"public"` |  |
 | insights.postgres.external.user | string | `"postgres"` |  |
+| insights.postgres.iamProvider | string | `""` |  |
 | insights.postgres.name | string | `"postgres"` |  |
 | insights.postgres.pdb.enabled | bool | `false` |  |
 | insights.postgres.pdb.minAvailable | int | `1` |  |
@@ -617,6 +620,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | insights.redis.external.connectionUrl | string | `""` |  |
 | insights.redis.external.enabled | bool | `false` |  |
 | insights.redis.external.existingSecretName | string | `""` |  |
+| insights.redis.iamProvider | string | `""` |  |
 | insights.redis.name | string | `"redis"` |  |
 | insights.redis.pdb.enabled | bool | `false` |  |
 | insights.redis.pdb.minAvailable | int | `1` |  |
@@ -726,6 +730,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | polly.postgres.external.port | string | `"5432"` |  |
 | polly.postgres.external.schema | string | `"public"` |  |
 | polly.postgres.external.user | string | `"postgres"` |  |
+| polly.postgres.iamProvider | string | `""` |  |
 | polly.postgres.name | string | `"postgres"` |  |
 | polly.postgres.pdb.enabled | bool | `false` |  |
 | polly.postgres.pdb.minAvailable | int | `1` |  |
@@ -815,6 +820,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | polly.redis.external.connectionUrl | string | `""` |  |
 | polly.redis.external.enabled | bool | `false` |  |
 | polly.redis.external.existingSecretName | string | `""` |  |
+| polly.redis.iamProvider | string | `""` |  |
 | polly.redis.name | string | `"redis"` |  |
 | polly.redis.pdb.enabled | bool | `false` |  |
 | polly.redis.pdb.minAvailable | int | `1` |  |

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -1040,6 +1040,12 @@ Extra env vars for fleet api-server and queue pods.
   (dict "name" "SSRF_ALLOW_PRIVATE_IPS_TOOLS" "value" "true")
   (dict "name" "SSRF_ALLOW_K8S_INTERNAL" "value" "true")
 -}}
+{{- if $feature.postgres.iamProvider -}}
+{{- $out = append $out (dict "name" "AGENT_POSTGRES_IAM_AUTH_PROVIDER" "value" $feature.postgres.iamProvider) -}}
+{{- end -}}
+{{- if $feature.redis.iamProvider -}}
+{{- $out = append $out (dict "name" "AGENT_REDIS_IAM_AUTH_PROVIDER" "value" $feature.redis.iamProvider) -}}
+{{- end -}}
 {{- if and (eq $componentName "apiServer") $feature.queue.enabled -}}
 {{- $out = append $out (dict "name" "N_JOBS_PER_WORKER" "value" "0") -}}
 {{- else -}}
@@ -1065,6 +1071,12 @@ Extra env vars for insights api-server and queue pods.
   (dict "name" "REDIS_URI" "valueFrom" (dict "secretKeyRef" (dict "name" (include "langsmith.agentFeatures.redisSecretName" (dict "root" $root "product" "insights")) "key" "redis_connection_url")))
   (dict "name" "LANGSMITH_TRACING" "value" "false")
 -}}
+{{- if $feature.postgres.iamProvider -}}
+{{- $out = append $out (dict "name" "AGENT_POSTGRES_IAM_AUTH_PROVIDER" "value" $feature.postgres.iamProvider) -}}
+{{- end -}}
+{{- if $feature.redis.iamProvider -}}
+{{- $out = append $out (dict "name" "AGENT_REDIS_IAM_AUTH_PROVIDER" "value" $feature.redis.iamProvider) -}}
+{{- end -}}
 {{- if and (eq $componentName "apiServer") $feature.queue.enabled -}}
 {{- $out = append $out (dict "name" "N_JOBS_PER_WORKER" "value" "0") -}}
 {{- else -}}
@@ -1092,6 +1104,12 @@ Extra env vars for polly api-server and queue pods.
   (dict "name" "LANGSMITH_DISABLE_RUN_COMPRESSION" "value" "true")
   (dict "name" "LANGSMITH_TRACING" "value" (ternary "false" "true" $feature.enableTracing))
 -}}
+{{- if $feature.postgres.iamProvider -}}
+{{- $out = append $out (dict "name" "AGENT_POSTGRES_IAM_AUTH_PROVIDER" "value" $feature.postgres.iamProvider) -}}
+{{- end -}}
+{{- if $feature.redis.iamProvider -}}
+{{- $out = append $out (dict "name" "AGENT_REDIS_IAM_AUTH_PROVIDER" "value" $feature.redis.iamProvider) -}}
+{{- end -}}
 {{- if and (eq $componentName "apiServer") $feature.queue.enabled -}}
 {{- $out = append $out (dict "name" "N_JOBS_PER_WORKER" "value" "0") -}}
 {{- else -}}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -1040,11 +1040,11 @@ Extra env vars for fleet api-server and queue pods.
   (dict "name" "SSRF_ALLOW_PRIVATE_IPS_TOOLS" "value" "true")
   (dict "name" "SSRF_ALLOW_K8S_INTERNAL" "value" "true")
 -}}
-{{- if $feature.postgres.iamProvider -}}
-{{- $out = append $out (dict "name" "AGENT_POSTGRES_IAM_AUTH_PROVIDER" "value" $feature.postgres.iamProvider) -}}
+{{- if $feature.postgres.external.iamProvider -}}
+{{- $out = append $out (dict "name" "AGENT_POSTGRES_IAM_AUTH_PROVIDER" "value" $feature.postgres.external.iamProvider) -}}
 {{- end -}}
-{{- if $feature.redis.iamProvider -}}
-{{- $out = append $out (dict "name" "AGENT_REDIS_IAM_AUTH_PROVIDER" "value" $feature.redis.iamProvider) -}}
+{{- if $feature.redis.external.iamProvider -}}
+{{- $out = append $out (dict "name" "AGENT_REDIS_IAM_AUTH_PROVIDER" "value" $feature.redis.external.iamProvider) -}}
 {{- end -}}
 {{- if and (eq $componentName "apiServer") $feature.queue.enabled -}}
 {{- $out = append $out (dict "name" "N_JOBS_PER_WORKER" "value" "0") -}}
@@ -1071,11 +1071,11 @@ Extra env vars for insights api-server and queue pods.
   (dict "name" "REDIS_URI" "valueFrom" (dict "secretKeyRef" (dict "name" (include "langsmith.agentFeatures.redisSecretName" (dict "root" $root "product" "insights")) "key" "redis_connection_url")))
   (dict "name" "LANGSMITH_TRACING" "value" "false")
 -}}
-{{- if $feature.postgres.iamProvider -}}
-{{- $out = append $out (dict "name" "AGENT_POSTGRES_IAM_AUTH_PROVIDER" "value" $feature.postgres.iamProvider) -}}
+{{- if $feature.postgres.external.iamProvider -}}
+{{- $out = append $out (dict "name" "AGENT_POSTGRES_IAM_AUTH_PROVIDER" "value" $feature.postgres.external.iamProvider) -}}
 {{- end -}}
-{{- if $feature.redis.iamProvider -}}
-{{- $out = append $out (dict "name" "AGENT_REDIS_IAM_AUTH_PROVIDER" "value" $feature.redis.iamProvider) -}}
+{{- if $feature.redis.external.iamProvider -}}
+{{- $out = append $out (dict "name" "AGENT_REDIS_IAM_AUTH_PROVIDER" "value" $feature.redis.external.iamProvider) -}}
 {{- end -}}
 {{- if and (eq $componentName "apiServer") $feature.queue.enabled -}}
 {{- $out = append $out (dict "name" "N_JOBS_PER_WORKER" "value" "0") -}}
@@ -1104,11 +1104,11 @@ Extra env vars for polly api-server and queue pods.
   (dict "name" "LANGSMITH_DISABLE_RUN_COMPRESSION" "value" "true")
   (dict "name" "LANGSMITH_TRACING" "value" (ternary "false" "true" $feature.enableTracing))
 -}}
-{{- if $feature.postgres.iamProvider -}}
-{{- $out = append $out (dict "name" "AGENT_POSTGRES_IAM_AUTH_PROVIDER" "value" $feature.postgres.iamProvider) -}}
+{{- if $feature.postgres.external.iamProvider -}}
+{{- $out = append $out (dict "name" "AGENT_POSTGRES_IAM_AUTH_PROVIDER" "value" $feature.postgres.external.iamProvider) -}}
 {{- end -}}
-{{- if $feature.redis.iamProvider -}}
-{{- $out = append $out (dict "name" "AGENT_REDIS_IAM_AUTH_PROVIDER" "value" $feature.redis.iamProvider) -}}
+{{- if $feature.redis.external.iamProvider -}}
+{{- $out = append $out (dict "name" "AGENT_REDIS_IAM_AUTH_PROVIDER" "value" $feature.redis.external.iamProvider) -}}
 {{- end -}}
 {{- if and (eq $componentName "apiServer") $feature.queue.enabled -}}
 {{- $out = append $out (dict "name" "N_JOBS_PER_WORKER" "value" "0") -}}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -437,6 +437,13 @@ AWS Marketplace Helm template verification).
 {{- range $pair := $agentPairs }}
 {{- $fn := index $pair "n" }}
 {{- $feat := index $.Values $fn }}
+{{- range $database := list "postgres" "redis" }}
+{{- $databaseConfig := index $feat $database }}
+{{- $provider := $databaseConfig.iamProvider }}
+{{- if and $provider (not (has $provider (list "azure" "gcp" "aws"))) }}
+{{- fail (printf "%s.%s.iamProvider must be one of [azure, gcp, aws]" $fn $database) }}
+{{- end }}
+{{- end }}
 {{- if $feat.enabled }}
 {{- if and (not $feat.encryptionKey) (not $.Values.config.existingSecretName) }}
 {{- fail (printf "%s.encryptionKey is required when %s.enabled is true (not needed if config.existingSecretName is set with the key already present)" $fn $fn) }}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -439,9 +439,9 @@ AWS Marketplace Helm template verification).
 {{- $feat := index $.Values $fn }}
 {{- range $database := list "postgres" "redis" }}
 {{- $databaseConfig := index $feat $database }}
-{{- $provider := $databaseConfig.iamProvider }}
+{{- $provider := $databaseConfig.external.iamProvider }}
 {{- if and $provider (not (has $provider (list "azure" "gcp" "aws"))) }}
-{{- fail (printf "%s.%s.iamProvider must be one of [azure, gcp, aws]" $fn $database) }}
+{{- fail (printf "%s.%s.external.iamProvider must be one of [azure, gcp, aws]" $fn $database) }}
 {{- end }}
 {{- end }}
 {{- if $feat.enabled }}

--- a/charts/langsmith/tests/agent_iam_provider_test.yaml
+++ b/charts/langsmith/tests/agent_iam_provider_test.yaml
@@ -1,0 +1,95 @@
+suite: agent IAM provider environment variables
+templates:
+  - agent-features/fleet/api-server/deployment.yaml
+  - agent-features/fleet/queue/deployment.yaml
+  - agent-features/insights/api-server/deployment.yaml
+  - agent-features/insights/queue/deployment.yaml
+  - agent-features/polly/api-server/deployment.yaml
+  - agent-features/polly/queue/deployment.yaml
+set:
+  fleet.enabled: true
+  fleet.postgres.iamProvider: "fleet-postgres"
+  fleet.redis.iamProvider: "fleet-redis"
+  insights.postgres.iamProvider: "insights-postgres"
+  insights.redis.iamProvider: "insights-redis"
+  polly.postgres.iamProvider: "polly-postgres"
+  polly.redis.iamProvider: "polly-redis"
+tests:
+  - it: maps fleet IAM providers to the api-server
+    template: agent-features/fleet/api-server/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AGENT_POSTGRES_IAM_AUTH_PROVIDER
+            value: fleet-postgres
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AGENT_REDIS_IAM_AUTH_PROVIDER
+            value: fleet-redis
+  - it: maps fleet IAM providers to the queue
+    template: agent-features/fleet/queue/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AGENT_POSTGRES_IAM_AUTH_PROVIDER
+            value: fleet-postgres
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AGENT_REDIS_IAM_AUTH_PROVIDER
+            value: fleet-redis
+  - it: maps insights IAM providers to the api-server
+    template: agent-features/insights/api-server/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AGENT_POSTGRES_IAM_AUTH_PROVIDER
+            value: insights-postgres
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AGENT_REDIS_IAM_AUTH_PROVIDER
+            value: insights-redis
+  - it: maps insights IAM providers to the queue
+    template: agent-features/insights/queue/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AGENT_POSTGRES_IAM_AUTH_PROVIDER
+            value: insights-postgres
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AGENT_REDIS_IAM_AUTH_PROVIDER
+            value: insights-redis
+  - it: maps polly IAM providers to the api-server
+    template: agent-features/polly/api-server/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AGENT_POSTGRES_IAM_AUTH_PROVIDER
+            value: polly-postgres
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AGENT_REDIS_IAM_AUTH_PROVIDER
+            value: polly-redis
+  - it: maps polly IAM providers to the queue
+    template: agent-features/polly/queue/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AGENT_POSTGRES_IAM_AUTH_PROVIDER
+            value: polly-postgres
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AGENT_REDIS_IAM_AUTH_PROVIDER
+            value: polly-redis

--- a/charts/langsmith/tests/agent_iam_provider_test.yaml
+++ b/charts/langsmith/tests/agent_iam_provider_test.yaml
@@ -6,14 +6,17 @@ templates:
   - agent-features/insights/queue/deployment.yaml
   - agent-features/polly/api-server/deployment.yaml
   - agent-features/polly/queue/deployment.yaml
+  - validate.yaml
 set:
+  config.existingSecretName: "langsmith-secrets"
+  config.skipValidation: true
   fleet.enabled: true
-  fleet.postgres.iamProvider: "fleet-postgres"
-  fleet.redis.iamProvider: "fleet-redis"
-  insights.postgres.iamProvider: "insights-postgres"
-  insights.redis.iamProvider: "insights-redis"
-  polly.postgres.iamProvider: "polly-postgres"
-  polly.redis.iamProvider: "polly-redis"
+  fleet.postgres.iamProvider: "aws"
+  fleet.redis.iamProvider: "gcp"
+  insights.postgres.iamProvider: "azure"
+  insights.redis.iamProvider: "aws"
+  polly.postgres.iamProvider: "gcp"
+  polly.redis.iamProvider: "azure"
 tests:
   - it: maps fleet IAM providers to the api-server
     template: agent-features/fleet/api-server/deployment.yaml
@@ -22,12 +25,12 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: AGENT_POSTGRES_IAM_AUTH_PROVIDER
-            value: fleet-postgres
+            value: aws
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: AGENT_REDIS_IAM_AUTH_PROVIDER
-            value: fleet-redis
+            value: gcp
   - it: maps fleet IAM providers to the queue
     template: agent-features/fleet/queue/deployment.yaml
     asserts:
@@ -35,12 +38,12 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: AGENT_POSTGRES_IAM_AUTH_PROVIDER
-            value: fleet-postgres
+            value: aws
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: AGENT_REDIS_IAM_AUTH_PROVIDER
-            value: fleet-redis
+            value: gcp
   - it: maps insights IAM providers to the api-server
     template: agent-features/insights/api-server/deployment.yaml
     asserts:
@@ -48,12 +51,12 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: AGENT_POSTGRES_IAM_AUTH_PROVIDER
-            value: insights-postgres
+            value: azure
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: AGENT_REDIS_IAM_AUTH_PROVIDER
-            value: insights-redis
+            value: aws
   - it: maps insights IAM providers to the queue
     template: agent-features/insights/queue/deployment.yaml
     asserts:
@@ -61,12 +64,12 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: AGENT_POSTGRES_IAM_AUTH_PROVIDER
-            value: insights-postgres
+            value: azure
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: AGENT_REDIS_IAM_AUTH_PROVIDER
-            value: insights-redis
+            value: aws
   - it: maps polly IAM providers to the api-server
     template: agent-features/polly/api-server/deployment.yaml
     asserts:
@@ -74,12 +77,12 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: AGENT_POSTGRES_IAM_AUTH_PROVIDER
-            value: polly-postgres
+            value: gcp
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: AGENT_REDIS_IAM_AUTH_PROVIDER
-            value: polly-redis
+            value: azure
   - it: maps polly IAM providers to the queue
     template: agent-features/polly/queue/deployment.yaml
     asserts:
@@ -87,9 +90,51 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: AGENT_POSTGRES_IAM_AUTH_PROVIDER
-            value: polly-postgres
+            value: gcp
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: AGENT_REDIS_IAM_AUTH_PROVIDER
-            value: polly-redis
+            value: azure
+  - it: rejects an invalid fleet Postgres IAM provider
+    template: validate.yaml
+    set:
+      fleet.postgres.iamProvider: "AWS"
+    asserts:
+      - failedTemplate:
+          errorMessage: "fleet.postgres.iamProvider must be one of [azure, gcp, aws]"
+  - it: rejects an invalid fleet Redis IAM provider
+    template: validate.yaml
+    set:
+      fleet.redis.iamProvider: "AWS"
+    asserts:
+      - failedTemplate:
+          errorMessage: "fleet.redis.iamProvider must be one of [azure, gcp, aws]"
+  - it: rejects an invalid insights Postgres IAM provider
+    template: validate.yaml
+    set:
+      insights.postgres.iamProvider: "AWS"
+    asserts:
+      - failedTemplate:
+          errorMessage: "insights.postgres.iamProvider must be one of [azure, gcp, aws]"
+  - it: rejects an invalid insights Redis IAM provider
+    template: validate.yaml
+    set:
+      insights.redis.iamProvider: "AWS"
+    asserts:
+      - failedTemplate:
+          errorMessage: "insights.redis.iamProvider must be one of [azure, gcp, aws]"
+  - it: rejects an invalid polly Postgres IAM provider
+    template: validate.yaml
+    set:
+      polly.postgres.iamProvider: "AWS"
+    asserts:
+      - failedTemplate:
+          errorMessage: "polly.postgres.iamProvider must be one of [azure, gcp, aws]"
+  - it: rejects an invalid polly Redis IAM provider
+    template: validate.yaml
+    set:
+      polly.redis.iamProvider: "AWS"
+    asserts:
+      - failedTemplate:
+          errorMessage: "polly.redis.iamProvider must be one of [azure, gcp, aws]"

--- a/charts/langsmith/tests/agent_iam_provider_test.yaml
+++ b/charts/langsmith/tests/agent_iam_provider_test.yaml
@@ -11,12 +11,12 @@ set:
   config.existingSecretName: "langsmith-secrets"
   config.skipValidation: true
   fleet.enabled: true
-  fleet.postgres.iamProvider: "aws"
-  fleet.redis.iamProvider: "gcp"
-  insights.postgres.iamProvider: "azure"
-  insights.redis.iamProvider: "aws"
-  polly.postgres.iamProvider: "gcp"
-  polly.redis.iamProvider: "azure"
+  fleet.postgres.external.iamProvider: "aws"
+  fleet.redis.external.iamProvider: "gcp"
+  insights.postgres.external.iamProvider: "azure"
+  insights.redis.external.iamProvider: "aws"
+  polly.postgres.external.iamProvider: "gcp"
+  polly.redis.external.iamProvider: "azure"
 tests:
   - it: maps fleet IAM providers to the api-server
     template: agent-features/fleet/api-server/deployment.yaml
@@ -99,42 +99,42 @@ tests:
   - it: rejects an invalid fleet Postgres IAM provider
     template: validate.yaml
     set:
-      fleet.postgres.iamProvider: "AWS"
+      fleet.postgres.external.iamProvider: "AWS"
     asserts:
       - failedTemplate:
-          errorMessage: "fleet.postgres.iamProvider must be one of [azure, gcp, aws]"
+          errorMessage: "fleet.postgres.external.iamProvider must be one of [azure, gcp, aws]"
   - it: rejects an invalid fleet Redis IAM provider
     template: validate.yaml
     set:
-      fleet.redis.iamProvider: "AWS"
+      fleet.redis.external.iamProvider: "AWS"
     asserts:
       - failedTemplate:
-          errorMessage: "fleet.redis.iamProvider must be one of [azure, gcp, aws]"
+          errorMessage: "fleet.redis.external.iamProvider must be one of [azure, gcp, aws]"
   - it: rejects an invalid insights Postgres IAM provider
     template: validate.yaml
     set:
-      insights.postgres.iamProvider: "AWS"
+      insights.postgres.external.iamProvider: "AWS"
     asserts:
       - failedTemplate:
-          errorMessage: "insights.postgres.iamProvider must be one of [azure, gcp, aws]"
+          errorMessage: "insights.postgres.external.iamProvider must be one of [azure, gcp, aws]"
   - it: rejects an invalid insights Redis IAM provider
     template: validate.yaml
     set:
-      insights.redis.iamProvider: "AWS"
+      insights.redis.external.iamProvider: "AWS"
     asserts:
       - failedTemplate:
-          errorMessage: "insights.redis.iamProvider must be one of [azure, gcp, aws]"
+          errorMessage: "insights.redis.external.iamProvider must be one of [azure, gcp, aws]"
   - it: rejects an invalid polly Postgres IAM provider
     template: validate.yaml
     set:
-      polly.postgres.iamProvider: "AWS"
+      polly.postgres.external.iamProvider: "AWS"
     asserts:
       - failedTemplate:
-          errorMessage: "polly.postgres.iamProvider must be one of [azure, gcp, aws]"
+          errorMessage: "polly.postgres.external.iamProvider must be one of [azure, gcp, aws]"
   - it: rejects an invalid polly Redis IAM provider
     template: validate.yaml
     set:
-      polly.redis.iamProvider: "AWS"
+      polly.redis.external.iamProvider: "AWS"
     asserts:
       - failedTemplate:
-          errorMessage: "polly.redis.iamProvider must be one of [azure, gcp, aws]"
+          errorMessage: "polly.redis.external.iamProvider must be one of [azure, gcp, aws]"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -290,9 +290,9 @@ fleet:
   postgres:
     name: "postgres"
     containerPort: 5432
-    iamProvider: ""
     external:
       enabled: false
+      iamProvider: ""
       host: ""
       port: "5432"
       user: "postgres"
@@ -344,9 +344,9 @@ fleet:
   redis:
     name: "redis"
     containerPort: 6379
-    iamProvider: ""
     external:
       enabled: false
+      iamProvider: ""
       connectionUrl: ""
       existingSecretName: ""
     statefulSet:
@@ -529,9 +529,9 @@ insights:
   postgres:
     name: "postgres"
     containerPort: 5432
-    iamProvider: ""
     external:
       enabled: false
+      iamProvider: ""
       host: ""
       port: "5432"
       user: "postgres"
@@ -583,9 +583,9 @@ insights:
   redis:
     name: "redis"
     containerPort: 6379
-    iamProvider: ""
     external:
       enabled: false
+      iamProvider: ""
       connectionUrl: ""
       existingSecretName: ""
     statefulSet:
@@ -767,9 +767,9 @@ polly:
   postgres:
     name: "postgres"
     containerPort: 5432
-    iamProvider: ""
     external:
       enabled: false
+      iamProvider: ""
       host: ""
       port: "5432"
       user: "postgres"
@@ -821,9 +821,9 @@ polly:
   redis:
     name: "redis"
     containerPort: 6379
-    iamProvider: ""
     external:
       enabled: false
+      iamProvider: ""
       connectionUrl: ""
       existingSecretName: ""
     statefulSet:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -290,6 +290,7 @@ fleet:
   postgres:
     name: "postgres"
     containerPort: 5432
+    iamProvider: ""
     external:
       enabled: false
       host: ""
@@ -343,6 +344,7 @@ fleet:
   redis:
     name: "redis"
     containerPort: 6379
+    iamProvider: ""
     external:
       enabled: false
       connectionUrl: ""
@@ -527,6 +529,7 @@ insights:
   postgres:
     name: "postgres"
     containerPort: 5432
+    iamProvider: ""
     external:
       enabled: false
       host: ""
@@ -580,6 +583,7 @@ insights:
   redis:
     name: "redis"
     containerPort: 6379
+    iamProvider: ""
     external:
       enabled: false
       connectionUrl: ""
@@ -763,6 +767,7 @@ polly:
   postgres:
     name: "postgres"
     containerPort: 5432
+    iamProvider: ""
     external:
       enabled: false
       host: ""
@@ -816,6 +821,7 @@ polly:
   redis:
     name: "redis"
     containerPort: 6379
+    iamProvider: ""
     external:
       enabled: false
       connectionUrl: ""


### PR DESCRIPTION
## Description
Backports external IAM provider settings for Fleet, Insights, and Polly Postgres/Redis connections to `v16-stable`.
Maps validated `azure`/`gcp`/`aws` values into API/queue environment variables and bumps the chart to `0.16.0-rc.18`.

## Test Plan
- [x] `helm unittest --color=false -f tests/agent_iam_provider_test.yaml charts/langsmith`
- [x] `helm lint charts/langsmith --with-subcharts`

Made by [Open SWE](https://openswe.vercel.app/agents/4f9f56c0-5504-8906-8f37-829a611b2a9a)
