### PR TITLE
fix(langsmith): configure plaintext OTLP exporters

### DIFF
--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -90,6 +90,7 @@ data:
   OTEL_ENVIRONMENT: "{{ .Values.config.observability.tracing.env }}"
   OTEL_EXPORTER: "{{ .Values.config.observability.tracing.exporter }}"
   OTEL_USE_TLS: "{{ .Values.config.observability.tracing.useTls }}"
+  OTEL_EXPORTER_OTLP_INSECURE: {{ (not .Values.config.observability.tracing.useTls) | quote }}
   {{- else }}
   OTEL_TRACING_ENABLED: "false"
   OTLP_ENDPOINT: ""

--- a/charts/langsmith/tests/langsmith_observability_tracing_test.yaml
+++ b/charts/langsmith/tests/langsmith_observability_tracing_test.yaml
@@ -1,0 +1,31 @@
+suite: test observability tracing configuration
+templates:
+  - config-map.yaml
+tests:
+  - it: should configure plaintext OTLP transport
+    set:
+      config.observability.tracing.enabled: true
+      config.observability.tracing.endpoint: default-otel-collector:4317
+      config.observability.tracing.useTls: false
+      config.observability.tracing.exporter: grpc
+    asserts:
+      - equal:
+          path: data.OTLP_ENDPOINT
+          value: default-otel-collector:4317
+      - equal:
+          path: data.OTEL_EXPORTER_OTLP_INSECURE
+          value: "true"
+
+  - it: should configure secure OTLP transport
+    set:
+      config.observability.tracing.enabled: true
+      config.observability.tracing.endpoint: secure-otel-collector:4317
+      config.observability.tracing.useTls: true
+      config.observability.tracing.exporter: grpc
+    asserts:
+      - equal:
+          path: data.OTLP_ENDPOINT
+          value: secure-otel-collector:4317
+      - equal:
+          path: data.OTEL_EXPORTER_OTLP_INSECURE
+          value: "false"

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -144,6 +144,40 @@ tests:
             name: OTEL_RESOURCE_ATTRIBUTES
             value: pod_name=$(POD_NAME),k8s.pod.name=$(POD_NAME),container_name=$(CONTAINER_NAME),k8s.container.name=$(CONTAINER_NAME)
 
+  - it: should preserve the bare endpoint for LangSmith services
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      config.observability.tracing.enabled: true
+      config.observability.tracing.endpoint: default-otel-collector:4317
+      config.observability.tracing.useTls: false
+      config.observability.tracing.exporter: grpc
+    template: config-map.yaml
+    asserts:
+      - equal:
+          path: data.OTLP_ENDPOINT
+          value: default-otel-collector:4317
+      - equal:
+          path: data.OTEL_EXPORTER_OTLP_INSECURE
+          value: "true"
+
+  - it: should configure secure OTLP transport for LangSmith services
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      config.observability.tracing.enabled: true
+      config.observability.tracing.endpoint: secure-otel-collector:4317
+      config.observability.tracing.useTls: true
+      config.observability.tracing.exporter: grpc
+    template: config-map.yaml
+    asserts:
+      - equal:
+          path: data.OTLP_ENDPOINT
+          value: secure-otel-collector:4317
+      - equal:
+          path: data.OTEL_EXPORTER_OTLP_INSECURE
+          value: "false"
+
   - it: should keep SmithDB tracing disabled when chart-level tracing is disabled
     values:
       - ./values/smithdb-enabled.yaml

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -144,40 +144,6 @@ tests:
             name: OTEL_RESOURCE_ATTRIBUTES
             value: pod_name=$(POD_NAME),k8s.pod.name=$(POD_NAME),container_name=$(CONTAINER_NAME),k8s.container.name=$(CONTAINER_NAME)
 
-  - it: should preserve the bare endpoint for LangSmith services
-    values:
-      - ./values/smithdb-enabled.yaml
-    set:
-      config.observability.tracing.enabled: true
-      config.observability.tracing.endpoint: default-otel-collector:4317
-      config.observability.tracing.useTls: false
-      config.observability.tracing.exporter: grpc
-    template: config-map.yaml
-    asserts:
-      - equal:
-          path: data.OTLP_ENDPOINT
-          value: default-otel-collector:4317
-      - equal:
-          path: data.OTEL_EXPORTER_OTLP_INSECURE
-          value: "true"
-
-  - it: should configure secure OTLP transport for LangSmith services
-    values:
-      - ./values/smithdb-enabled.yaml
-    set:
-      config.observability.tracing.enabled: true
-      config.observability.tracing.endpoint: secure-otel-collector:4317
-      config.observability.tracing.useTls: true
-      config.observability.tracing.exporter: grpc
-    template: config-map.yaml
-    asserts:
-      - equal:
-          path: data.OTLP_ENDPOINT
-          value: secure-otel-collector:4317
-      - equal:
-          path: data.OTEL_EXPORTER_OTLP_INSECURE
-          value: "false"
-
   - it: should keep SmithDB tracing disabled when chart-level tracing is disabled
     values:
       - ./values/smithdb-enabled.yaml


### PR DESCRIPTION
## Summary
- derive `OTEL_EXPORTER_OTLP_INSECURE` from `config.observability.tracing.useTls`
- allow Python OTLP/gRPC exporters to connect to plaintext collectors when the shared endpoint is intentionally scheme-free
- retain secure exporter behavior when TLS is enabled

## Test Plan
- [x] Verify `useTls: false` renders `OTEL_EXPORTER_OTLP_INSECURE: \"true\"`
- [x] Verify `useTls: true` renders `OTEL_EXPORTER_OTLP_INSECURE: \"false\"`
- [x] Lint the LangSmith chart with SmithDB enabled

Made with [Cursor](https://cursor.com)