### PR TITLE
feat: add priorityClassName to all workloads

### DIFF
--- a/charts/langgraph-cloud/README.md
+++ b/charts/langgraph-cloud/README.md
@@ -375,6 +375,7 @@ If you are upgrading from a chart revision that used the old flat MongoDB values
 | mongo.external.enabled | bool | `false` | Use an external MongoDB deployment instead of the chart-managed MongoDB instance. |
 | mongo.external.existingSecretName | string | `""` | Existing secret name containing the MongoDB connection URL. |
 | mongo.statefulSet.persistence.size | string | `"8Gi"` | Persistent volume size for the bundled MongoDB instance. |
+| mongo.statefulSet.priorityClassName | string | `""` | Optional priority class for the in-chart MongoDB pod. |
 | mongo.statefulSet.resources | object | `{"limits":{"cpu":"2000m","memory":"4Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}` | Resource requests and limits for the bundled MongoDB pod. |
 | mongo.statefulSet.updateStrategy | object | `{}` | Optional StatefulSet update strategy for the in-chart MongoDB instance. Leave unset to keep the Kubernetes default RollingUpdate behavior. |
 | nameOverride | string | `""` | Provide a name in place of `langgraph-cloud` for the chart |

--- a/charts/langgraph-cloud/templates/mongo/stateful-set.yaml
+++ b/charts/langgraph-cloud/templates/mongo/stateful-set.yaml
@@ -28,6 +28,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.mongo.statefulSet.priorityClassName }}
+      priorityClassName: {{ .Values.mongo.statefulSet.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: 30
       {{- include "langGraphCloud.dnsConfig" . | nindent 6 }}
       containers:

--- a/charts/langgraph-cloud/tests/priority_class_name_test.yaml
+++ b/charts/langgraph-cloud/tests/priority_class_name_test.yaml
@@ -1,0 +1,19 @@
+suite: StatefulSet priorityClassName rendering
+templates:
+  - mongo/stateful-set.yaml
+tests:
+  - it: does not render MongoDB priorityClassName by default
+    set:
+      mongo.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+
+  - it: renders a configured MongoDB priorityClassName
+    set:
+      mongo.enabled: true
+      mongo.statefulSet.priorityClassName: database-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: database-priority

--- a/charts/langgraph-cloud/values.yaml
+++ b/charts/langgraph-cloud/values.yaml
@@ -412,6 +412,8 @@ mongo:
     # -- Existing secret name containing the MongoDB connection URL.
     existingSecretName: ""
   statefulSet:
+    # -- Optional priority class for the in-chart MongoDB pod.
+    priorityClassName: ""
     # -- Optional StatefulSet update strategy for the in-chart MongoDB instance.
     # Leave unset to keep the Kubernetes default RollingUpdate behavior.
     updateStrategy: {}

--- a/charts/langgraph-dataplane/README.md
+++ b/charts/langgraph-dataplane/README.md
@@ -63,7 +63,7 @@ You can find the guide to deploy a LangGraph Dataplane [here](https://langchain-
 | operator.deployment.lifecycle | object | `{}` |  |
 | operator.deployment.nodeSelector | object | `{}` |  |
 | operator.deployment.podSecurityContext | object | `{}` |  |
-| operator.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| operator.deployment.priorityClassName | string | `""` |  |
 | operator.deployment.replicas | int | `1` |  |
 | operator.deployment.resources.limits.cpu | string | `"2000m"` |  |
 | operator.deployment.resources.limits.memory | string | `"4Gi"` |  |
@@ -141,7 +141,7 @@ You can find the guide to deploy a LangGraph Dataplane [here](https://langchain-
 | listener.deployment.livenessProbe.timeoutSeconds | int | `60` |  |
 | listener.deployment.nodeSelector | object | `{}` |  |
 | listener.deployment.podSecurityContext | object | `{}` |  |
-| listener.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| listener.deployment.priorityClassName | string | `""` |  |
 | listener.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | listener.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | listener.deployment.readinessProbe.httpGet.port | int | `8080` |  |
@@ -190,7 +190,7 @@ You can find the guide to deploy a LangGraph Dataplane [here](https://langchain-
 | operator.deployment.lifecycle | object | `{}` |  |
 | operator.deployment.nodeSelector | object | `{}` |  |
 | operator.deployment.podSecurityContext | object | `{}` |  |
-| operator.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| operator.deployment.priorityClassName | string | `""` |  |
 | operator.deployment.replicas | int | `1` |  |
 | operator.deployment.resources.limits.cpu | string | `"2000m"` |  |
 | operator.deployment.resources.limits.memory | string | `"4Gi"` |  |

--- a/charts/langgraph-dataplane/README.md
+++ b/charts/langgraph-dataplane/README.md
@@ -63,6 +63,7 @@ You can find the guide to deploy a LangGraph Dataplane [here](https://langchain-
 | operator.deployment.lifecycle | object | `{}` |  |
 | operator.deployment.nodeSelector | object | `{}` |  |
 | operator.deployment.podSecurityContext | object | `{}` |  |
+| operator.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | operator.deployment.replicas | int | `1` |  |
 | operator.deployment.resources.limits.cpu | string | `"2000m"` |  |
 | operator.deployment.resources.limits.memory | string | `"4Gi"` |  |
@@ -140,6 +141,7 @@ You can find the guide to deploy a LangGraph Dataplane [here](https://langchain-
 | listener.deployment.livenessProbe.timeoutSeconds | int | `60` |  |
 | listener.deployment.nodeSelector | object | `{}` |  |
 | listener.deployment.podSecurityContext | object | `{}` |  |
+| listener.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | listener.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | listener.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | listener.deployment.readinessProbe.httpGet.port | int | `8080` |  |
@@ -188,6 +190,7 @@ You can find the guide to deploy a LangGraph Dataplane [here](https://langchain-
 | operator.deployment.lifecycle | object | `{}` |  |
 | operator.deployment.nodeSelector | object | `{}` |  |
 | operator.deployment.podSecurityContext | object | `{}` |  |
+| operator.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | operator.deployment.replicas | int | `1` |  |
 | operator.deployment.resources.limits.cpu | string | `"2000m"` |  |
 | operator.deployment.resources.limits.memory | string | `"4Gi"` |  |

--- a/charts/langgraph-dataplane/README.md
+++ b/charts/langgraph-dataplane/README.md
@@ -266,6 +266,7 @@ You can find the guide to deploy a LangGraph Dataplane [here](https://langchain-
 | redis.statefulSet.persistence.storageClassName | string | `""` |  |
 | redis.statefulSet.persistentVolumeClaimRetentionPolicy | object | `{}` |  |
 | redis.statefulSet.podSecurityContext | object | `{}` |  |
+| redis.statefulSet.priorityClassName | string | `""` | Optional priority class for the in-chart Redis pod. |
 | redis.statefulSet.readinessProbe.exec.command[0] | string | `"/bin/sh"` |  |
 | redis.statefulSet.readinessProbe.exec.command[1] | string | `"-c"` |  |
 | redis.statefulSet.readinessProbe.exec.command[2] | string | `"exec redis-cli ping"` |  |

--- a/charts/langgraph-dataplane/templates/listener/deployment.yaml
+++ b/charts/langgraph-dataplane/templates/listener/deployment.yaml
@@ -59,6 +59,9 @@ spec:
         {{- include "langgraphDataplane.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.listener.name }}
     spec:
+      {{- if .Values.listener.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.listener.deployment.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.listener.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/langgraph-dataplane/templates/listener/deployment.yaml
+++ b/charts/langgraph-dataplane/templates/listener/deployment.yaml
@@ -59,13 +59,13 @@ spec:
         {{- include "langgraphDataplane.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langgraphDataplane.fullname" . }}-{{ .Values.listener.name }}
     spec:
-      {{- if .Values.listener.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.listener.deployment.priorityClassName }}
-      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.listener.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.listener.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.listener.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.listener.deployment.podSecurityContext | nindent 8 }}

--- a/charts/langgraph-dataplane/templates/operator/deployment.yaml
+++ b/charts/langgraph-dataplane/templates/operator/deployment.yaml
@@ -37,15 +37,15 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.operator.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.operator.deployment.priorityClassName }}
-      {{- end }}
       serviceAccountName: {{ include "operator.serviceAccountName" . }}
       {{- include "langgraphDataplane.dnsConfig" . | nindent 6 }}
       automountServiceAccountToken: {{ .Values.operator.serviceAccount.automountServiceAccountToken }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.operator.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.operator.deployment.priorityClassName }}
       {{- end }}
       {{- with .Values.operator.deployment.podSecurityContext }}
       securityContext:

--- a/charts/langgraph-dataplane/templates/operator/deployment.yaml
+++ b/charts/langgraph-dataplane/templates/operator/deployment.yaml
@@ -37,6 +37,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.operator.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.operator.deployment.priorityClassName }}
+      {{- end }}
       serviceAccountName: {{ include "operator.serviceAccountName" . }}
       {{- include "langgraphDataplane.dnsConfig" . | nindent 6 }}
       automountServiceAccountToken: {{ .Values.operator.serviceAccount.automountServiceAccountToken }}

--- a/charts/langgraph-dataplane/templates/redis/stateful-set.yaml
+++ b/charts/langgraph-dataplane/templates/redis/stateful-set.yaml
@@ -46,6 +46,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.redis.statefulSet.priorityClassName }}
+      priorityClassName: {{ .Values.redis.statefulSet.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.redis.statefulSet.terminationGracePeriodSeconds }}
       securityContext:
         {{- toYaml .Values.redis.statefulSet.podSecurityContext | nindent 8 }}

--- a/charts/langgraph-dataplane/tests/deployment_priority_class_name_test.yaml
+++ b/charts/langgraph-dataplane/tests/deployment_priority_class_name_test.yaml
@@ -1,0 +1,29 @@
+suite: Deployment priorityClassName rendering
+templates:
+  - listener/deployment.yaml
+  - operator/deployment.yaml
+  - operator/config-map.yaml
+tests:
+  - it: does not render listener priorityClassName by default
+    template: listener/deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+
+  - it: renders a configured listener priorityClassName
+    template: listener/deployment.yaml
+    set:
+      listener.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured operator priorityClassName
+    template: operator/deployment.yaml
+    set:
+      operator.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority

--- a/charts/langgraph-dataplane/tests/priority_class_name_test.yaml
+++ b/charts/langgraph-dataplane/tests/priority_class_name_test.yaml
@@ -1,0 +1,16 @@
+suite: StatefulSet priorityClassName rendering
+templates:
+  - redis/stateful-set.yaml
+tests:
+  - it: does not render Redis priorityClassName by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+
+  - it: renders a configured Redis priorityClassName
+    set:
+      redis.statefulSet.priorityClassName: database-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: database-priority

--- a/charts/langgraph-dataplane/values.yaml
+++ b/charts/langgraph-dataplane/values.yaml
@@ -389,6 +389,8 @@ redis:
     existingSecretName: ""
   containerPort: 6379
   statefulSet:
+    # -- Optional priority class for the in-chart Redis pod.
+    priorityClassName: ""
     # -- Optional StatefulSet update strategy for the in-chart Redis instance.
     # Leave unset to keep the Kubernetes default RollingUpdate behavior.
     updateStrategy: {}

--- a/charts/langgraph-dataplane/values.yaml
+++ b/charts/langgraph-dataplane/values.yaml
@@ -98,8 +98,6 @@ listener:
   name: "listener"
   containerPort: 8080
   deployment:
-    # -- Optional priority class for the pod.
-    priorityClassName: ""
     autoRestart: true
     replicas: 1
     labels: {}
@@ -107,6 +105,7 @@ listener:
     podSecurityContext: {}
     securityContext: {}
     lifecycle: {}
+    priorityClassName: ""
     resources:
       limits:
         cpu: 2000m
@@ -180,8 +179,6 @@ operator:
   watchNamespaces: ""
   kedaEnabled: true
   deployment:
-    # -- Optional priority class for the pod.
-    priorityClassName: ""
     autoRestart: true
     replicas: 1
     labels: {}
@@ -189,6 +186,7 @@ operator:
     podSecurityContext: {}
     securityContext: {}
     lifecycle: {}
+    priorityClassName: ""
     resources:
       limits:
         cpu: 2000m

--- a/charts/langgraph-dataplane/values.yaml
+++ b/charts/langgraph-dataplane/values.yaml
@@ -98,6 +98,8 @@ listener:
   name: "listener"
   containerPort: 8080
   deployment:
+    # -- Optional priority class for the pod.
+    priorityClassName: ""
     autoRestart: true
     replicas: 1
     labels: {}
@@ -178,6 +180,8 @@ operator:
   watchNamespaces: ""
   kedaEnabled: true
   deployment:
+    # -- Optional priority class for the pod.
+    priorityClassName: ""
     autoRestart: true
     replicas: 1
     labels: {}

--- a/charts/langsmith-auth-proxy/README.md
+++ b/charts/langsmith-auth-proxy/README.md
@@ -93,7 +93,7 @@ Control which phases are sent to the transformer via `processingMode`:
 | authProxy.deployment.livenessProbe.timeoutSeconds | int | `1` |  |
 | authProxy.deployment.nodeSelector | object | `{}` |  |
 | authProxy.deployment.podSecurityContext | object | `{}` |  |
-| authProxy.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| authProxy.deployment.priorityClassName | string | `""` |  |
 | authProxy.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | authProxy.deployment.readinessProbe.httpGet.path | string | `"/healthz"` |  |
 | authProxy.deployment.readinessProbe.httpGet.port | int | `10000` |  |

--- a/charts/langsmith-auth-proxy/README.md
+++ b/charts/langsmith-auth-proxy/README.md
@@ -93,6 +93,7 @@ Control which phases are sent to the transformer via `processingMode`:
 | authProxy.deployment.livenessProbe.timeoutSeconds | int | `1` |  |
 | authProxy.deployment.nodeSelector | object | `{}` |  |
 | authProxy.deployment.podSecurityContext | object | `{}` |  |
+| authProxy.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | authProxy.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | authProxy.deployment.readinessProbe.httpGet.path | string | `"/healthz"` |  |
 | authProxy.deployment.readinessProbe.httpGet.port | int | `10000` |  |

--- a/charts/langsmith-auth-proxy/templates/auth-proxy/deployment.yaml
+++ b/charts/langsmith-auth-proxy/templates/auth-proxy/deployment.yaml
@@ -45,13 +45,13 @@ spec:
         {{- include "authProxy.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "authProxy.fullname" . }}-{{ .Values.authProxy.name }}
     spec:
-      {{- if .Values.authProxy.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.authProxy.deployment.priorityClassName }}
-      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.authProxy.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.authProxy.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.authProxy.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- include "authProxy.podSecurityContext" (dict "Values" .Values "componentSecurityContext" .Values.authProxy.deployment.podSecurityContext) | nindent 8 }}

--- a/charts/langsmith-auth-proxy/templates/auth-proxy/deployment.yaml
+++ b/charts/langsmith-auth-proxy/templates/auth-proxy/deployment.yaml
@@ -45,6 +45,9 @@ spec:
         {{- include "authProxy.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "authProxy.fullname" . }}-{{ .Values.authProxy.name }}
     spec:
+      {{- if .Values.authProxy.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.authProxy.deployment.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.authProxy.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/langsmith-auth-proxy/tests/priority_class_name_test.yaml
+++ b/charts/langsmith-auth-proxy/tests/priority_class_name_test.yaml
@@ -1,0 +1,33 @@
+suite: Deployment priorityClassName rendering
+templates:
+  - auth-proxy/config-map.yaml
+  - auth-proxy/deployment.yaml
+values:
+  - common-values.yaml
+tests:
+  - it: does not render auth proxy priorityClassName by default
+    template: auth-proxy/deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+
+  - it: renders a configured auth proxy priorityClassName
+    template: auth-proxy/deployment.yaml
+    set:
+      authProxy.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders priorityClassName for an auth proxy Rollout
+    template: auth-proxy/deployment.yaml
+    set:
+      authProxy.rollout.enabled: true
+      authProxy.deployment.priorityClassName: workload-priority
+    asserts:
+      - isKind:
+          of: Rollout
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority

--- a/charts/langsmith-auth-proxy/values.yaml
+++ b/charts/langsmith-auth-proxy/values.yaml
@@ -154,14 +154,13 @@ authProxy:
         steps:
           - setWeight: 100
   deployment:
-    # -- Optional priority class for the pod.
-    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}
     podSecurityContext: {}
     securityContext: {}
     lifecycle: {}
+    priorityClassName: ""
     resources:
       limits:
         cpu: 500m

--- a/charts/langsmith-auth-proxy/values.yaml
+++ b/charts/langsmith-auth-proxy/values.yaml
@@ -154,6 +154,8 @@ authProxy:
         steps:
           - setWeight: 100
   deployment:
+    # -- Optional priority class for the pod.
+    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}

--- a/charts/langsmith-observability/README.md
+++ b/charts/langsmith-observability/README.md
@@ -161,6 +161,7 @@ Values for Loki Single Binary: `https://github.com/grafana/loki/blob/main/produc
 | mimir.persistence.storageClass | string | `""` |  |
 | mimir.podAnnotations | object | `{}` |  |
 | mimir.podSecurityContext | object | `{}` |  |
+| mimir.priorityClassName | string | `""` | Optional priority class for the Mimir pod. |
 | mimir.readinessProbe.failureThreshold | int | `3` |  |
 | mimir.readinessProbe.httpGet.path | string | `"/ready"` |  |
 | mimir.readinessProbe.httpGet.port | string | `"http"` |  |

--- a/charts/langsmith-observability/templates/mimir/stateful-set.yaml
+++ b/charts/langsmith-observability/templates/mimir/stateful-set.yaml
@@ -25,6 +25,9 @@ spec:
         {{- toYaml .Values.mimir.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.mimir.priorityClassName }}
+      priorityClassName: {{ .Values.mimir.priorityClassName }}
+      {{- end }}
       containers:
         - name: mimir
           image: {{ .Values.mimir.image.registry }}/{{ .Values.mimir.image.repository }}{{ if .Values.mimir.image.tag }}:{{ .Values.mimir.image.tag }}{{ end }}

--- a/charts/langsmith-observability/tests/priority_class_name_test.yaml
+++ b/charts/langsmith-observability/tests/priority_class_name_test.yaml
@@ -1,0 +1,22 @@
+suite: StatefulSet priorityClassName rendering
+templates:
+  - mimir/stateful-set.yaml
+  - mimir/config-map.yaml
+tests:
+  - it: does not render Mimir priorityClassName by default
+    template: mimir/stateful-set.yaml
+    set:
+      mimir.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+
+  - it: renders a configured Mimir priorityClassName
+    template: mimir/stateful-set.yaml
+    set:
+      mimir.enabled: true
+      mimir.priorityClassName: observability-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: observability-priority

--- a/charts/langsmith-observability/values.yaml
+++ b/charts/langsmith-observability/values.yaml
@@ -159,6 +159,8 @@ loki:
 
 mimir:
   enabled: false
+  # -- Optional priority class for the Mimir pod.
+  priorityClassName: ""
   image:
     registry: docker.io
     repository: grafana/mimir

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -247,6 +247,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | fleetToolServer.deployment.livenessProbe.timeoutSeconds | int | `3` |  |
 | fleetToolServer.deployment.nodeSelector | object | `{}` |  |
 | fleetToolServer.deployment.podSecurityContext | object | `{}` |  |
+| fleetToolServer.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | fleetToolServer.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | fleetToolServer.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | fleetToolServer.deployment.readinessProbe.httpGet.port | int | `1989` |  |
@@ -302,6 +303,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | fleetTriggerServer.deployment.livenessProbe.timeoutSeconds | int | `1` |  |
 | fleetTriggerServer.deployment.nodeSelector | object | `{}` |  |
 | fleetTriggerServer.deployment.podSecurityContext | object | `{}` |  |
+| fleetTriggerServer.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | fleetTriggerServer.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | fleetTriggerServer.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | fleetTriggerServer.deployment.readinessProbe.httpGet.port | int | `1990` |  |
@@ -420,6 +422,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | ingestQueue.deployment.livenessProbe.timeoutSeconds | int | `1` |  |
 | ingestQueue.deployment.nodeSelector | object | `{}` |  |
 | ingestQueue.deployment.podSecurityContext | object | `{}` |  |
+| ingestQueue.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | ingestQueue.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | ingestQueue.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | ingestQueue.deployment.readinessProbe.httpGet.port | int | `1989` |  |
@@ -868,6 +871,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.clusterManager.deployment.labels | object | `{}` |  |
 | smithdb.clusterManager.deployment.nodeSelector | object | `{}` |  |
 | smithdb.clusterManager.deployment.podSecurityContext | object | `{}` |  |
+| smithdb.clusterManager.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | smithdb.clusterManager.deployment.probes.livenessProbe.failureThreshold | int | `6` |  |
 | smithdb.clusterManager.deployment.probes.livenessProbe.httpGet.path | string | `"/health"` |  |
 | smithdb.clusterManager.deployment.probes.livenessProbe.httpGet.port | string | `"http"` |  |
@@ -914,6 +918,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.compaction.deployment.labels | object | `{}` |  |
 | smithdb.compaction.deployment.nodeSelector | object | `{}` |  |
 | smithdb.compaction.deployment.podSecurityContext | object | `{}` |  |
+| smithdb.compaction.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | smithdb.compaction.deployment.probes.livenessProbe.failureThreshold | int | `6` |  |
 | smithdb.compaction.deployment.probes.livenessProbe.httpGet.path | string | `"/health"` |  |
 | smithdb.compaction.deployment.probes.livenessProbe.httpGet.port | string | `"http"` |  |
@@ -967,6 +972,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.compactionWorker.deployment.labels | object | `{}` |  |
 | smithdb.compactionWorker.deployment.nodeSelector | object | `{}` |  |
 | smithdb.compactionWorker.deployment.podSecurityContext | object | `{}` |  |
+| smithdb.compactionWorker.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | smithdb.compactionWorker.deployment.probes.livenessProbe.failureThreshold | int | `6` |  |
 | smithdb.compactionWorker.deployment.probes.livenessProbe.httpGet.path | string | `"/health"` |  |
 | smithdb.compactionWorker.deployment.probes.livenessProbe.httpGet.port | string | `"http"` |  |
@@ -1040,6 +1046,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.ingestion.deployment.labels | object | `{}` |  |
 | smithdb.ingestion.deployment.nodeSelector | object | `{}` |  |
 | smithdb.ingestion.deployment.podSecurityContext | object | `{}` |  |
+| smithdb.ingestion.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | smithdb.ingestion.deployment.probes.livenessProbe.failureThreshold | int | `6` |  |
 | smithdb.ingestion.deployment.probes.livenessProbe.httpGet.path | string | `"/health"` |  |
 | smithdb.ingestion.deployment.probes.livenessProbe.httpGet.port | string | `"http"` |  |
@@ -1209,6 +1216,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.query.deployment.labels | object | `{}` |  |
 | smithdb.query.deployment.nodeSelector | object | `{}` |  |
 | smithdb.query.deployment.podSecurityContext | object | `{}` |  |
+| smithdb.query.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | smithdb.query.deployment.probes.livenessProbe.failureThreshold | int | `6` |  |
 | smithdb.query.deployment.probes.livenessProbe.httpGet.path | string | `"/health"` |  |
 | smithdb.query.deployment.probes.livenessProbe.httpGet.port | string | `"http"` |  |
@@ -1389,6 +1397,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | aceBackend.deployment.livenessProbe.timeoutSeconds | int | `1` |  |
 | aceBackend.deployment.nodeSelector | object | `{}` |  |
 | aceBackend.deployment.podSecurityContext | object | `{}` |  |
+| aceBackend.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | aceBackend.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | aceBackend.deployment.readinessProbe.httpGet.path | string | `"/ok"` |  |
 | aceBackend.deployment.readinessProbe.httpGet.port | int | `1987` |  |
@@ -1536,6 +1545,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | backend.deployment.livenessProbe.timeoutSeconds | int | `10` |  |
 | backend.deployment.nodeSelector | object | `{}` |  |
 | backend.deployment.podSecurityContext | object | `{}` |  |
+| backend.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | backend.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | backend.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | backend.deployment.readinessProbe.httpGet.port | int | `1984` |  |
@@ -1762,6 +1772,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | hostBackend.deployment.livenessProbe.timeoutSeconds | int | `1` |  |
 | hostBackend.deployment.nodeSelector | object | `{}` |  |
 | hostBackend.deployment.podSecurityContext | object | `{}` |  |
+| hostBackend.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | hostBackend.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | hostBackend.deployment.readinessProbe.httpGet.path | string | `"/ok"` |  |
 | hostBackend.deployment.readinessProbe.httpGet.port | int | `1985` |  |
@@ -1849,6 +1860,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | frontend.deployment.livenessProbe.timeoutSeconds | int | `1` |  |
 | frontend.deployment.nodeSelector | object | `{}` |  |
 | frontend.deployment.podSecurityContext | object | `{}` |  |
+| frontend.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | frontend.deployment.readinessProbe.failureThreshold | int | `10` |  |
 | frontend.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | frontend.deployment.readinessProbe.httpGet.port | int | `8080` |  |
@@ -1949,6 +1961,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | listener.deployment.livenessProbe.timeoutSeconds | int | `60` |  |
 | listener.deployment.nodeSelector | object | `{}` |  |
 | listener.deployment.podSecurityContext | object | `{}` |  |
+| listener.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | listener.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | listener.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | listener.deployment.readinessProbe.httpGet.port | int | `8080` |  |
@@ -2012,6 +2025,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | agentGateway.deployment.livenessProbe.timeoutSeconds | int | `3` |  |
 | agentGateway.deployment.nodeSelector | object | `{}` |  |
 | agentGateway.deployment.podSecurityContext | object | `{}` |  |
+| agentGateway.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | agentGateway.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | agentGateway.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | agentGateway.deployment.readinessProbe.httpGet.port | int | `8083` |  |
@@ -2068,6 +2082,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | presidioAnalyzer.deployment.livenessProbe.timeoutSeconds | int | `3` |  |
 | presidioAnalyzer.deployment.nodeSelector | object | `{}` |  |
 | presidioAnalyzer.deployment.podSecurityContext | object | `{}` |  |
+| presidioAnalyzer.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | presidioAnalyzer.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | presidioAnalyzer.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | presidioAnalyzer.deployment.readinessProbe.httpGet.port | int | `3000` |  |
@@ -2115,6 +2130,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | operator.deployment.lifecycle | object | `{}` |  |
 | operator.deployment.nodeSelector | object | `{}` |  |
 | operator.deployment.podSecurityContext | object | `{}` |  |
+| operator.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | operator.deployment.replicas | int | `1` |  |
 | operator.deployment.resources.limits.cpu | string | `"2000m"` |  |
 | operator.deployment.resources.limits.memory | string | `"4Gi"` |  |
@@ -2191,6 +2207,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | platformBackend.deployment.livenessProbe.timeoutSeconds | int | `1` |  |
 | platformBackend.deployment.nodeSelector | object | `{}` |  |
 | platformBackend.deployment.podSecurityContext | object | `{}` |  |
+| platformBackend.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | platformBackend.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | platformBackend.deployment.readinessProbe.httpGet.path | string | `"/ok"` |  |
 | platformBackend.deployment.readinessProbe.httpGet.port | int | `1986` |  |
@@ -2274,6 +2291,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | playground.deployment.livenessProbe.timeoutSeconds | int | `1` |  |
 | playground.deployment.nodeSelector | object | `{}` |  |
 | playground.deployment.podSecurityContext | object | `{}` |  |
+| playground.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | playground.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | playground.deployment.readinessProbe.httpGet.path | string | `"/ok"` |  |
 | playground.deployment.readinessProbe.httpGet.port | int | `1988` |  |
@@ -2442,6 +2460,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | queue.deployment.livenessProbe.timeoutSeconds | int | `60` |  |
 | queue.deployment.nodeSelector | object | `{}` |  |
 | queue.deployment.podSecurityContext | object | `{}` |  |
+| queue.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
 | queue.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | queue.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | queue.deployment.readinessProbe.httpGet.port | int | `8080` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -247,7 +247,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | fleetToolServer.deployment.livenessProbe.timeoutSeconds | int | `3` |  |
 | fleetToolServer.deployment.nodeSelector | object | `{}` |  |
 | fleetToolServer.deployment.podSecurityContext | object | `{}` |  |
-| fleetToolServer.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| fleetToolServer.deployment.priorityClassName | string | `""` |  |
 | fleetToolServer.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | fleetToolServer.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | fleetToolServer.deployment.readinessProbe.httpGet.port | int | `1989` |  |
@@ -303,7 +303,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | fleetTriggerServer.deployment.livenessProbe.timeoutSeconds | int | `1` |  |
 | fleetTriggerServer.deployment.nodeSelector | object | `{}` |  |
 | fleetTriggerServer.deployment.podSecurityContext | object | `{}` |  |
-| fleetTriggerServer.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| fleetTriggerServer.deployment.priorityClassName | string | `""` |  |
 | fleetTriggerServer.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | fleetTriggerServer.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | fleetTriggerServer.deployment.readinessProbe.httpGet.port | int | `1990` |  |
@@ -422,7 +422,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | ingestQueue.deployment.livenessProbe.timeoutSeconds | int | `1` |  |
 | ingestQueue.deployment.nodeSelector | object | `{}` |  |
 | ingestQueue.deployment.podSecurityContext | object | `{}` |  |
-| ingestQueue.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| ingestQueue.deployment.priorityClassName | string | `""` |  |
 | ingestQueue.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | ingestQueue.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | ingestQueue.deployment.readinessProbe.httpGet.port | int | `1989` |  |
@@ -871,7 +871,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.clusterManager.deployment.labels | object | `{}` |  |
 | smithdb.clusterManager.deployment.nodeSelector | object | `{}` |  |
 | smithdb.clusterManager.deployment.podSecurityContext | object | `{}` |  |
-| smithdb.clusterManager.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| smithdb.clusterManager.deployment.priorityClassName | string | `""` |  |
 | smithdb.clusterManager.deployment.probes.livenessProbe.failureThreshold | int | `6` |  |
 | smithdb.clusterManager.deployment.probes.livenessProbe.httpGet.path | string | `"/health"` |  |
 | smithdb.clusterManager.deployment.probes.livenessProbe.httpGet.port | string | `"http"` |  |
@@ -918,7 +918,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.compaction.deployment.labels | object | `{}` |  |
 | smithdb.compaction.deployment.nodeSelector | object | `{}` |  |
 | smithdb.compaction.deployment.podSecurityContext | object | `{}` |  |
-| smithdb.compaction.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| smithdb.compaction.deployment.priorityClassName | string | `""` |  |
 | smithdb.compaction.deployment.probes.livenessProbe.failureThreshold | int | `6` |  |
 | smithdb.compaction.deployment.probes.livenessProbe.httpGet.path | string | `"/health"` |  |
 | smithdb.compaction.deployment.probes.livenessProbe.httpGet.port | string | `"http"` |  |
@@ -972,7 +972,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.compactionWorker.deployment.labels | object | `{}` |  |
 | smithdb.compactionWorker.deployment.nodeSelector | object | `{}` |  |
 | smithdb.compactionWorker.deployment.podSecurityContext | object | `{}` |  |
-| smithdb.compactionWorker.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| smithdb.compactionWorker.deployment.priorityClassName | string | `""` |  |
 | smithdb.compactionWorker.deployment.probes.livenessProbe.failureThreshold | int | `6` |  |
 | smithdb.compactionWorker.deployment.probes.livenessProbe.httpGet.path | string | `"/health"` |  |
 | smithdb.compactionWorker.deployment.probes.livenessProbe.httpGet.port | string | `"http"` |  |
@@ -1046,7 +1046,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.ingestion.deployment.labels | object | `{}` |  |
 | smithdb.ingestion.deployment.nodeSelector | object | `{}` |  |
 | smithdb.ingestion.deployment.podSecurityContext | object | `{}` |  |
-| smithdb.ingestion.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| smithdb.ingestion.deployment.priorityClassName | string | `""` |  |
 | smithdb.ingestion.deployment.probes.livenessProbe.failureThreshold | int | `6` |  |
 | smithdb.ingestion.deployment.probes.livenessProbe.httpGet.path | string | `"/health"` |  |
 | smithdb.ingestion.deployment.probes.livenessProbe.httpGet.port | string | `"http"` |  |
@@ -1216,7 +1216,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.query.deployment.labels | object | `{}` |  |
 | smithdb.query.deployment.nodeSelector | object | `{}` |  |
 | smithdb.query.deployment.podSecurityContext | object | `{}` |  |
-| smithdb.query.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| smithdb.query.deployment.priorityClassName | string | `""` |  |
 | smithdb.query.deployment.probes.livenessProbe.failureThreshold | int | `6` |  |
 | smithdb.query.deployment.probes.livenessProbe.httpGet.path | string | `"/health"` |  |
 | smithdb.query.deployment.probes.livenessProbe.httpGet.port | string | `"http"` |  |
@@ -1397,7 +1397,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | aceBackend.deployment.livenessProbe.timeoutSeconds | int | `1` |  |
 | aceBackend.deployment.nodeSelector | object | `{}` |  |
 | aceBackend.deployment.podSecurityContext | object | `{}` |  |
-| aceBackend.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| aceBackend.deployment.priorityClassName | string | `""` |  |
 | aceBackend.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | aceBackend.deployment.readinessProbe.httpGet.path | string | `"/ok"` |  |
 | aceBackend.deployment.readinessProbe.httpGet.port | int | `1987` |  |
@@ -1545,7 +1545,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | backend.deployment.livenessProbe.timeoutSeconds | int | `10` |  |
 | backend.deployment.nodeSelector | object | `{}` |  |
 | backend.deployment.podSecurityContext | object | `{}` |  |
-| backend.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| backend.deployment.priorityClassName | string | `""` |  |
 | backend.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | backend.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | backend.deployment.readinessProbe.httpGet.port | int | `1984` |  |
@@ -1772,7 +1772,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | hostBackend.deployment.livenessProbe.timeoutSeconds | int | `1` |  |
 | hostBackend.deployment.nodeSelector | object | `{}` |  |
 | hostBackend.deployment.podSecurityContext | object | `{}` |  |
-| hostBackend.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| hostBackend.deployment.priorityClassName | string | `""` |  |
 | hostBackend.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | hostBackend.deployment.readinessProbe.httpGet.path | string | `"/ok"` |  |
 | hostBackend.deployment.readinessProbe.httpGet.port | int | `1985` |  |
@@ -1860,7 +1860,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | frontend.deployment.livenessProbe.timeoutSeconds | int | `1` |  |
 | frontend.deployment.nodeSelector | object | `{}` |  |
 | frontend.deployment.podSecurityContext | object | `{}` |  |
-| frontend.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| frontend.deployment.priorityClassName | string | `""` |  |
 | frontend.deployment.readinessProbe.failureThreshold | int | `10` |  |
 | frontend.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | frontend.deployment.readinessProbe.httpGet.port | int | `8080` |  |
@@ -1961,7 +1961,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | listener.deployment.livenessProbe.timeoutSeconds | int | `60` |  |
 | listener.deployment.nodeSelector | object | `{}` |  |
 | listener.deployment.podSecurityContext | object | `{}` |  |
-| listener.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| listener.deployment.priorityClassName | string | `""` |  |
 | listener.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | listener.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | listener.deployment.readinessProbe.httpGet.port | int | `8080` |  |
@@ -2025,7 +2025,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | agentGateway.deployment.livenessProbe.timeoutSeconds | int | `3` |  |
 | agentGateway.deployment.nodeSelector | object | `{}` |  |
 | agentGateway.deployment.podSecurityContext | object | `{}` |  |
-| agentGateway.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| agentGateway.deployment.priorityClassName | string | `""` |  |
 | agentGateway.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | agentGateway.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | agentGateway.deployment.readinessProbe.httpGet.port | int | `8083` |  |
@@ -2082,7 +2082,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | presidioAnalyzer.deployment.livenessProbe.timeoutSeconds | int | `3` |  |
 | presidioAnalyzer.deployment.nodeSelector | object | `{}` |  |
 | presidioAnalyzer.deployment.podSecurityContext | object | `{}` |  |
-| presidioAnalyzer.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| presidioAnalyzer.deployment.priorityClassName | string | `""` |  |
 | presidioAnalyzer.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | presidioAnalyzer.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | presidioAnalyzer.deployment.readinessProbe.httpGet.port | int | `3000` |  |
@@ -2130,7 +2130,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | operator.deployment.lifecycle | object | `{}` |  |
 | operator.deployment.nodeSelector | object | `{}` |  |
 | operator.deployment.podSecurityContext | object | `{}` |  |
-| operator.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| operator.deployment.priorityClassName | string | `""` |  |
 | operator.deployment.replicas | int | `1` |  |
 | operator.deployment.resources.limits.cpu | string | `"2000m"` |  |
 | operator.deployment.resources.limits.memory | string | `"4Gi"` |  |
@@ -2207,7 +2207,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | platformBackend.deployment.livenessProbe.timeoutSeconds | int | `1` |  |
 | platformBackend.deployment.nodeSelector | object | `{}` |  |
 | platformBackend.deployment.podSecurityContext | object | `{}` |  |
-| platformBackend.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| platformBackend.deployment.priorityClassName | string | `""` |  |
 | platformBackend.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | platformBackend.deployment.readinessProbe.httpGet.path | string | `"/ok"` |  |
 | platformBackend.deployment.readinessProbe.httpGet.port | int | `1986` |  |
@@ -2291,7 +2291,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | playground.deployment.livenessProbe.timeoutSeconds | int | `1` |  |
 | playground.deployment.nodeSelector | object | `{}` |  |
 | playground.deployment.podSecurityContext | object | `{}` |  |
-| playground.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| playground.deployment.priorityClassName | string | `""` |  |
 | playground.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | playground.deployment.readinessProbe.httpGet.path | string | `"/ok"` |  |
 | playground.deployment.readinessProbe.httpGet.port | int | `1988` |  |
@@ -2460,7 +2460,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | queue.deployment.livenessProbe.timeoutSeconds | int | `60` |  |
 | queue.deployment.nodeSelector | object | `{}` |  |
 | queue.deployment.podSecurityContext | object | `{}` |  |
-| queue.deployment.priorityClassName | string | `""` | Optional priority class for the pod. |
+| queue.deployment.priorityClassName | string | `""` |  |
 | queue.deployment.readinessProbe.failureThreshold | int | `6` |  |
 | queue.deployment.readinessProbe.httpGet.path | string | `"/health"` |  |
 | queue.deployment.readinessProbe.httpGet.port | int | `8080` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1164,6 +1164,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.migration.taskdb.postgres.statefulSet.persistence.storageClassName | string | `""` |  |
 | smithdb.migration.taskdb.postgres.statefulSet.persistentVolumeClaimRetentionPolicy | object | `{"whenDeleted":"Delete","whenScaled":"Retain"}` | Delete the migration-scoped taskdb PVC when its StatefulSet is removed. |
 | smithdb.migration.taskdb.postgres.statefulSet.podSecurityContext | object | `{}` |  |
+| smithdb.migration.taskdb.postgres.statefulSet.priorityClassName | string | `""` | Optional priority class for the in-chart SmithDB taskdb Postgres pod. |
 | smithdb.migration.taskdb.postgres.statefulSet.readinessProbe.exec.command[0] | string | `"/bin/sh"` |  |
 | smithdb.migration.taskdb.postgres.statefulSet.readinessProbe.exec.command[1] | string | `"-c"` |  |
 | smithdb.migration.taskdb.postgres.statefulSet.readinessProbe.exec.command[2] | string | `"exec pg_isready -d \"$POSTGRES_DB\" -U \"$POSTGRES_USER\""` |  |
@@ -1692,6 +1693,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | clickhouse.statefulSet.persistence.storageClassName | string | `""` |  |
 | clickhouse.statefulSet.persistentVolumeClaimRetentionPolicy | object | `{}` |  |
 | clickhouse.statefulSet.podSecurityContext | object | `{}` |  |
+| clickhouse.statefulSet.priorityClassName | string | `""` | Optional priority class for the in-chart ClickHouse pod. |
 | clickhouse.statefulSet.readinessProbe.failureThreshold | int | `6` |  |
 | clickhouse.statefulSet.readinessProbe.httpGet.path | string | `"/ping"` |  |
 | clickhouse.statefulSet.readinessProbe.httpGet.port | int | `8123` |  |
@@ -2370,6 +2372,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | postgres.statefulSet.persistence.storageClassName | string | `""` |  |
 | postgres.statefulSet.persistentVolumeClaimRetentionPolicy | object | `{}` |  |
 | postgres.statefulSet.podSecurityContext | object | `{}` |  |
+| postgres.statefulSet.priorityClassName | string | `""` | Optional priority class for the in-chart PostgreSQL pod. |
 | postgres.statefulSet.readinessProbe.exec.command[0] | string | `"/bin/sh"` |  |
 | postgres.statefulSet.readinessProbe.exec.command[1] | string | `"-c"` |  |
 | postgres.statefulSet.readinessProbe.exec.command[2] | string | `"exec pg_isready -d postgres -U postgres"` |  |
@@ -2531,6 +2534,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | redis.statefulSet.persistence.storageClassName | string | `""` |  |
 | redis.statefulSet.persistentVolumeClaimRetentionPolicy | object | `{}` |  |
 | redis.statefulSet.podSecurityContext | object | `{}` |  |
+| redis.statefulSet.priorityClassName | string | `""` | Optional priority class for the in-chart Redis pod. |
 | redis.statefulSet.readinessProbe.exec.command[0] | string | `"/bin/sh"` |  |
 | redis.statefulSet.readinessProbe.exec.command[1] | string | `"-c"` |  |
 | redis.statefulSet.readinessProbe.exec.command[2] | string | `"exec redis-cli ping"` |  |

--- a/charts/langsmith/templates/ace-backend/deployment.yaml
+++ b/charts/langsmith/templates/ace-backend/deployment.yaml
@@ -49,13 +49,13 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.aceBackend.name }}
     spec:
-      {{- if .Values.aceBackend.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.aceBackend.deployment.priorityClassName }}
-      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.aceBackend.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.aceBackend.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.aceBackend.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- include "langsmith.podSecurityContext" (dict "Values" .Values "componentSecurityContext" .Values.aceBackend.deployment.podSecurityContext) | nindent 8 }}

--- a/charts/langsmith/templates/ace-backend/deployment.yaml
+++ b/charts/langsmith/templates/ace-backend/deployment.yaml
@@ -49,6 +49,9 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.aceBackend.name }}
     spec:
+      {{- if .Values.aceBackend.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.aceBackend.deployment.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.aceBackend.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/langsmith/templates/agent-features/fleet/tool-server/deployment.yaml
+++ b/charts/langsmith/templates/agent-features/fleet/tool-server/deployment.yaml
@@ -42,6 +42,9 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.fleetToolServer.name }}
     spec:
+      {{- if .Values.fleetToolServer.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.fleetToolServer.deployment.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.fleetToolServer.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/langsmith/templates/agent-features/fleet/tool-server/deployment.yaml
+++ b/charts/langsmith/templates/agent-features/fleet/tool-server/deployment.yaml
@@ -42,13 +42,13 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.fleetToolServer.name }}
     spec:
-      {{- if .Values.fleetToolServer.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.fleetToolServer.deployment.priorityClassName }}
-      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.fleetToolServer.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.fleetToolServer.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.fleetToolServer.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- include "langsmith.podSecurityContext" (dict "Values" .Values "componentSecurityContext" .Values.fleetToolServer.deployment.podSecurityContext) | nindent 8 }}

--- a/charts/langsmith/templates/agent-features/fleet/trigger-server/deployment.yaml
+++ b/charts/langsmith/templates/agent-features/fleet/trigger-server/deployment.yaml
@@ -41,13 +41,13 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.fleetTriggerServer.name }}
     spec:
-      {{- if .Values.fleetTriggerServer.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.fleetTriggerServer.deployment.priorityClassName }}
-      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.fleetTriggerServer.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.fleetTriggerServer.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.fleetTriggerServer.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- include "langsmith.podSecurityContext" (dict "Values" .Values "componentSecurityContext" .Values.fleetTriggerServer.deployment.podSecurityContext) | nindent 8 }}

--- a/charts/langsmith/templates/agent-features/fleet/trigger-server/deployment.yaml
+++ b/charts/langsmith/templates/agent-features/fleet/trigger-server/deployment.yaml
@@ -41,6 +41,9 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.fleetTriggerServer.name }}
     spec:
+      {{- if .Values.fleetTriggerServer.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.fleetTriggerServer.deployment.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.fleetTriggerServer.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/langsmith/templates/agent-gateway/deployment.yaml
+++ b/charts/langsmith/templates/agent-gateway/deployment.yaml
@@ -49,13 +49,13 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.agentGateway.name }}
     spec:
-      {{- if .Values.agentGateway.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.agentGateway.deployment.priorityClassName }}
-      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.agentGateway.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.agentGateway.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.agentGateway.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- include "langsmith.podSecurityContext" (dict "Values" .Values "componentSecurityContext" .Values.agentGateway.deployment.podSecurityContext) | nindent 8 }}

--- a/charts/langsmith/templates/agent-gateway/deployment.yaml
+++ b/charts/langsmith/templates/agent-gateway/deployment.yaml
@@ -49,6 +49,9 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.agentGateway.name }}
     spec:
+      {{- if .Values.agentGateway.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.agentGateway.deployment.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.agentGateway.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/langsmith/templates/backend/deployment.yaml
+++ b/charts/langsmith/templates/backend/deployment.yaml
@@ -61,6 +61,9 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}
     spec:
+      {{- if .Values.backend.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.backend.deployment.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.backend.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/langsmith/templates/backend/deployment.yaml
+++ b/charts/langsmith/templates/backend/deployment.yaml
@@ -61,13 +61,13 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.backend.name }}
     spec:
-      {{- if .Values.backend.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.backend.deployment.priorityClassName }}
-      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.backend.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.backend.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.backend.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- include "langsmith.podSecurityContext" (dict "Values" .Values "componentSecurityContext" .Values.backend.deployment.podSecurityContext) | nindent 8 }}

--- a/charts/langsmith/templates/clickhouse/stateful-set.yaml
+++ b/charts/langsmith/templates/clickhouse/stateful-set.yaml
@@ -69,6 +69,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.clickhouse.statefulSet.priorityClassName }}
+      priorityClassName: {{ .Values.clickhouse.statefulSet.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.clickhouse.statefulSet.terminationGracePeriodSeconds }}
       securityContext:
         {{- include "langsmith.podSecurityContext" (dict "Values" .Values "componentSecurityContext" .Values.clickhouse.statefulSet.podSecurityContext) | nindent 8 }}

--- a/charts/langsmith/templates/frontend/deployment.yaml
+++ b/charts/langsmith/templates/frontend/deployment.yaml
@@ -151,13 +151,13 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.frontend.name }}
     spec:
-      {{- if .Values.frontend.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.frontend.deployment.priorityClassName }}
-      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.frontend.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.frontend.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.frontend.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- include "langsmith.podSecurityContext" (dict "Values" .Values "componentSecurityContext" .Values.frontend.deployment.podSecurityContext) | nindent 8 }}

--- a/charts/langsmith/templates/frontend/deployment.yaml
+++ b/charts/langsmith/templates/frontend/deployment.yaml
@@ -151,6 +151,9 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.frontend.name }}
     spec:
+      {{- if .Values.frontend.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.frontend.deployment.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.frontend.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/langsmith/templates/host-backend/deployment.yaml
+++ b/charts/langsmith/templates/host-backend/deployment.yaml
@@ -71,6 +71,9 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.hostBackend.name }}
     spec:
+      {{- if .Values.hostBackend.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.hostBackend.deployment.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.hostBackend.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/langsmith/templates/host-backend/deployment.yaml
+++ b/charts/langsmith/templates/host-backend/deployment.yaml
@@ -71,13 +71,13 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.hostBackend.name }}
     spec:
-      {{- if .Values.hostBackend.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.hostBackend.deployment.priorityClassName }}
-      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.hostBackend.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.hostBackend.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.hostBackend.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- include "langsmith.podSecurityContext" (dict "Values" .Values "componentSecurityContext" .Values.hostBackend.deployment.podSecurityContext) | nindent 8 }}

--- a/charts/langsmith/templates/ingest-queue/deployment.yaml
+++ b/charts/langsmith/templates/ingest-queue/deployment.yaml
@@ -52,6 +52,9 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.ingestQueue.name }}
     spec:
+      {{- if .Values.ingestQueue.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.ingestQueue.deployment.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.ingestQueue.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/langsmith/templates/ingest-queue/deployment.yaml
+++ b/charts/langsmith/templates/ingest-queue/deployment.yaml
@@ -52,13 +52,13 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.ingestQueue.name }}
     spec:
-      {{- if .Values.ingestQueue.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.ingestQueue.deployment.priorityClassName }}
-      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.ingestQueue.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.ingestQueue.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.ingestQueue.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- include "langsmith.podSecurityContext" (dict "Values" .Values "componentSecurityContext" .Values.ingestQueue.deployment.podSecurityContext) | nindent 8 }}

--- a/charts/langsmith/templates/listener/deployment.yaml
+++ b/charts/langsmith/templates/listener/deployment.yaml
@@ -58,13 +58,13 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.listener.name }}
     spec:
-      {{- if .Values.listener.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.listener.deployment.priorityClassName }}
-      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.listener.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.listener.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.listener.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- include "langsmith.podSecurityContext" (dict "Values" .Values "componentSecurityContext" .Values.listener.deployment.podSecurityContext) | nindent 8 }}

--- a/charts/langsmith/templates/listener/deployment.yaml
+++ b/charts/langsmith/templates/listener/deployment.yaml
@@ -58,6 +58,9 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.listener.name }}
     spec:
+      {{- if .Values.listener.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.listener.deployment.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.listener.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/langsmith/templates/operator/deployment.yaml
+++ b/charts/langsmith/templates/operator/deployment.yaml
@@ -42,6 +42,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.operator.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.operator.deployment.priorityClassName }}
+      {{- end }}
       serviceAccountName: {{ include "operator.serviceAccountName" . }}
       {{- include "langsmith.dnsConfig" . | nindent 6 }}
       automountServiceAccountToken: {{ .Values.operator.serviceAccount.automountServiceAccountToken }}

--- a/charts/langsmith/templates/operator/deployment.yaml
+++ b/charts/langsmith/templates/operator/deployment.yaml
@@ -42,15 +42,15 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.operator.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.operator.deployment.priorityClassName }}
-      {{- end }}
       serviceAccountName: {{ include "operator.serviceAccountName" . }}
       {{- include "langsmith.dnsConfig" . | nindent 6 }}
       automountServiceAccountToken: {{ .Values.operator.serviceAccount.automountServiceAccountToken }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.operator.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.operator.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- include "langsmith.podSecurityContext" (dict "Values" .Values "componentSecurityContext" .Values.operator.deployment.podSecurityContext) | nindent 8 }}

--- a/charts/langsmith/templates/platform-backend/deployment.yaml
+++ b/charts/langsmith/templates/platform-backend/deployment.yaml
@@ -61,6 +61,9 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}
     spec:
+      {{- if .Values.platformBackend.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.platformBackend.deployment.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.platformBackend.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/langsmith/templates/platform-backend/deployment.yaml
+++ b/charts/langsmith/templates/platform-backend/deployment.yaml
@@ -61,13 +61,13 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}
     spec:
-      {{- if .Values.platformBackend.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.platformBackend.deployment.priorityClassName }}
-      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.platformBackend.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.platformBackend.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.platformBackend.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- include "langsmith.podSecurityContext" (dict "Values" .Values "componentSecurityContext" .Values.platformBackend.deployment.podSecurityContext) | nindent 8 }}

--- a/charts/langsmith/templates/playground/deployment.yaml
+++ b/charts/langsmith/templates/playground/deployment.yaml
@@ -55,13 +55,13 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.playground.name }}
     spec:
-      {{- if .Values.playground.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.playground.deployment.priorityClassName }}
-      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.playground.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.playground.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.playground.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- include "langsmith.podSecurityContext" (dict "Values" .Values "componentSecurityContext" .Values.playground.deployment.podSecurityContext) | nindent 8 }}

--- a/charts/langsmith/templates/playground/deployment.yaml
+++ b/charts/langsmith/templates/playground/deployment.yaml
@@ -55,6 +55,9 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.playground.name }}
     spec:
+      {{- if .Values.playground.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.playground.deployment.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.playground.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/langsmith/templates/postgres/stateful-set.yaml
+++ b/charts/langsmith/templates/postgres/stateful-set.yaml
@@ -70,6 +70,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.postgres.statefulSet.priorityClassName }}
+      priorityClassName: {{ .Values.postgres.statefulSet.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.postgres.statefulSet.terminationGracePeriodSeconds }}
       securityContext:
         {{- include "langsmith.podSecurityContext" (dict "Values" .Values "componentSecurityContext" .Values.postgres.statefulSet.podSecurityContext) | nindent 8 }}

--- a/charts/langsmith/templates/presidio-analyzer/deployment.yaml
+++ b/charts/langsmith/templates/presidio-analyzer/deployment.yaml
@@ -39,13 +39,13 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.presidioAnalyzer.name }}
     spec:
-      {{- if .Values.presidioAnalyzer.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.presidioAnalyzer.deployment.priorityClassName }}
-      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.presidioAnalyzer.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.presidioAnalyzer.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.presidioAnalyzer.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- include "langsmith.podSecurityContext" (dict "Values" .Values "componentSecurityContext" .Values.presidioAnalyzer.deployment.podSecurityContext) | nindent 8 }}

--- a/charts/langsmith/templates/presidio-analyzer/deployment.yaml
+++ b/charts/langsmith/templates/presidio-analyzer/deployment.yaml
@@ -39,6 +39,9 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.presidioAnalyzer.name }}
     spec:
+      {{- if .Values.presidioAnalyzer.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.presidioAnalyzer.deployment.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.presidioAnalyzer.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/langsmith/templates/queue/deployment.yaml
+++ b/charts/langsmith/templates/queue/deployment.yaml
@@ -57,13 +57,13 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.queue.name }}
     spec:
-      {{- if .Values.queue.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.queue.deployment.priorityClassName }}
-      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.queue.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.queue.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.queue.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- include "langsmith.podSecurityContext" (dict "Values" .Values "componentSecurityContext" .Values.queue.deployment.podSecurityContext) | nindent 8 }}

--- a/charts/langsmith/templates/queue/deployment.yaml
+++ b/charts/langsmith/templates/queue/deployment.yaml
@@ -57,6 +57,9 @@ spec:
         {{- include "langsmith.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ include "langsmith.fullname" . }}-{{ .Values.queue.name }}
     spec:
+      {{- if .Values.queue.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.queue.deployment.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.queue.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/langsmith/templates/redis/stateful-set.yaml
+++ b/charts/langsmith/templates/redis/stateful-set.yaml
@@ -48,6 +48,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.redis.statefulSet.priorityClassName }}
+      priorityClassName: {{ .Values.redis.statefulSet.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.redis.statefulSet.terminationGracePeriodSeconds }}
       securityContext:
         {{- include "langsmith.podSecurityContext" (dict "Values" .Values "componentSecurityContext" .Values.redis.statefulSet.podSecurityContext) | nindent 8 }}

--- a/charts/langsmith/templates/smithdb/cluster-manager-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/cluster-manager-deployment.yaml
@@ -37,12 +37,12 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.smithdb.clusterManager.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.smithdb.clusterManager.deployment.priorityClassName }}
-      {{- end }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.smithdb.clusterManager.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.smithdb.clusterManager.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.smithdb.clusterManager.deployment.podSecurityContext | nindent 8 }}

--- a/charts/langsmith/templates/smithdb/cluster-manager-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/cluster-manager-deployment.yaml
@@ -37,6 +37,9 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.smithdb.clusterManager.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.smithdb.clusterManager.deployment.priorityClassName }}
+      {{- end }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/langsmith/templates/smithdb/compaction-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-deployment.yaml
@@ -37,6 +37,9 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.smithdb.compaction.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.smithdb.compaction.deployment.priorityClassName }}
+      {{- end }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/langsmith/templates/smithdb/compaction-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-deployment.yaml
@@ -37,12 +37,12 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.smithdb.compaction.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.smithdb.compaction.deployment.priorityClassName }}
-      {{- end }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.smithdb.compaction.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.smithdb.compaction.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.smithdb.compaction.deployment.podSecurityContext | nindent 8 }}

--- a/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
@@ -39,12 +39,12 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.smithdb.compactionWorker.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.smithdb.compactionWorker.deployment.priorityClassName }}
-      {{- end }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.smithdb.compactionWorker.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.smithdb.compactionWorker.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.smithdb.compactionWorker.deployment.podSecurityContext | nindent 8 }}

--- a/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
@@ -39,6 +39,9 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.smithdb.compactionWorker.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.smithdb.compactionWorker.deployment.priorityClassName }}
+      {{- end }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/langsmith/templates/smithdb/ingestion-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/ingestion-deployment.yaml
@@ -41,6 +41,9 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.smithdb.ingestion.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.smithdb.ingestion.deployment.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.smithdb.ingestion.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/langsmith/templates/smithdb/ingestion-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/ingestion-deployment.yaml
@@ -41,13 +41,13 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.smithdb.ingestion.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.smithdb.ingestion.deployment.priorityClassName }}
-      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.smithdb.ingestion.deployment.terminationGracePeriodSeconds }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.smithdb.ingestion.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.smithdb.ingestion.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.smithdb.ingestion.deployment.podSecurityContext | nindent 8 }}

--- a/charts/langsmith/templates/smithdb/query-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/query-deployment.yaml
@@ -41,6 +41,9 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.smithdb.query.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.smithdb.query.deployment.priorityClassName }}
+      {{- end }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/langsmith/templates/smithdb/query-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/query-deployment.yaml
@@ -41,12 +41,12 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.smithdb.query.deployment.priorityClassName }}
-      priorityClassName: {{ .Values.smithdb.query.deployment.priorityClassName }}
-      {{- end }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.smithdb.query.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.smithdb.query.deployment.priorityClassName }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.smithdb.query.deployment.podSecurityContext | nindent 8 }}

--- a/charts/langsmith/templates/smithdb/taskdb-postgres-statefulset.yaml
+++ b/charts/langsmith/templates/smithdb/taskdb-postgres-statefulset.yaml
@@ -50,6 +50,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if $taskdb.statefulSet.priorityClassName }}
+      priorityClassName: {{ $taskdb.statefulSet.priorityClassName }}
+      {{- end }}
       securityContext:
         {{- include "langsmith.podSecurityContext" (dict "Values" .Values "componentSecurityContext" $taskdb.statefulSet.podSecurityContext) | nindent 8 }}
       {{- include "langsmith.dnsConfig" . | nindent 6 }}

--- a/charts/langsmith/tests/deployment_priority_class_name_test.yaml
+++ b/charts/langsmith/tests/deployment_priority_class_name_test.yaml
@@ -1,0 +1,234 @@
+suite: Deployment priorityClassName rendering
+templates:
+  - config-map.yaml
+  - secrets.yaml
+  - redis/secrets.yaml
+  - postgres/secrets.yaml
+  - clickhouse/secrets.yaml
+  - frontend/config-map.yaml
+  - operator/config-map.yaml
+  - ace-backend/deployment.yaml
+  - agent-features/fleet/tool-server/deployment.yaml
+  - agent-features/fleet/trigger-server/deployment.yaml
+  - agent-gateway/deployment.yaml
+  - backend/deployment.yaml
+  - frontend/deployment.yaml
+  - host-backend/deployment.yaml
+  - ingest-queue/deployment.yaml
+  - listener/deployment.yaml
+  - operator/deployment.yaml
+  - platform-backend/deployment.yaml
+  - playground/deployment.yaml
+  - presidio-analyzer/deployment.yaml
+  - queue/deployment.yaml
+  - smithdb/cluster-manager-deployment.yaml
+  - smithdb/compaction-deployment.yaml
+  - smithdb/compaction-worker-deployment.yaml
+  - smithdb/ingestion-deployment.yaml
+  - smithdb/query-deployment.yaml
+tests:
+  - it: does not render backend priorityClassName by default
+    template: backend/deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+
+  - it: renders a configured ACE backend priorityClassName
+    template: ace-backend/deployment.yaml
+    set:
+      aceBackend.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured fleet tool server priorityClassName
+    template: agent-features/fleet/tool-server/deployment.yaml
+    set:
+      config.agentBuilder.enabled: true
+      fleetToolServer.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured fleet trigger server priorityClassName
+    template: agent-features/fleet/trigger-server/deployment.yaml
+    set:
+      config.agentBuilder.enabled: true
+      fleetTriggerServer.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured agent gateway priorityClassName
+    template: agent-gateway/deployment.yaml
+    set:
+      agentGateway.enabled: true
+      agentGateway.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured backend priorityClassName
+    template: backend/deployment.yaml
+    set:
+      backend.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders priorityClassName for a backend Rollout
+    template: backend/deployment.yaml
+    set:
+      backend.rollout.enabled: true
+      backend.deployment.priorityClassName: workload-priority
+    asserts:
+      - isKind:
+          of: Rollout
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured frontend priorityClassName
+    template: frontend/deployment.yaml
+    set:
+      frontend.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured host backend priorityClassName
+    template: host-backend/deployment.yaml
+    set:
+      hostBackend.enabled: true
+      hostBackend.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured ingest queue priorityClassName
+    template: ingest-queue/deployment.yaml
+    set:
+      ingestQueue.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured listener priorityClassName
+    template: listener/deployment.yaml
+    set:
+      config.deployment.enabled: true
+      listener.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured operator priorityClassName
+    template: operator/deployment.yaml
+    set:
+      config.deployment.enabled: true
+      operator.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured platform backend priorityClassName
+    template: platform-backend/deployment.yaml
+    set:
+      platformBackend.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured playground priorityClassName
+    template: playground/deployment.yaml
+    set:
+      playground.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured Presidio analyzer priorityClassName
+    template: presidio-analyzer/deployment.yaml
+    set:
+      presidioAnalyzer.enabled: true
+      presidioAnalyzer.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured queue priorityClassName
+    template: queue/deployment.yaml
+    set:
+      queue.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured SmithDB cluster manager priorityClassName
+    template: smithdb/cluster-manager-deployment.yaml
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.clusterManager.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured SmithDB compaction priorityClassName
+    template: smithdb/compaction-deployment.yaml
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.compaction.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured SmithDB compaction worker priorityClassName
+    template: smithdb/compaction-worker-deployment.yaml
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.compactionWorker.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured SmithDB ingestion priorityClassName
+    template: smithdb/ingestion-deployment.yaml
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.ingestion.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority
+
+  - it: renders a configured SmithDB query priorityClassName
+    template: smithdb/query-deployment.yaml
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.query.deployment.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority

--- a/charts/langsmith/tests/priority_class_name_test.yaml
+++ b/charts/langsmith/tests/priority_class_name_test.yaml
@@ -1,0 +1,76 @@
+suite: StatefulSet priorityClassName rendering
+templates:
+  - clickhouse/stateful-set.yaml
+  - clickhouse/config-map.yaml
+  - postgres/stateful-set.yaml
+  - redis/stateful-set.yaml
+  - smithdb/taskdb-postgres-statefulset.yaml
+tests:
+  - it: does not render ClickHouse priorityClassName by default
+    template: clickhouse/stateful-set.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+
+  - it: renders a configured ClickHouse priorityClassName
+    template: clickhouse/stateful-set.yaml
+    set:
+      clickhouse.statefulSet.priorityClassName: database-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: database-priority
+
+  - it: does not render PostgreSQL priorityClassName by default
+    template: postgres/stateful-set.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+
+  - it: renders a configured PostgreSQL priorityClassName
+    template: postgres/stateful-set.yaml
+    set:
+      postgres.statefulSet.priorityClassName: database-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: database-priority
+
+  - it: does not render Redis priorityClassName by default
+    template: redis/stateful-set.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+
+  - it: renders a configured Redis priorityClassName
+    template: redis/stateful-set.yaml
+    set:
+      redis.statefulSet.priorityClassName: database-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: database-priority
+
+  - it: does not render SmithDB taskdb priorityClassName by default
+    template: smithdb/taskdb-postgres-statefulset.yaml
+    set:
+      smithdb.enabled: true
+      smithdb.langsmith.migration.enabled: true
+      smithdb.migration.taskdb.postgres.enabled: true
+      smithdb.migration.taskdb.postgres.auth.password: taskdb-password
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+
+  - it: renders a configured SmithDB taskdb priorityClassName
+    template: smithdb/taskdb-postgres-statefulset.yaml
+    set:
+      smithdb.enabled: true
+      smithdb.langsmith.migration.enabled: true
+      smithdb.migration.taskdb.postgres.enabled: true
+      smithdb.migration.taskdb.postgres.auth.password: taskdb-password
+      smithdb.migration.taskdb.postgres.statefulSet.priorityClassName: database-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: database-priority

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1116,6 +1116,8 @@ aceBackend:
         steps:
           - setWeight: 100
   deployment:
+    # -- Optional priority class for the pod.
+    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}
@@ -1272,6 +1274,8 @@ smithdb:
     containerPort: 8060
     containerGrpcPort: 8080
     deployment:
+      # -- Optional priority class for the pod.
+      priorityClassName: ""
       replicas: 1
       strategy:
         type: RollingUpdate
@@ -1349,6 +1353,8 @@ smithdb:
     containerPort: 8050
     containerGrpcPort: 8082
     deployment:
+      # -- Optional priority class for the pod.
+      priorityClassName: ""
       replicas: 1
       strategy:
         type: RollingUpdate
@@ -1436,6 +1442,8 @@ smithdb:
     containerPort: 8070
     containerGrpcPort: 8071
     deployment:
+      # -- Optional priority class for the pod.
+      priorityClassName: ""
       replicas: 1
       labels: {}
       annotations: {}
@@ -1500,6 +1508,8 @@ smithdb:
     # -- Maximum concurrent jobs per compaction worker. Empty uses the SmithDB default.
     maxConcurrentJobs: ""
     deployment:
+      # -- Optional priority class for the pod.
+      priorityClassName: ""
       replicas: 2
       labels: {}
       annotations: {}
@@ -1575,6 +1585,8 @@ smithdb:
     containerPort: 8090
     containerGrpcPort: 8091
     deployment:
+      # -- Optional priority class for the pod.
+      priorityClassName: ""
       replicas: 1
       labels: {}
       annotations: {}
@@ -1809,6 +1821,8 @@ backend:
         steps:
           - setWeight: 100
   deployment:
+    # -- Optional priority class for the pod.
+    priorityClassName: ""
     replicas: 2
     labels: {}
     annotations: {}
@@ -2219,6 +2233,8 @@ frontend:
     # This is the path the key must be mounted to in the container.
     keyPath: ""
   deployment:
+    # -- Optional priority class for the pod.
+    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}
@@ -2329,6 +2345,8 @@ hostBackend:
         steps:
           - setWeight: 100
   deployment:
+    # -- Optional priority class for the pod.
+    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}
@@ -2440,6 +2458,8 @@ listener:
         steps:
           - setWeight: 100
   deployment:
+    # -- Optional priority class for the pod.
+    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}
@@ -2552,6 +2572,8 @@ platformBackend:
         steps:
           - setWeight: 100
   deployment:
+    # -- Optional priority class for the pod.
+    priorityClassName: ""
     replicas: 3
     labels: {}
     annotations: {}
@@ -2663,6 +2685,8 @@ operator:
         steps:
           - setWeight: 100
   deployment:
+    # -- Optional priority class for the pod.
+    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}
@@ -2849,6 +2873,8 @@ playground:
         steps:
           - setWeight: 100
   deployment:
+    # -- Optional priority class for the pod.
+    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}
@@ -3069,6 +3095,8 @@ queue:
         steps:
           - setWeight: 100
   deployment:
+    # -- Optional priority class for the pod.
+    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}
@@ -3175,6 +3203,8 @@ ingestQueue:
         steps:
           - setWeight: 100
   deployment:
+    # -- Optional priority class for the pod.
+    priorityClassName: ""
     replicas: 3
     labels: {}
     annotations: {}
@@ -3387,6 +3417,8 @@ fleetToolServer:
   name: "fleet-tool-server"
   containerPort: 1989
   deployment:
+    # -- Optional priority class for the pod.
+    priorityClassName: ""
     command:
       - "agent_builder_tool_server_entrypoint.sh"
     replicas: 1
@@ -3467,6 +3499,8 @@ fleetTriggerServer:
   name: "fleet-trigger-server"
   containerPort: 1990
   deployment:
+    # -- Optional priority class for the pod.
+    priorityClassName: ""
     command:
       - "agent_builder_trigger_server_entrypoint.sh"
     labels: {}
@@ -3534,6 +3568,8 @@ agentGateway:
   name: "agent-gateway"
   containerPort: 8083
   deployment:
+    # -- Optional priority class for the pod.
+    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}
@@ -3605,6 +3641,8 @@ presidioAnalyzer:
   name: "presidio-analyzer"
   containerPort: 3000
   deployment:
+    # -- Optional priority class for the pod.
+    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1116,14 +1116,13 @@ aceBackend:
         steps:
           - setWeight: 100
   deployment:
-    # -- Optional priority class for the pod.
-    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}
     podSecurityContext: {}
     securityContext: {}
     lifecycle: {}
+    priorityClassName: ""
     resources:
       limits:
         cpu: 2
@@ -1274,8 +1273,6 @@ smithdb:
     containerPort: 8060
     containerGrpcPort: 8080
     deployment:
-      # -- Optional priority class for the pod.
-      priorityClassName: ""
       replicas: 1
       strategy:
         type: RollingUpdate
@@ -1286,6 +1283,7 @@ smithdb:
       annotations: {}
       podSecurityContext: {}
       securityContext: {}
+      priorityClassName: ""
       resources:
         requests:
           cpu: "4"
@@ -1353,8 +1351,6 @@ smithdb:
     containerPort: 8050
     containerGrpcPort: 8082
     deployment:
-      # -- Optional priority class for the pod.
-      priorityClassName: ""
       replicas: 1
       strategy:
         type: RollingUpdate
@@ -1365,6 +1361,7 @@ smithdb:
       annotations: {}
       podSecurityContext: {}
       securityContext: {}
+      priorityClassName: ""
       resources:
         requests:
           cpu: "4"
@@ -1442,13 +1439,12 @@ smithdb:
     containerPort: 8070
     containerGrpcPort: 8071
     deployment:
-      # -- Optional priority class for the pod.
-      priorityClassName: ""
       replicas: 1
       labels: {}
       annotations: {}
       podSecurityContext: {}
       securityContext: {}
+      priorityClassName: ""
       resources:
         requests:
           cpu: "2"
@@ -1508,13 +1504,12 @@ smithdb:
     # -- Maximum concurrent jobs per compaction worker. Empty uses the SmithDB default.
     maxConcurrentJobs: ""
     deployment:
-      # -- Optional priority class for the pod.
-      priorityClassName: ""
       replicas: 2
       labels: {}
       annotations: {}
       podSecurityContext: {}
       securityContext: {}
+      priorityClassName: ""
       terminationGracePeriodSeconds: 120
       resources:
         requests:
@@ -1585,13 +1580,12 @@ smithdb:
     containerPort: 8090
     containerGrpcPort: 8091
     deployment:
-      # -- Optional priority class for the pod.
-      priorityClassName: ""
       replicas: 1
       labels: {}
       annotations: {}
       podSecurityContext: {}
       securityContext: {}
+      priorityClassName: ""
       resources:
         requests:
           cpu: "250m"
@@ -1821,14 +1815,13 @@ backend:
         steps:
           - setWeight: 100
   deployment:
-    # -- Optional priority class for the pod.
-    priorityClassName: ""
     replicas: 2
     labels: {}
     annotations: {}
     podSecurityContext: {}
     securityContext: {}
     lifecycle: {}
+    priorityClassName: ""
     resources:
       limits:
         cpu: 2000m
@@ -2233,14 +2226,13 @@ frontend:
     # This is the path the key must be mounted to in the container.
     keyPath: ""
   deployment:
-    # -- Optional priority class for the pod.
-    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}
     podSecurityContext: {}
     securityContext: {}
     lifecycle: {}
+    priorityClassName: ""
     resources:
       limits:
         cpu: 1000m
@@ -2345,14 +2337,13 @@ hostBackend:
         steps:
           - setWeight: 100
   deployment:
-    # -- Optional priority class for the pod.
-    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}
     podSecurityContext: {}
     securityContext: {}
     lifecycle: {}
+    priorityClassName: ""
     resources:
       limits:
         cpu: 1000m
@@ -2458,14 +2449,13 @@ listener:
         steps:
           - setWeight: 100
   deployment:
-    # -- Optional priority class for the pod.
-    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}
     podSecurityContext: {}
     securityContext: {}
     lifecycle: {}
+    priorityClassName: ""
     resources:
       limits:
         cpu: 2000m
@@ -2572,14 +2562,13 @@ platformBackend:
         steps:
           - setWeight: 100
   deployment:
-    # -- Optional priority class for the pod.
-    priorityClassName: ""
     replicas: 3
     labels: {}
     annotations: {}
     podSecurityContext: {}
     securityContext: {}
     lifecycle: {}
+    priorityClassName: ""
     resources:
       limits:
         cpu: 2000m
@@ -2685,14 +2674,13 @@ operator:
         steps:
           - setWeight: 100
   deployment:
-    # -- Optional priority class for the pod.
-    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}
     podSecurityContext: {}
     securityContext: {}
     lifecycle: {}
+    priorityClassName: ""
     resources:
       limits:
         cpu: 2000m
@@ -2873,14 +2861,13 @@ playground:
         steps:
           - setWeight: 100
   deployment:
-    # -- Optional priority class for the pod.
-    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}
     podSecurityContext: {}
     securityContext: {}
     lifecycle: {}
+    priorityClassName: ""
     resources:
       limits:
         cpu: 1000m
@@ -3095,14 +3082,13 @@ queue:
         steps:
           - setWeight: 100
   deployment:
-    # -- Optional priority class for the pod.
-    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}
     podSecurityContext: {}
     securityContext: {}
     lifecycle: {}
+    priorityClassName: ""
     resources:
       limits:
         cpu: 2000m
@@ -3203,14 +3189,13 @@ ingestQueue:
         steps:
           - setWeight: 100
   deployment:
-    # -- Optional priority class for the pod.
-    priorityClassName: ""
     replicas: 3
     labels: {}
     annotations: {}
     podSecurityContext: {}
     securityContext: {}
     lifecycle: {}
+    priorityClassName: ""
     resources:
       limits:
         cpu: 2000m
@@ -3417,8 +3402,6 @@ fleetToolServer:
   name: "fleet-tool-server"
   containerPort: 1989
   deployment:
-    # -- Optional priority class for the pod.
-    priorityClassName: ""
     command:
       - "agent_builder_tool_server_entrypoint.sh"
     replicas: 1
@@ -3427,6 +3410,7 @@ fleetToolServer:
     podSecurityContext: {}
     securityContext: {}
     lifecycle: {}
+    priorityClassName: ""
     resources:
       limits:
         cpu: 2000m
@@ -3499,8 +3483,6 @@ fleetTriggerServer:
   name: "fleet-trigger-server"
   containerPort: 1990
   deployment:
-    # -- Optional priority class for the pod.
-    priorityClassName: ""
     command:
       - "agent_builder_trigger_server_entrypoint.sh"
     labels: {}
@@ -3508,6 +3490,7 @@ fleetTriggerServer:
     podSecurityContext: {}
     securityContext: {}
     lifecycle: {}
+    priorityClassName: ""
     resources:
       limits:
         cpu: 2000m
@@ -3568,14 +3551,13 @@ agentGateway:
   name: "agent-gateway"
   containerPort: 8083
   deployment:
-    # -- Optional priority class for the pod.
-    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}
     podSecurityContext: {}
     securityContext: {}
     lifecycle: {}
+    priorityClassName: ""
     resources:
       limits:
         cpu: 500m
@@ -3641,14 +3623,13 @@ presidioAnalyzer:
   name: "presidio-analyzer"
   containerPort: 3000
   deployment:
-    # -- Optional priority class for the pod.
-    priorityClassName: ""
     replicas: 1
     labels: {}
     annotations: {}
     podSecurityContext: {}
     securityContext: {}
     lifecycle: {}
+    priorityClassName: ""
     resources:
       limits:
         cpu: 1

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1683,6 +1683,8 @@ smithdb:
           labels: {}
           annotations: {}
         statefulSet:
+          # -- Optional priority class for the in-chart SmithDB taskdb Postgres pod.
+          priorityClassName: ""
           # -- Optional StatefulSet update strategy for the in-chart SmithDB taskdb Postgres instance.
           updateStrategy: {}
           labels: {}
@@ -2094,6 +2096,8 @@ clickhouse:
   statefulSet:
     labels: {}
     annotations: {}
+    # -- Optional priority class for the in-chart ClickHouse pod.
+    priorityClassName: ""
     # -- Optional StatefulSet update strategy for the in-chart ClickHouse instance.
     # -- Leave unset to keep the Kubernetes default RollingUpdate behavior.
     updateStrategy: {}
@@ -2972,6 +2976,8 @@ postgres:
       keySecretKey: "tls.key"
   containerPort: 5432
   statefulSet:
+    # -- Optional priority class for the in-chart PostgreSQL pod.
+    priorityClassName: ""
     # -- Optional StatefulSet update strategy for the in-chart PostgreSQL instance.
     # Leave unset to keep the Kubernetes default RollingUpdate behavior.
     updateStrategy: {}
@@ -3294,6 +3300,8 @@ redis:
       tlsEnabled: true
   containerPort: 6379
   statefulSet:
+    # -- Optional priority class for the in-chart Redis pod.
+    priorityClassName: ""
     # -- Optional StatefulSet update strategy for the in-chart Redis instance.
     # Leave unset to keep the Kubernetes default RollingUpdate behavior.
     updateStrategy: {}

--- a/charts/mission-control/README.md
+++ b/charts/mission-control/README.md
@@ -110,7 +110,7 @@ Equivalent to setting every flag above to `false` individually, but guaranteed n
 | diagnostics.persistence.storageClass | string | `""` | Leave empty to use the cluster default StorageClass. |
 | frontend.extraEnv | list | `[]` | Additional environment variables passed to the frontend container. |
 | frontend.podSecurityContext | object | `{}` | Pod-level security context. |
-| frontend.priorityClassName | string | `""` | Optional priority class for the pod. |
+| frontend.priorityClassName | string | `""` |  |
 | frontend.replicas | int | `1` | Replica count. |
 | frontend.resources.limits.cpu | string | `"200m"` |  |
 | frontend.resources.limits.memory | string | `"256Mi"` |  |

--- a/charts/mission-control/README.md
+++ b/charts/mission-control/README.md
@@ -69,6 +69,7 @@ Equivalent to setting every flag above to `false` individually, but guaranteed n
 |-----|------|---------|-------------|
 | backend.extraEnv | list | `[]` | Additional environment variables passed to the backend container. |
 | backend.podSecurityContext | object | `{}` | Pod-level security context. |
+| backend.priorityClassName | string | `""` | Optional priority class for the backend pod. |
 | backend.replicas | int | `1` | Replica count. Set > 1 only when config.auth.jwtSecretKey is set so all pods validate each other's tokens. |
 | backend.resources.limits.cpu | string | `"500m"` |  |
 | backend.resources.limits.memory | string | `"512Mi"` |  |

--- a/charts/mission-control/README.md
+++ b/charts/mission-control/README.md
@@ -110,6 +110,7 @@ Equivalent to setting every flag above to `false` individually, but guaranteed n
 | diagnostics.persistence.storageClass | string | `""` | Leave empty to use the cluster default StorageClass. |
 | frontend.extraEnv | list | `[]` | Additional environment variables passed to the frontend container. |
 | frontend.podSecurityContext | object | `{}` | Pod-level security context. |
+| frontend.priorityClassName | string | `""` | Optional priority class for the pod. |
 | frontend.replicas | int | `1` | Replica count. |
 | frontend.resources.limits.cpu | string | `"200m"` |  |
 | frontend.resources.limits.memory | string | `"256Mi"` |  |

--- a/charts/mission-control/templates/backend/statefulset.yaml
+++ b/charts/mission-control/templates/backend/statefulset.yaml
@@ -28,6 +28,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "missionControl.serviceAccountName" . }}
+      {{- if .Values.backend.priorityClassName }}
+      priorityClassName: {{ .Values.backend.priorityClassName }}
+      {{- end }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/mission-control/templates/frontend/deployment.yaml
+++ b/charts/mission-control/templates/frontend/deployment.yaml
@@ -26,6 +26,9 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.frontend.priorityClassName }}
+      priorityClassName: {{ .Values.frontend.priorityClassName }}
+      {{- end }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/mission-control/templates/frontend/deployment.yaml
+++ b/charts/mission-control/templates/frontend/deployment.yaml
@@ -26,12 +26,12 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- if .Values.frontend.priorityClassName }}
-      priorityClassName: {{ .Values.frontend.priorityClassName }}
-      {{- end }}
       {{- with .Values.images.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.frontend.priorityClassName }}
+      priorityClassName: {{ .Values.frontend.priorityClassName }}
       {{- end }}
       {{- with .Values.frontend.podSecurityContext }}
       securityContext:

--- a/charts/mission-control/tests/deployment_priority_class_name_test.yaml
+++ b/charts/mission-control/tests/deployment_priority_class_name_test.yaml
@@ -1,0 +1,16 @@
+suite: Deployment priorityClassName rendering
+templates:
+  - frontend/deployment.yaml
+tests:
+  - it: does not render frontend priorityClassName by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+
+  - it: renders a configured frontend priorityClassName
+    set:
+      frontend.priorityClassName: workload-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: workload-priority

--- a/charts/mission-control/tests/priority_class_name_test.yaml
+++ b/charts/mission-control/tests/priority_class_name_test.yaml
@@ -1,0 +1,16 @@
+suite: StatefulSet priorityClassName rendering
+templates:
+  - backend/statefulset.yaml
+tests:
+  - it: does not render backend priorityClassName by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+
+  - it: renders a configured backend priorityClassName
+    set:
+      backend.priorityClassName: backend-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: backend-priority

--- a/charts/mission-control/values.yaml
+++ b/charts/mission-control/values.yaml
@@ -184,6 +184,8 @@ backend:
 
 # Frontend (static React app served by an HTTP server) component.
 frontend:
+  # -- Optional priority class for the pod.
+  priorityClassName: ""
   # -- Replica count.
   replicas: 1
   # -- Pod-level security context.

--- a/charts/mission-control/values.yaml
+++ b/charts/mission-control/values.yaml
@@ -141,6 +141,8 @@ images:
 backend:
   # -- Replica count. Set > 1 only when config.auth.jwtSecretKey is set so all pods validate each other's tokens.
   replicas: 1
+  # -- Optional priority class for the backend pod.
+  priorityClassName: ""
   # -- Pod-level security context.
   podSecurityContext: {}
   # -- Container-level security context.

--- a/charts/mission-control/values.yaml
+++ b/charts/mission-control/values.yaml
@@ -184,14 +184,13 @@ backend:
 
 # Frontend (static React app served by an HTTP server) component.
 frontend:
-  # -- Optional priority class for the pod.
-  priorityClassName: ""
   # -- Replica count.
   replicas: 1
   # -- Pod-level security context.
   podSecurityContext: {}
   # -- Container-level security context.
   securityContext: {}
+  priorityClassName: ""
   # -- Additional environment variables passed to the frontend container.
   extraEnv: []
   resources:


### PR DESCRIPTION
## Description
Exposes optional `priorityClassName` values for every direct chart-managed Deployment and StatefulSet on `main`; empty defaults preserve existing scheduling behavior.

## Test Plan
- [x] Helm lint for affected charts
- [x] Focused priority class Helm unit tests
- [x] Static audit of all 47 workload templates

Made by [Open SWE](https://openswe.vercel.app/agents/2a1ad2fe-639b-7e8a-9102-6c254826c693)