### PR TITLE
fix(langsmith): configure plaintext OTLP exporters

### DIFF
--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -90,6 +90,7 @@ data:
   OTEL_ENVIRONMENT: "{{ .Values.config.observability.tracing.env }}"
   OTEL_EXPORTER: "{{ .Values.config.observability.tracing.exporter }}"
   OTEL_USE_TLS: "{{ .Values.config.observability.tracing.useTls }}"
+  OTEL_EXPORTER_OTLP_INSECURE: {{ (not .Values.config.observability.tracing.useTls) | quote }}
   {{- else }}
   OTEL_TRACING_ENABLED: "false"
   OTLP_ENDPOINT: ""

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -158,6 +158,26 @@ tests:
       - equal:
           path: data.OTLP_ENDPOINT
           value: default-otel-collector:4317
+      - equal:
+          path: data.OTEL_EXPORTER_OTLP_INSECURE
+          value: "true"
+
+  - it: should configure secure OTLP transport for LangSmith services
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      config.observability.tracing.enabled: true
+      config.observability.tracing.endpoint: secure-otel-collector:4317
+      config.observability.tracing.useTls: true
+      config.observability.tracing.exporter: grpc
+    template: config-map.yaml
+    asserts:
+      - equal:
+          path: data.OTLP_ENDPOINT
+          value: secure-otel-collector:4317
+      - equal:
+          path: data.OTEL_EXPORTER_OTLP_INSECURE
+          value: "false"
 
   - it: should derive the TLS SmithDB OTLP endpoint from chart-level tracing
     values:


### PR DESCRIPTION
## Summary
- derive `OTEL_EXPORTER_OTLP_INSECURE` from `config.observability.tracing.useTls`
- allow Python OTLP/gRPC exporters to connect to plaintext collectors when the shared endpoint is intentionally scheme-free
- retain secure exporter behavior when TLS is enabled

## Test Plan
- [x] Verify `useTls: false` renders `OTEL_EXPORTER_OTLP_INSECURE: \"true\"`
- [x] Verify `useTls: true` renders `OTEL_EXPORTER_OTLP_INSECURE: \"false\"`
- [x] Lint the LangSmith chart with SmithDB enabled

Made with [Cursor](https://cursor.com)