### PR TITLE
feat(frontend): route bare /v2/ to platform-backend for self-hosted [v16-stable]

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.0-rc.19
+version: 0.16.0-rc.20
 appVersion: "0.16.23rc1"

--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -146,6 +146,21 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
 
+        # Bare /v2/ (no /api prefix). The langsmith-go SDK emits root-relative
+        # /v2/... query paths, which work when the API is served at the host
+        # root. Single-origin deployments serve the API under /api, so those
+        # v2 calls would 404/405 without this. Forward to the same
+        # platform-backend as /api/v2/ above; the backend enforces its own
+        # API-key/tenant auth.
+        location /{{ .Values.config.basePath }}/v2/ {
+            rewrite /{{ .Values.config.basePath }}/v2/(.*) /v2/$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
         location /{{ .Values.config.basePath }}/api/v1/oauth/ {
             rewrite /{{ .Values.config.basePath }}/api/v1/oauth/(.*) /oauth/$1  break;
             proxy_set_header Connection '';
@@ -762,6 +777,18 @@ data:
 
         location /api/v2/ {
             rewrite /api/v2/(.*) /v2/$1  break;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
+        }
+
+        # Bare /v2/ (no /api prefix). The langsmith-go SDK emits root-relative
+        # /v2/... query paths, which work when the API is served at the host
+        # root. Single-origin deployments serve the API under /api, so those
+        # v2 calls 404/405 without this. Same target/auth as /api/v2/.
+        location /v2/ {
             proxy_set_header Connection '';
             proxy_http_version 1.1;
             proxy_buffering off;


### PR DESCRIPTION
## Description

Cherry-picks #829 (`62022ddf`) onto `v16-stable` so the 0.16 line serves the bare `/v2/` frontend route, and bumps the chart to `0.16.0-rc.20`.

#829 landed on `main` (so 0.17 has it) but the 0.16 line does not. The langsmith-go SDK — and therefore the `langsmith` CLI — emits root-relative `/v2/...` runs/traces query paths. That is correct on SaaS, where the API host *is* the backend, but single-origin self-hosted only proxies `/api/*`, so v2 queries hit the frontend and 405.

The CLI auto-selects the v2 API for any deployment reporting `>= 0.16` (langsmith-cli#203), so without this route every 0.16 self-hosted install would fail `run list`, `trace list`, `trace get`, `trace export`, `thread list`, `thread get`, and `trace messages`.

Confirmed against the internal test instances — all three 405 on bare `/v2/` and 200 on `/api/v2/`, exactly inverted from SaaS prod:

| instance | version | `POST /v2/runs/query` | `POST /api/v2/runs/query` |
|---|---|---|---|
| `aks` | 0.16.23rc1 | 405 (nginx) | 200 |
| `stable-dual` | 0.16.22rc1 | 405 (nginx) | 200 |
| `stable-smithdb` | 0.16.22rc1 | 405 (nginx) | 200 |
| SaaS prod | 0.17.1 | 200 | 404 |

Not urgent — 0.16 has not shipped to customers, so nothing is broken in the field. This just needs to land before 0.16.0 GA.

## Worth a second look

`0.16.0-rc.17` **did** contain #829; `rc.18` and `rc.19` do not. The compare API reports those tags as `diverged` from `62022ddf` rather than one reverting the other, and there is no revert of the file on `main`. That reads like the branch was recreated or force-updated rather than someone deliberately dropping the route — so it may be worth checking whether anything else was lost the same way. If the removal *was* intentional, say so and I'll close this.

## Test Plan

- [x] Cherry-pick applies with no conflicts (the only drift on this file between `main` and `v16-stable` was exactly #829's 27 lines)
- [x] `helm lint` passes
- [x] `helm template` renders; bare `location /v2/` appears immediately after `location /api/v2/` with the same `proxy_pass` target
- [x] Both template hunks exercised: default values render `/v2/`, and `--set config.basePath=langsmith` renders `/langsmith/v2/`
- [ ] Deploy rc.20 to a self-hosted test instance and confirm `POST /v2/runs/query` returns 200 (needs a cluster; not done locally)