### PR TITLE
feat(langsmith): enable SMITHDB_UPGRADE_CRON_ENABLED by default

### DIFF
--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -61,6 +61,7 @@ data:
   {{- if .Values.smithdb.enabled }}
   SMITHDB_CLUSTER_MANAGER_ENABLED: "true"
   SMITHDB_CLUSTER_MANAGER_URL: {{ include "langsmith.smithdb.grpcServiceUrl" (dict "root" . "component" "clusterManager" "port" .Values.smithdb.clusterManager.service.port) | quote }}
+  SMITHDB_UPGRADE_CRON_ENABLED: "true"
   SMITHDB_QUERY_SERVICE_MAX_CALL_RECV_MSG_SIZE: "1073741824"
   SMITHDB_FEEDBACK_MUTATION_RPS_PER_KEY: "100"
   SMITHDB_FEEDBACK_MUTATION_BURST_PER_KEY: "150"

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -299,6 +299,9 @@ tests:
           path: data.SMITHDB_MUTATIONS_SERVICE_URL
           value: RELEASE-NAME-langsmith-smithdb-query.NAMESPACE.svc.cluster.local:8080
       - equal:
+          path: data.SMITHDB_UPGRADE_CRON_ENABLED
+          value: "true"
+      - equal:
           path: data.SMITHDB_QUERY_SERVICE_MAX_CALL_RECV_MSG_SIZE
           value: "1073741824"
       - equal:
@@ -409,6 +412,8 @@ tests:
           path: data.SMITHDB_CLUSTER_MANAGER_ENABLED
       - notExists:
           path: data.SMITHDB_CLUSTER_MANAGER_URL
+      - notExists:
+          path: data.SMITHDB_UPGRADE_CRON_ENABLED
       - notExists:
           path: data.SMITHDB_QUERY_SERVICE_MAX_CALL_RECV_MSG_SIZE
       - notExists:


### PR DESCRIPTION
## Summary
- set `SMITHDB_UPGRADE_CRON_ENABLED=true` into the shared LangSmith ConfigMap when `smithdb.enabled` is true