### PR TITLE
fix: enable Rules Redis tracking on v16-stable

### DIFF
--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -57,6 +57,8 @@ data:
   {{- if .Values.smithdb.langsmith.ingestion.enabled }}
   SMITHDB_MUTATIONS_SERVICE_URL: {{ include "langsmith.smithdb.grpcServiceUrl" (dict "root" . "component" "query" "port" .Values.smithdb.query.service.port) | quote }}
   SMITHDB_INGESTION_SERVICE_URL: {{ include "langsmith.smithdb.grpcServiceUrl" (dict "root" . "component" "ingestion" "port" .Values.smithdb.ingestion.service.port) | quote }}
+  RULES_REDIS_TRACKING_ENABLED: "true"
+  RULES_REDIS_TRACKING_MULTIPART_ENABLED: "true"
   {{- end }}
   {{- if .Values.smithdb.enabled }}
   SMITHDB_CLUSTER_MANAGER_ENABLED: "true"

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -319,6 +319,12 @@ tests:
           path: data.SMITHDB_MUTATIONS_SERVICE_URL
           value: RELEASE-NAME-langsmith-smithdb-query.NAMESPACE.svc.cluster.local:8080
       - equal:
+          path: data.RULES_REDIS_TRACKING_ENABLED
+          value: "true"
+      - equal:
+          path: data.RULES_REDIS_TRACKING_MULTIPART_ENABLED
+          value: "true"
+      - equal:
           path: data.SMITHDB_UPGRADE_CRON_ENABLED
           value: "true"
       - equal:
@@ -370,6 +376,12 @@ tests:
       - equal:
           path: data.SMITHDB_QUERY_ENABLED
           value: "false"
+      - equal:
+          path: data.RULES_REDIS_TRACKING_ENABLED
+          value: "true"
+      - equal:
+          path: data.RULES_REDIS_TRACKING_MULTIPART_ENABLED
+          value: "true"
 
   - it: should wire frontend SmithDB v2 endpoint flag when enabled
     values:
@@ -432,6 +444,10 @@ tests:
           path: data.SMITHDB_CLUSTER_MANAGER_ENABLED
       - notExists:
           path: data.SMITHDB_CLUSTER_MANAGER_URL
+      - notExists:
+          path: data.RULES_REDIS_TRACKING_ENABLED
+      - notExists:
+          path: data.RULES_REDIS_TRACKING_MULTIPART_ENABLED
       - notExists:
           path: data.SMITHDB_UPGRADE_CRON_ENABLED
       - notExists:


### PR DESCRIPTION
## Description
Backports the Rules Redis tracking configuration so dual and SmithDB-only ingestion modes write tracking entries on v16-stable. The flags remain absent for ClickHouse-only deployments.

## Test Plan
- [x] `helm unittest --color=false -f 'tests/langsmith_smithdb_test.yaml' charts/langsmith`
- [x] `helm lint charts/langsmith`

Made by [Open SWE](https://openswe.vercel.app/agents/bbe00f87-9bd3-83e5-e913-638b0d21469a)