### PR TITLE
fix(langsmith): normalize SmithDB OTLP endpoint scheme

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1323,7 +1323,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | config.observability.tracing.endpoint | string | `""` |  |
 | config.observability.tracing.env | string | `"ls_self_hosted"` |  |
 | config.observability.tracing.exporter | string | `"http"` |  |
-| config.observability.tracing.useTls | bool | `true` |  |
+| config.observability.tracing.useTls | bool | `true` | Use TLS for OTLP export. |
 | config.orgAdminsInstallationUsageExportEnabled | bool | `false` | When true, any org admin can use the usage backfill export. |
 | config.personalOrgsDisabled | bool | `true` | Disable personal orgs. |
 | config.security | object | `{"cors":{"allowedOrigins":"*","allowedOriginsRegex":"","alwaysAllowPathsRegex":""}}` | Security configuration for CORS, headers, and other security-related settings. These settings control cross-origin access and help protect against common web vulnerabilities. |

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -616,6 +616,15 @@ SmithDB OTEL resource attributes.
 {{- end }}
 
 {{/*
+SmithDB OTLP endpoint. The chart models TLS separately, while the standard
+OTEL_EXPORTER_OTLP_ENDPOINT consumed by SmithDB requires a URI scheme.
+*/}}
+{{- define "langsmith.smithdb.otelEndpoint" -}}
+{{- $tracing := .Values.config.observability.tracing -}}
+{{- printf "%s://%s" (ternary "https" "http" $tracing.useTls) $tracing.endpoint -}}
+{{- end }}
+
+{{/*
 Common per-process SmithDB env: logging, OpenTelemetry, pod identity, allocator.
 Args: root, service, displayName.
 */}}
@@ -623,7 +632,8 @@ Args: root, service, displayName.
 {{- $root := .root -}}
 {{- $prefix := printf "SMITHDB_%s" (upper .service) -}}
 {{- $displayName := .displayName -}}
-{{- $tracingEnabled := and $root.Values.config.observability.tracing.enabled (eq $root.Values.config.observability.tracing.exporter "grpc") -}}
+{{- $tracing := $root.Values.config.observability.tracing -}}
+{{- $tracingEnabled := and $tracing.enabled (eq $tracing.exporter "grpc") -}}
 - name: {{ $prefix }}__LOGGING__FORMAT
   value: {{ ternary "opentelemetry" "console" $tracingEnabled | quote }}
 - name: {{ $prefix }}__LOGGING__TRACING_ENABLED
@@ -654,7 +664,7 @@ Args: root, service, displayName.
   value: {{ $displayName | quote }}
 {{- if $tracingEnabled }}
 - name: OTEL_EXPORTER_OTLP_ENDPOINT
-  value: {{ $root.Values.config.observability.tracing.endpoint | quote }}
+  value: {{ include "langsmith.smithdb.otelEndpoint" $root | quote }}
 {{- /* SmithDB exports OTLP over gRPC. */}}
 - name: OTEL_EXPORTER_OTLP_PROTOCOL
   value: "grpc"

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -109,12 +109,13 @@ tests:
               resourceFieldRef:
                 resource: limits.memory
 
-  - it: should configure the SmithDB OTLP gRPC exporter when tracing is enabled
+  - it: should derive the plaintext SmithDB OTLP endpoint from chart-level tracing
     values:
       - ./values/smithdb-enabled.yaml
     set:
       config.observability.tracing.enabled: true
-      config.observability.tracing.endpoint: http://default-otel-collector:4317
+      config.observability.tracing.endpoint: default-otel-collector:4317
+      config.observability.tracing.useTls: false
       config.observability.tracing.exporter: grpc
     template: smithdb/query-deployment.yaml
     asserts:
@@ -143,6 +144,51 @@ tests:
           content:
             name: OTEL_RESOURCE_ATTRIBUTES
             value: pod_name=$(POD_NAME),k8s.pod.name=$(POD_NAME),container_name=$(CONTAINER_NAME),k8s.container.name=$(CONTAINER_NAME)
+
+  - it: should preserve the bare endpoint for LangSmith services
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      config.observability.tracing.enabled: true
+      config.observability.tracing.endpoint: default-otel-collector:4317
+      config.observability.tracing.useTls: false
+      config.observability.tracing.exporter: grpc
+    template: config-map.yaml
+    asserts:
+      - equal:
+          path: data.OTLP_ENDPOINT
+          value: default-otel-collector:4317
+
+  - it: should derive the TLS SmithDB OTLP endpoint from chart-level tracing
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      config.observability.tracing.enabled: true
+      config.observability.tracing.endpoint: secure-otel-collector:4317
+      config.observability.tracing.useTls: true
+      config.observability.tracing.exporter: grpc
+    template: smithdb/query-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_QUERY__LOGGING__TRACING_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_QUERY__LOGGING__FORMAT
+            value: opentelemetry
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: https://secure-otel-collector:4317
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_EXPORTER_OTLP_PROTOCOL
+            value: grpc
 
   - it: should keep SmithDB tracing disabled when chart-level tracing is disabled
     values:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1074,6 +1074,7 @@ config:
       enabled: false
       # Replace this with the endpoint of your trace collector. If you are using the LangSmith Observability helm chart, this will be the endpoint of the OTEL Gateway collector.
       endpoint: ""
+      # -- Use TLS for OTLP export.
       useTls: true
       env: "ls_self_hosted"
       exporter: "http"


### PR DESCRIPTION
## Summary

- Forward-port #843 from `v16-stable` to `main`.
- Derive the URI scheme required by SmithDB from the shared chart-level `useTls` setting.
- Render `http://` for plaintext OTLP/gRPC and `https://` for TLS while preserving the bare endpoint consumed by other LangSmith services.
- Keep SmithDB OpenTelemetry disabled when the shared exporter uses a non-gRPC protocol.

## Test Plan

- [x] Verified bare plaintext endpoints render as `http://` for SmithDB.
- [x] Verified TLS endpoints render as `https://` with SmithDB tracing enabled.
- [x] Verified the endpoint remains bare for existing LangSmith services.
- [x] Ran all 38 SmithDB Helm unit tests.
- [x] Ran `helm lint charts/langsmith --set smithdb.enabled=true`.


Made with [Cursor](https://cursor.com)