### PR TITLE
feat(engine): wire the sandbox tenant id for self-hosted Engine

### DIFF
--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -1078,6 +1078,8 @@ Extra env vars for insights api-server and queue pods.
 {{- $out = append $out (dict "name" "ISSUES_AGENT_ENCRYPTION_KEY" "valueFrom" (dict "secretKeyRef" (dict "name" (include "langsmith.secretsName" $root) "key" "engine_encryption_key" "optional" $root.Values.config.disableSecretCreation))) -}}
 {{- $out = append $out (dict "name" "ISSUES_AGENT_ENCRYPTION_KEY_PREVIOUS" "valueFrom" (dict "secretKeyRef" (dict "name" (include "langsmith.secretsName" $root) "key" "engine_encryption_key_previous" "optional" true))) -}}
 {{- $out = append $out (dict "name" "ISSUES_AGENT_SANDBOX_TENANT_ID" "value" $root.Values.engine.sandboxTenantId) -}}
+{{- $out = append $out (dict "name" "ISSUES_AGENT_SNAPSHOT_NAME" "value" $root.Values.engine.snapshotName) -}}
+{{- $out = append $out (dict "name" "ISSUES_AGENT_SNAPSHOT_IMAGE" "value" (include "langsmith.image" (dict "Values" $root.Values "Chart" $root.Chart "component" "engineSandboxImage"))) -}}
 {{- end -}}
 {{- if and (eq $componentName "apiServer") $feature.queue.enabled -}}
 {{- $out = append $out (dict "name" "N_JOBS_PER_WORKER" "value" "0") -}}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -1077,6 +1077,9 @@ Extra env vars for insights api-server and queue pods.
 {{- $out = append $out (dict "name" "ENGINE_INTELLIGENCE_BASE_URL" "value" $root.Values.engine.intelligenceBaseUrl) -}}
 {{- $out = append $out (dict "name" "ISSUES_AGENT_ENCRYPTION_KEY" "valueFrom" (dict "secretKeyRef" (dict "name" (include "langsmith.secretsName" $root) "key" "engine_encryption_key" "optional" $root.Values.config.disableSecretCreation))) -}}
 {{- $out = append $out (dict "name" "ISSUES_AGENT_ENCRYPTION_KEY_PREVIOUS" "valueFrom" (dict "secretKeyRef" (dict "name" (include "langsmith.secretsName" $root) "key" "engine_encryption_key_previous" "optional" true))) -}}
+{{- if $root.Values.config.sandboxes.enabled -}}
+{{- $out = append $out (dict "name" "ISSUES_AGENT_SANDBOX_TENANT_ID" "value" $root.Values.engine.sandboxTenantId) -}}
+{{- end -}}
 {{- end -}}
 {{- if and (eq $componentName "apiServer") $feature.queue.enabled -}}
 {{- $out = append $out (dict "name" "N_JOBS_PER_WORKER" "value" "0") -}}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -1077,9 +1077,7 @@ Extra env vars for insights api-server and queue pods.
 {{- $out = append $out (dict "name" "ENGINE_INTELLIGENCE_BASE_URL" "value" $root.Values.engine.intelligenceBaseUrl) -}}
 {{- $out = append $out (dict "name" "ISSUES_AGENT_ENCRYPTION_KEY" "valueFrom" (dict "secretKeyRef" (dict "name" (include "langsmith.secretsName" $root) "key" "engine_encryption_key" "optional" $root.Values.config.disableSecretCreation))) -}}
 {{- $out = append $out (dict "name" "ISSUES_AGENT_ENCRYPTION_KEY_PREVIOUS" "valueFrom" (dict "secretKeyRef" (dict "name" (include "langsmith.secretsName" $root) "key" "engine_encryption_key_previous" "optional" true))) -}}
-{{- if $root.Values.config.sandboxes.enabled -}}
 {{- $out = append $out (dict "name" "ISSUES_AGENT_SANDBOX_TENANT_ID" "value" $root.Values.engine.sandboxTenantId) -}}
-{{- end -}}
 {{- end -}}
 {{- if and (eq $componentName "apiServer") $feature.queue.enabled -}}
 {{- $out = append $out (dict "name" "N_JOBS_PER_WORKER" "value" "0") -}}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -1078,8 +1078,6 @@ Extra env vars for insights api-server and queue pods.
 {{- $out = append $out (dict "name" "ISSUES_AGENT_ENCRYPTION_KEY" "valueFrom" (dict "secretKeyRef" (dict "name" (include "langsmith.secretsName" $root) "key" "engine_encryption_key" "optional" $root.Values.config.disableSecretCreation))) -}}
 {{- $out = append $out (dict "name" "ISSUES_AGENT_ENCRYPTION_KEY_PREVIOUS" "valueFrom" (dict "secretKeyRef" (dict "name" (include "langsmith.secretsName" $root) "key" "engine_encryption_key_previous" "optional" true))) -}}
 {{- $out = append $out (dict "name" "ISSUES_AGENT_SANDBOX_TENANT_ID" "value" $root.Values.engine.sandboxTenantId) -}}
-{{- $out = append $out (dict "name" "ISSUES_AGENT_SNAPSHOT_NAME" "value" $root.Values.engine.snapshotName) -}}
-{{- $out = append $out (dict "name" "ISSUES_AGENT_SNAPSHOT_IMAGE" "value" (include "langsmith.image" (dict "Values" $root.Values "Chart" $root.Chart "component" "engineSandboxImage"))) -}}
 {{- end -}}
 {{- if and (eq $componentName "apiServer") $feature.queue.enabled -}}
 {{- $out = append $out (dict "name" "N_JOBS_PER_WORKER" "value" "0") -}}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -528,6 +528,9 @@ AWS Marketplace Helm template verification).
 {{- if not .Values.engine.intelligenceBaseUrl }}
 {{- fail "engine.intelligenceBaseUrl is required when engine.enabled is true: the self-hosted Engine has no ANTHROPIC_API_KEY and routes model calls through the LSI gateway for its cloud/region (e.g. AWS: https://beacon.aws.langchain.com/intelligence)." }}
 {{- end }}
+{{- if and .Values.config.sandboxes.enabled (not .Values.engine.sandboxTenantId) }}
+{{- fail "engine.sandboxTenantId is required when engine.enabled and config.sandboxes.enabled are both true: the Engine signs its sandbox service key with this workspace id and smith-go rejects a service key without a tenant. Use a workspace reserved for the Engine — its sandboxes consume that workspace's sandbox quota and are visible to anyone with access to it." }}
+{{- end }}
 {{- end }}
 
 {{- /* Validate agent feature (fleet/insights/polly) configuration */ -}}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -528,8 +528,11 @@ AWS Marketplace Helm template verification).
 {{- if not .Values.engine.intelligenceBaseUrl }}
 {{- fail "engine.intelligenceBaseUrl is required when engine.enabled is true: the self-hosted Engine has no ANTHROPIC_API_KEY and routes model calls through the LSI gateway for its cloud/region (e.g. AWS: https://beacon.aws.langchain.com/intelligence)." }}
 {{- end }}
-{{- if and .Values.config.sandboxes.enabled (not .Values.engine.sandboxTenantId) }}
-{{- fail "engine.sandboxTenantId is required when engine.enabled and config.sandboxes.enabled are both true: the Engine signs its sandbox service key with this workspace id and smith-go rejects a service key without a tenant. Use a workspace reserved for the Engine — its sandboxes consume that workspace's sandbox quota and are visible to anyone with access to it." }}
+{{- if not .Values.config.sandboxes.enabled }}
+{{- fail "engine.enabled is true but config.sandboxes.enabled is false: every Engine run executes in a sandbox, so Engine cannot run without them." }}
+{{- end }}
+{{- if not .Values.engine.sandboxTenantId }}
+{{- fail "engine.sandboxTenantId is required when engine.enabled is true: the Engine signs its sandbox service key with this workspace id and smith-go rejects a service key without a tenant. Use a workspace reserved for the Engine — its sandboxes consume that workspace's sandbox quota and are visible to anyone with access to it." }}
 {{- end }}
 {{- end }}
 

--- a/charts/langsmith/tests/engine_insights_agent_test.yaml
+++ b/charts/langsmith/tests/engine_insights_agent_test.yaml
@@ -51,9 +51,9 @@ tests:
       images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
     asserts:
       - failedTemplate:
-          errorMessage: "engine.sandboxTenantId is required when engine.enabled and config.sandboxes.enabled are both true: the Engine signs its sandbox service key with this workspace id and smith-go rejects a service key without a tenant. Use a workspace reserved for the Engine — its sandboxes consume that workspace's sandbox quota and are visible to anyone with access to it."
+          errorMessage: "engine.sandboxTenantId is required when engine.enabled is true: the Engine signs its sandbox service key with this workspace id and smith-go rejects a service key without a tenant. Use a workspace reserved for the Engine — its sandboxes consume that workspace's sandbox quota and are visible to anyone with access to it."
 
-  - it: should not require a sandbox tenant when sandboxes are disabled
+  - it: should fail when engine is enabled without sandboxes
     values:
       - ./values/sandboxes-enabled.yaml
     set:
@@ -61,6 +61,8 @@ tests:
       engine.enabled: true
       engine.encryptionKey: test-key
       engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
+      engine.sandboxTenantId: 00000000-0000-0000-0000-000000000000
       images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
     asserts:
-      - notFailedTemplate: {}
+      - failedTemplate:
+          errorMessage: "engine.enabled is true but config.sandboxes.enabled is false: every Engine run executes in a sandbox, so Engine cannot run without them."

--- a/charts/langsmith/tests/engine_insights_agent_test.yaml
+++ b/charts/langsmith/tests/engine_insights_agent_test.yaml
@@ -18,6 +18,9 @@ tests:
 
   - it: should fail when engine is enabled without the combined image
     set:
+      config.existingSecretName: langsmith-secrets
+      config.oauth.enabled: true
+      config.authType: oauth
       engine.enabled: true
       engine.encryptionKey: test-key
       engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
@@ -28,9 +31,36 @@ tests:
 
   - it: should fail when engine is enabled without an intelligence base URL
     set:
+      config.existingSecretName: langsmith-secrets
+      config.oauth.enabled: true
+      config.authType: oauth
       engine.enabled: true
       engine.encryptionKey: test-key
       images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
     asserts:
       - failedTemplate:
           errorMessage: "engine.intelligenceBaseUrl is required when engine.enabled is true: the self-hosted Engine has no ANTHROPIC_API_KEY and routes model calls through the LSI gateway for its cloud/region (e.g. AWS: https://beacon.aws.langchain.com/intelligence)."
+
+  - it: should fail when engine and sandboxes are enabled without a sandbox tenant
+    values:
+      - ./values/sandboxes-enabled.yaml
+    set:
+      engine.enabled: true
+      engine.encryptionKey: test-key
+      engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
+      images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
+    asserts:
+      - failedTemplate:
+          errorMessage: "engine.sandboxTenantId is required when engine.enabled and config.sandboxes.enabled are both true: the Engine signs its sandbox service key with this workspace id and smith-go rejects a service key without a tenant. Use a workspace reserved for the Engine — its sandboxes consume that workspace's sandbox quota and are visible to anyone with access to it."
+
+  - it: should not require a sandbox tenant when sandboxes are disabled
+    values:
+      - ./values/sandboxes-enabled.yaml
+    set:
+      config.sandboxes.enabled: false
+      engine.enabled: true
+      engine.encryptionKey: test-key
+      engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
+      images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
+    asserts:
+      - notFailedTemplate: {}

--- a/charts/langsmith/tests/engine_sandbox_tenant_test.yaml
+++ b/charts/langsmith/tests/engine_sandbox_tenant_test.yaml
@@ -19,23 +19,6 @@ tests:
             name: ISSUES_AGENT_SANDBOX_TENANT_ID
             value: 11111111-2222-3333-4444-555555555555
 
-  - it: should omit the sandbox tenant when sandboxes are disabled
-    values:
-      - ./values/sandboxes-enabled.yaml
-    set:
-      config.sandboxes.enabled: false
-      engine.enabled: true
-      engine.encryptionKey: test-key
-      engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
-      engine.sandboxTenantId: 11111111-2222-3333-4444-555555555555
-      images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
-    asserts:
-      - notContains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: ISSUES_AGENT_SANDBOX_TENANT_ID
-            value: 11111111-2222-3333-4444-555555555555
-
   - it: should omit the sandbox tenant when engine is disabled
     values:
       - ./values/sandboxes-enabled.yaml

--- a/charts/langsmith/tests/engine_sandbox_tenant_test.yaml
+++ b/charts/langsmith/tests/engine_sandbox_tenant_test.yaml
@@ -19,22 +19,45 @@ tests:
             name: ISSUES_AGENT_SANDBOX_TENANT_ID
             value: 11111111-2222-3333-4444-555555555555
 
-  - it: should omit the sandbox tenant when sandboxes are disabled
+  - it: should pass the snapshot name and image to both engine pods
     values:
       - ./values/sandboxes-enabled.yaml
     set:
-      config.sandboxes.enabled: false
       engine.enabled: true
       engine.encryptionKey: test-key
       engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
       engine.sandboxTenantId: 11111111-2222-3333-4444-555555555555
       images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
+      images.engineSandboxImage.tag: test-engine-sandbox
     asserts:
-      - notContains:
+      - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: ISSUES_AGENT_SANDBOX_TENANT_ID
-            value: 11111111-2222-3333-4444-555555555555
+            name: ISSUES_AGENT_SNAPSHOT_NAME
+            value: engine-sandbox
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ISSUES_AGENT_SNAPSHOT_IMAGE
+            value: docker.io/langchain/engine-sandbox:test-engine-sandbox
+
+  - it: should route the sandbox image through the registry override
+    values:
+      - ./values/sandboxes-enabled.yaml
+    set:
+      engine.enabled: true
+      engine.encryptionKey: test-key
+      engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
+      engine.sandboxTenantId: 11111111-2222-3333-4444-555555555555
+      images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
+      images.engineSandboxImage.tag: test-engine-sandbox
+      images.registry: mirror.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ISSUES_AGENT_SNAPSHOT_IMAGE
+            value: mirror.example.com/docker.io/langchain/engine-sandbox:test-engine-sandbox
 
   - it: should omit the sandbox tenant when engine is disabled
     values:

--- a/charts/langsmith/tests/engine_sandbox_tenant_test.yaml
+++ b/charts/langsmith/tests/engine_sandbox_tenant_test.yaml
@@ -19,45 +19,22 @@ tests:
             name: ISSUES_AGENT_SANDBOX_TENANT_ID
             value: 11111111-2222-3333-4444-555555555555
 
-  - it: should pass the snapshot name and image to both engine pods
+  - it: should omit the sandbox tenant when sandboxes are disabled
     values:
       - ./values/sandboxes-enabled.yaml
     set:
+      config.sandboxes.enabled: false
       engine.enabled: true
       engine.encryptionKey: test-key
       engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
       engine.sandboxTenantId: 11111111-2222-3333-4444-555555555555
       images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
-      images.engineSandboxImage.tag: test-engine-sandbox
     asserts:
-      - contains:
+      - notContains:
           path: spec.template.spec.containers[0].env
           content:
-            name: ISSUES_AGENT_SNAPSHOT_NAME
-            value: engine-sandbox
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: ISSUES_AGENT_SNAPSHOT_IMAGE
-            value: docker.io/langchain/engine-sandbox:test-engine-sandbox
-
-  - it: should route the sandbox image through the registry override
-    values:
-      - ./values/sandboxes-enabled.yaml
-    set:
-      engine.enabled: true
-      engine.encryptionKey: test-key
-      engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
-      engine.sandboxTenantId: 11111111-2222-3333-4444-555555555555
-      images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
-      images.engineSandboxImage.tag: test-engine-sandbox
-      images.registry: mirror.example.com
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: ISSUES_AGENT_SNAPSHOT_IMAGE
-            value: mirror.example.com/docker.io/langchain/engine-sandbox:test-engine-sandbox
+            name: ISSUES_AGENT_SANDBOX_TENANT_ID
+            value: 11111111-2222-3333-4444-555555555555
 
   - it: should omit the sandbox tenant when engine is disabled
     values:

--- a/charts/langsmith/tests/engine_sandbox_tenant_test.yaml
+++ b/charts/langsmith/tests/engine_sandbox_tenant_test.yaml
@@ -1,0 +1,47 @@
+suite: engine sandbox tenant env
+templates:
+  - templates/agent-features/insights/api-server/deployment.yaml
+  - templates/agent-features/insights/queue/deployment.yaml
+tests:
+  - it: should pass the sandbox tenant to both engine pods
+    values:
+      - ./values/sandboxes-enabled.yaml
+    set:
+      engine.enabled: true
+      engine.encryptionKey: test-key
+      engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
+      engine.sandboxTenantId: 11111111-2222-3333-4444-555555555555
+      images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ISSUES_AGENT_SANDBOX_TENANT_ID
+            value: 11111111-2222-3333-4444-555555555555
+
+  - it: should omit the sandbox tenant when sandboxes are disabled
+    values:
+      - ./values/sandboxes-enabled.yaml
+    set:
+      config.sandboxes.enabled: false
+      engine.enabled: true
+      engine.encryptionKey: test-key
+      engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
+      engine.sandboxTenantId: 11111111-2222-3333-4444-555555555555
+      images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ISSUES_AGENT_SANDBOX_TENANT_ID
+            value: 11111111-2222-3333-4444-555555555555
+
+  - it: should omit the sandbox tenant when engine is disabled
+    values:
+      - ./values/sandboxes-enabled.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ISSUES_AGENT_SANDBOX_TENANT_ID
+            value: ""

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -123,6 +123,13 @@ images:
     repository: "docker.io/langchain/sandbox-host"
     pullPolicy: IfNotPresent
     tag: ""
+  # -- Engine sandbox base image. Not run as a workload: the Engine builds its
+  # sandbox snapshot from it on first use. Only used when engine.enabled and
+  # config.sandboxes.enabled are both true.
+  engineSandboxImage:
+    repository: "docker.io/langchain/engine-sandbox"
+    pullPolicy: IfNotPresent
+    tag: ""
   # -- JuiceFS CSI driver image. Only used when config.sandboxes.enabled is true.
   juicefsCSIImage:
     repository: "docker.io/juicedata/juicefs-csi-driver"
@@ -428,6 +435,10 @@ engine:
   # can be stopped by anyone with access, while each one runs agent-generated
   # code and holds a GitHub token for the repo under analysis.
   sandboxTenantId: ""
+  # -- Name of the sandbox snapshot Engine runs boot from. The Engine builds it
+  # from images.engineSandboxImage on first use if it is not already there, so
+  # this only needs changing to run two Engines off distinct snapshots.
+  snapshotName: "engine-sandbox"
 
 insights:
   enabled: true

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -123,13 +123,6 @@ images:
     repository: "docker.io/langchain/sandbox-host"
     pullPolicy: IfNotPresent
     tag: ""
-  # -- Engine sandbox base image. Not run as a workload: the Engine builds its
-  # sandbox snapshot from it on first use. Only used when engine.enabled and
-  # config.sandboxes.enabled are both true.
-  engineSandboxImage:
-    repository: "docker.io/langchain/engine-sandbox"
-    pullPolicy: IfNotPresent
-    tag: ""
   # -- JuiceFS CSI driver image. Only used when config.sandboxes.enabled is true.
   juicefsCSIImage:
     repository: "docker.io/juicedata/juicefs-csi-driver"
@@ -435,10 +428,6 @@ engine:
   # can be stopped by anyone with access, while each one runs agent-generated
   # code and holds a GitHub token for the repo under analysis.
   sandboxTenantId: ""
-  # -- Name of the sandbox snapshot Engine runs boot from. The Engine builds it
-  # from images.engineSandboxImage on first use if it is not already there, so
-  # this only needs changing to run two Engines off distinct snapshots.
-  snapshotName: "engine-sandbox"
 
 insights:
   enabled: true

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -417,6 +417,17 @@ engine:
   # Prior key, accepted for decryption only, so encryptionKey can be rotated
   # without failing runs encrypted just before the swap.
   encryptionKeyPrevious: ""
+  # -- Workspace id that owns Engine sandboxes. Required when sandboxes are
+  # enabled: the Engine signs a service key with this tenant and smith-go
+  # rejects one without it.
+  #
+  # Use a workspace reserved for the Engine, not one people work in. Sandboxes
+  # land in this workspace, so they consume its sandbox quota — an Engine run
+  # can be refused because the workspace is at its cap, and Engine sandboxes
+  # count against a cap bought for other work. They are also listed in it and
+  # can be stopped by anyone with access, while each one runs agent-generated
+  # code and holds a GitHub token for the repo under analysis.
+  sandboxTenantId: ""
 
 insights:
   enabled: true


### PR DESCRIPTION
Adds `engine.sandboxTenantId` → `ISSUES_AGENT_SANDBOX_TENANT_ID` on the Engine pods, plus the guards that make a misconfigured install fail at template time.

langchainplus#31840 moved the Engine off a standing LangSmith API key onto a short-lived `X-Service-Key` JWT for its sandbox calls. That JWT must carry a `tenant_id` claim — smith-go rejects one without it — and the Engine reads it from `ISSUES_AGENT_SANDBOX_TENANT_ID`, raising at sandbox-create time if unset. The chart set no such value, so a self-hosted Engine with sandboxes enabled could not create a sandbox.

**Why a designated workspace rather than the run's own tenant.** A sandbox in the customer's workspace would consume their sandbox quota (`SandboxLimits` has no exemption path, so an Engine run can be refused because the customer is at their cap, and Engine usage eats a cap bought for other work), appear in their sandbox list where anyone with access can stop it, and hold a GitHub App installation token for the repo under analysis. SaaS avoids this with a LangChain-internal workspace. Self-hosted has no vendor-owned workspace and there is no system/reserved-tenant primitive in the product — no `is_system` on tenants, and the only auto-provisioned workspace is `DEFAULT_WORKSPACE_NAME`. So the operator designates one, and the `values.yaml` comment states the quota and visibility consequences so that choice is informed.

This is interim. The durable fix is a real system tenant — reserved at org creation, hidden from workspace lists, exempt from sandbox quota — which is a platform primitive worth scoping on its own rather than folding in here.

Notes for review:
- Plain `value:`, not a `secretKeyRef` — it is a workspace UUID that already appears in logs and trace tags, not a credential. The JWT is signed with `api_key_salt`, which remains a secret ref.
- **No snapshot or image values.** An earlier revision added `engine.snapshotName` and `images.engineSandboxImage`; those are reverted. With langchain-ai/langchainplus#32224 the guest rootfs carries the Engine's toolchain, so runs boot the platform default snapshot (langchain-ai/langchainplus#32304) — which `sandbox-host` already provisions at startup from the ext4 baked into its own image. Nothing to mirror, nothing to point at, no private-registry credential problem.
- The first commit is a separable fix: both existing engine validation tests asserted on the engine failure message but tripped the earlier `apiKeySalt` and auth guards first, so they passed for the wrong reason and never reached the assertion under test. `helm unittest charts/langsmith` was already red on this branch before it.

## Test Plan
- [x] `helm unittest charts/langsmith` — 196 passed, 15 suites, green
- [x] `helm template` with sandboxes enabled renders `ISSUES_AGENT_SANDBOX_TENANT_ID` on both the api-server and queue pods
- [x] `helm template` with engine enabled and no `sandboxTenantId` fails with the guard message; same for sandboxes disabled
- [ ] End-to-end: a self-hosted Engine run creates a sandbox in the designated workspace
