### PR TITLE
fix(langsmith): set TaskDB resource defaults

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1170,7 +1170,10 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.migration.taskdb.postgres.statefulSet.readinessProbe.failureThreshold | int | `6` |  |
 | smithdb.migration.taskdb.postgres.statefulSet.readinessProbe.periodSeconds | int | `10` |  |
 | smithdb.migration.taskdb.postgres.statefulSet.readinessProbe.timeoutSeconds | int | `1` |  |
-| smithdb.migration.taskdb.postgres.statefulSet.resources | object | `{}` |  |
+| smithdb.migration.taskdb.postgres.statefulSet.resources.limits.cpu | string | `"4"` |  |
+| smithdb.migration.taskdb.postgres.statefulSet.resources.limits.memory | string | `"8Gi"` |  |
+| smithdb.migration.taskdb.postgres.statefulSet.resources.requests.cpu | string | `"2"` |  |
+| smithdb.migration.taskdb.postgres.statefulSet.resources.requests.memory | string | `"4Gi"` |  |
 | smithdb.migration.taskdb.postgres.statefulSet.securityContext | object | `{}` |  |
 | smithdb.migration.taskdb.postgres.statefulSet.sidecars | list | `[]` |  |
 | smithdb.migration.taskdb.postgres.statefulSet.startupProbe.exec.command[0] | string | `"/bin/sh"` |  |

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -814,6 +814,22 @@ tests:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 5433
       - template: smithdb/taskdb-postgres-statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: "2"
+      - template: smithdb/taskdb-postgres-statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: "4Gi"
+      - template: smithdb/taskdb-postgres-statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: "4"
+      - template: smithdb/taskdb-postgres-statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: "8Gi"
+      - template: smithdb/taskdb-postgres-statefulset.yaml
         contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1690,7 +1690,13 @@ smithdb:
           podSecurityContext: {}
           securityContext: {}
           terminationGracePeriodSeconds: 30
-          resources: {}
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "4"
+              memory: "8Gi"
           startupProbe:
             exec:
               command:


### PR DESCRIPTION
## Summary
- forward-port #872 to `main`
- give the chart-managed migration TaskDB guaranteed CPU and memory instead of BestEffort QoS

## Test plan
- [x] verify the rendered TaskDB StatefulSet includes all four resource defaults