### PR TITLE
fix: align ace backend resources with SaaS defaults (#866)

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1391,10 +1391,10 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | aceBackend.deployment.readinessProbe.periodSeconds | int | `10` |  |
 | aceBackend.deployment.readinessProbe.timeoutSeconds | int | `1` |  |
 | aceBackend.deployment.replicas | int | `1` |  |
-| aceBackend.deployment.resources.limits.cpu | string | `"1000m"` |  |
-| aceBackend.deployment.resources.limits.memory | string | `"2Gi"` |  |
-| aceBackend.deployment.resources.requests.cpu | string | `"200m"` |  |
-| aceBackend.deployment.resources.requests.memory | string | `"1000Mi"` |  |
+| aceBackend.deployment.resources.limits.cpu | int | `2` |  |
+| aceBackend.deployment.resources.limits.memory | string | `"4000Mi"` |  |
+| aceBackend.deployment.resources.requests.cpu | int | `1` |  |
+| aceBackend.deployment.resources.requests.memory | string | `"2000Mi"` |  |
 | aceBackend.deployment.securityContext | object | `{}` |  |
 | aceBackend.deployment.sidecars | list | `[]` |  |
 | aceBackend.deployment.startupProbe.failureThreshold | int | `6` |  |

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1124,11 +1124,11 @@ aceBackend:
     lifecycle: {}
     resources:
       limits:
-        cpu: 1000m
-        memory: 2Gi
+        cpu: 2
+        memory: 4000Mi
       requests:
-        cpu: 200m
-        memory: 1000Mi
+        cpu: 1
+        memory: 2000Mi
     command:
       - "./entrypoint.sh"
     startupProbe:


### PR DESCRIPTION
## Description
Aligns the ace-backend default CPU and memory requests/limits with the SaaS deployment settings and refreshes the generated values documentation.

## Test Plan
- [x] Lint the LangSmith chart with Helm 3.12.1
- [x] Render the chart and verify the ace-backend resource block

Made by [Open SWE](https://openswe.vercel.app/agents/7dbf0a05-e7e9-aef6-5444-b98651f90075)