### PR TITLE
fix(engine): configure sandbox runtime endpoints

### DIFF
--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -1077,6 +1077,8 @@ Extra env vars for insights api-server and queue pods.
 {{- $out = append $out (dict "name" "ENGINE_INTELLIGENCE_BASE_URL" "value" $root.Values.engine.intelligenceBaseUrl) -}}
 {{- $out = append $out (dict "name" "ISSUES_AGENT_ENCRYPTION_KEY" "valueFrom" (dict "secretKeyRef" (dict "name" (include "langsmith.secretsName" $root) "key" "engine_encryption_key" "optional" $root.Values.config.disableSecretCreation))) -}}
 {{- $out = append $out (dict "name" "ISSUES_AGENT_ENCRYPTION_KEY_PREVIOUS" "valueFrom" (dict "secretKeyRef" (dict "name" (include "langsmith.secretsName" $root) "key" "engine_encryption_key_previous" "optional" true))) -}}
+{{- $out = append $out (dict "name" "LANGSMITH_SANDBOX_ENDPOINT" "value" (printf "%s/v2/sandboxes" (include "langsmith.sandboxes.langsmithInternalEndpoint" $root))) -}}
+{{- $out = append $out (dict "name" "LANGSMITH_CLI_ENDPOINT" "value" (include "langsmith.sandboxes.platformEndpoint" $root)) -}}
 {{- end -}}
 {{- if and (eq $componentName "apiServer") $feature.queue.enabled -}}
 {{- $out = append $out (dict "name" "N_JOBS_PER_WORKER" "value" "0") -}}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -528,6 +528,9 @@ AWS Marketplace Helm template verification).
 {{- if not .Values.engine.intelligenceBaseUrl }}
 {{- fail "engine.intelligenceBaseUrl is required when engine.enabled is true: the self-hosted Engine has no ANTHROPIC_API_KEY and routes model calls through the LSI gateway for its cloud/region (e.g. AWS: https://beacon.aws.langchain.com/intelligence)." }}
 {{- end }}
+{{- if not .Values.config.hostname }}
+{{- fail "config.hostname is required when engine.enabled is true: Engine sandbox CLI calls require an absolute LangSmith API endpoint." }}
+{{- end }}
 {{- end }}
 
 {{- /* Validate agent feature (fleet/insights/polly) configuration */ -}}

--- a/charts/langsmith/tests/engine_runtime_endpoints_test.yaml
+++ b/charts/langsmith/tests/engine_runtime_endpoints_test.yaml
@@ -1,0 +1,63 @@
+suite: engine runtime endpoints
+templates:
+  - templates/validate.yaml
+  - templates/agent-features/insights/api-server/deployment.yaml
+  - templates/agent-features/insights/queue/deployment.yaml
+tests:
+  - it: should require a hostname when engine is enabled
+    values:
+      - ./values/sandboxes-enabled.yaml
+    set:
+      engine.enabled: true
+      engine.encryptionKey: test-key
+      engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
+      engine.sandboxTenantId: test-tenant-id
+      images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
+    template: templates/validate.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "config.hostname is required when engine.enabled is true: Engine sandbox CLI calls require an absolute LangSmith API endpoint."
+
+  - it: should wire absolute runtime endpoints into both engine pods
+    values:
+      - ./values/sandboxes-enabled.yaml
+    set:
+      config.hostname: langsmith.example.com
+      config.basePath: langsmith
+      engine.enabled: true
+      engine.encryptionKey: test-key
+      engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
+      engine.sandboxTenantId: test-tenant-id
+      images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
+    templates:
+      - templates/agent-features/insights/api-server/deployment.yaml
+      - templates/agent-features/insights/queue/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGSMITH_SANDBOX_ENDPOINT
+            value: http://RELEASE-NAME-langsmith-platform-backend.NAMESPACE.svc.cluster.local:1986/v2/sandboxes
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGSMITH_CLI_ENDPOINT
+            value: https://langsmith.example.com/langsmith/api
+
+  - it: should omit engine runtime endpoints when engine is disabled
+    values:
+      - ./values/sandboxes-enabled.yaml
+    set:
+      insights.enabled: true
+    templates:
+      - templates/agent-features/insights/api-server/deployment.yaml
+      - templates/agent-features/insights/queue/deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGSMITH_SANDBOX_ENDPOINT
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGSMITH_CLI_ENDPOINT


### PR DESCRIPTION
Depends on #874, which adds the sandbox tenant requirement and fixes the existing Engine validation fixtures on this feature branch. The chart-wide check will remain blocked until that PR lands; this PR's new endpoint suite passes 3/3.

## Summary

- configure Engine API server and queue pods with the internal sandbox endpoint and public LangSmith CLI endpoint
- require config.hostname when Engine is enabled so sandbox CLI calls always receive an absolute URL
- cover both pods, base-path URL construction, disabled behavior, and validation

## Test Plan

- [x] Rendered both Engine deployments and confirmed the internal sandbox endpoint and public CLI endpoint
- [x] Confirmed Engine without config.hostname fails chart validation
- [x] Focused Helm unit tests pass: 3/3
- [x] Existing Engine Helm unit tests pass with the sandbox fixture: 4/4
- [x] Helm lint passes