### PR TITLE
feat(langsmith): set RUN_RULES_QUERY_LIMIT for SmithDB installs

### DIFF
--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -73,6 +73,7 @@ data:
   RUN_RULES_SMITHDB_RETRIEVER_PCT: "100"
   RUN_RULES_SMITHDB_THREAD_RETRIEVER_TENANTS: '["*"]'
   RUN_RULES_SMITHDB_THREAD_RETRIEVER_PCT: "100"
+  RUN_RULES_QUERY_LIMIT: "250"
   {{- end }}
   {{- if .Values.config.hostname }}
   # Remote MCP server / OAuth Authorization Server (served under /api). The AS only

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -335,6 +335,9 @@ tests:
           path: data.RUN_RULES_SMITHDB_THREAD_RETRIEVER_PCT
           value: "100"
       - equal:
+          path: data.RUN_RULES_QUERY_LIMIT
+          value: "250"
+      - equal:
           path: data.RUN_RULES_REDIS_DEDUP_TENANTS
           value: '["*"]'
       - equal:
@@ -444,6 +447,8 @@ tests:
           path: data.RUN_RULES_SMITHDB_THREAD_RETRIEVER_TENANTS
       - notExists:
           path: data.RUN_RULES_SMITHDB_THREAD_RETRIEVER_PCT
+      - notExists:
+          path: data.RUN_RULES_QUERY_LIMIT
       - equal:
           path: data.RUN_RULES_REDIS_DEDUP_TENANTS
           value: '["*"]'


### PR DESCRIPTION
Set `RUN_RULES_QUERY_LIMIT=250` in the shared LangSmith ConfigMap for self-hosted installs that include SmithDB.

## Gating

The key is added to the existing `{{- if .Values.smithdb.enabled }}` block, alongside the sibling `RUN_RULES_SMITHDB_*` retriever settings. `smithdb.enabled` is true in both target modes:

- **dual** — SmithDB + ClickHouse
- **SmithDB only** — SmithDB on, ClickHouse off

Pure-ClickHouse installs (`smithdb.enabled=false`) do not get the key and keep the application default.

## Test plan

`charts/langsmith/tests/langsmith_smithdb_test.yaml`:
- asserts `data.RUN_RULES_QUERY_LIMIT == "250"` in the smithdb-enabled case
- asserts `notExists` in the smithdb-disabled case

`helm unittest charts/langsmith` passes locally: 168 tests, 15 suites.
