### PR TITLE
fix: cap Run Rules backfills at one day

### DIFF
--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -103,6 +103,7 @@ data:
   SEPARATE_QUEUES_WITH_SINGLE_WORKER: '["host"]'
   RUN_RULES_REDIS_DEDUP_TENANTS: '["*"]'
   RUN_RULES_LIMIT_RRA_RECORDS_PER_BATCH_TENANTS: '["*"]'
+  RUN_RULES_MAX_BACKFILL_MINUTES_TO_PROCESS: "1440"
   {{- if .Values.config.observability.tracing.enabled }}
   OTEL_TRACING_ENABLED: "{{ .Values.config.observability.tracing.enabled }}"
   OTLP_ENDPOINT: "{{ .Values.config.observability.tracing.endpoint }}"

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -360,6 +360,9 @@ tests:
       - equal:
           path: data.RUN_RULES_LIMIT_RRA_RECORDS_PER_BATCH_TENANTS
           value: '["*"]'
+      - equal:
+          path: data.RUN_RULES_MAX_BACKFILL_MINUTES_TO_PROCESS
+          value: "1440"
 
   - it: should configure SmithDB ingestion without SmithDB query endpoints
     values:
@@ -470,6 +473,9 @@ tests:
       - equal:
           path: data.RUN_RULES_LIMIT_RRA_RECORDS_PER_BATCH_TENANTS
           value: '["*"]'
+      - equal:
+          path: data.RUN_RULES_MAX_BACKFILL_MINUTES_TO_PROCESS
+          value: "1440"
 
   - it: should omit frontend SmithDB v2 endpoint flag when disabled
     values:


### PR DESCRIPTION
## Description
Sets `RUN_RULES_MAX_BACKFILL_MINUTES_TO_PROCESS` to 1440 beside the existing Run Rules settings, limiting self-hosted backfill processing to one day.

## Test Plan
- [x] `helm unittest --color=false -f 'tests/langsmith_smithdb_test.yaml' charts/langsmith`
- [x] `helm lint charts/langsmith`

Made by [Open SWE](https://openswe.vercel.app/agents/5880e63e-f300-b895-fd86-6b3437043b04)