### PR TITLE
chore(engine): drop engine.cliEndpoint from the chart

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -26,7 +26,6 @@ The chart-managed frontend owns public API route rewrites for LangSmith services
 | commonPodSecurityContext | object | `{}` | Common pod security context applied to all pods. Component-specific podSecurityContext values will be merged on top of this (component values take precedence). |
 | commonVolumeMounts | list | `[]` | Common volume mounts added to all deployments/statefulsets except for the playground/aceBackend services (which are sandboxed). |
 | commonVolumes | list | `[]` | Common volumes added to all deployments/statefulsets except for the playground/aceBackend services (which are sandboxed). |
-| engine.cliEndpoint | string | `""` | Override for the LangSmith URL the sandbox runs the langsmith CLI against. Defaults to <config.hostname>/api. Set this only when that is not routable from the sandbox network (e.g. a tunnel to a local smith-go); an in-cluster service URL will not work. The sandbox proxy allow-lists this host and injects LangSmith credentials for it. |
 | engine.enabled | bool | `false` |  |
 | engine.encryptionKey | string | `""` |  |
 | engine.encryptionKeyPrevious | string | `""` |  |

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -1079,7 +1079,6 @@ Extra env vars for insights api-server and queue pods.
 {{- $out = append $out (dict "name" "ISSUES_AGENT_ENCRYPTION_KEY_PREVIOUS" "valueFrom" (dict "secretKeyRef" (dict "name" (include "langsmith.secretsName" $root) "key" "engine_encryption_key_previous" "optional" true))) -}}
 {{- $out = append $out (dict "name" "ISSUES_AGENT_SANDBOX_TENANT_ID" "value" $root.Values.engine.sandboxTenantId) -}}
 {{- $out = append $out (dict "name" "LANGSMITH_SANDBOX_ENDPOINT" "value" (printf "http://%s-%s.%s.svc.%s:%v/v2/sandboxes" (include "langsmith.fullname" $root) $root.Values.platformBackend.name (default $root.Release.Namespace $root.Values.namespace) $root.Values.clusterDomain $root.Values.platformBackend.service.port)) -}}
-{{- $out = append $out (dict "name" "LANGSMITH_CLI_ENDPOINT" "value" (include "langsmith.engine.cliEndpoint" $root)) -}}
 {{- end -}}
 {{- if and (eq $componentName "apiServer") $feature.queue.enabled -}}
 {{- $out = append $out (dict "name" "N_JOBS_PER_WORKER" "value" "0") -}}
@@ -1468,20 +1467,6 @@ When hostname is unset, keep this relative so browser callers use the same origi
   {{- printf "/%s/api" $basePath -}}
 {{- else -}}
   /api
-{{- end -}}
-{{- end -}}
-
-{{/*
-LangSmith URL the Engine's sandboxes run the langsmith CLI against. Defaults to
-the public API endpoint; engine.cliEndpoint overrides it for a host the sandbox
-network can reach but config.hostname doesn't name (e.g. a tunnel to a local
-smith-go). validate.yaml rejects a config.hostname no sandbox could reach.
-*/}}
-{{- define "langsmith.engine.cliEndpoint" -}}
-{{- if .Values.engine.cliEndpoint -}}
-{{- .Values.engine.cliEndpoint -}}
-{{- else -}}
-{{- include "langsmith.sandboxes.platformEndpoint" . -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -531,16 +531,14 @@ AWS Marketplace Helm template verification).
 {{- if not .Values.config.sandboxes.enabled }}
 {{- fail "engine.enabled is true but config.sandboxes.enabled is false: every Engine run executes in a sandbox, so Engine cannot run without them." }}
 {{- end }}
-{{- if not .Values.engine.cliEndpoint }}
 {{- if not .Values.config.hostname }}
-{{- fail "engine.enabled is true but neither config.hostname nor engine.cliEndpoint is set: the sandbox runs the langsmith CLI against an externally reachable LangSmith URL, derived from config.hostname unless engine.cliEndpoint overrides it." }}
+{{- fail "engine.enabled is true but config.hostname is not set: the sandbox runs the langsmith CLI against an externally reachable LangSmith URL, which is derived from it." }}
 {{- end }}
 {{- if regexMatch "^(?:[a-zA-Z][a-zA-Z0-9+.-]*://)?(?:localhost|127\\.0\\.0\\.1|\\[::1\\])(?::[0-9]+)?(?:/.*)?$" .Values.config.hostname }}
-{{- fail (printf "engine.enabled is true and config.hostname is %q, which a sandbox cannot reach: set engine.cliEndpoint to a LangSmith URL routable from the sandbox network (e.g. a tunnel to your local smith-go)." .Values.config.hostname) }}
+{{- fail (printf "engine.enabled is true and config.hostname is %q, which a sandbox cannot reach: it must be the externally reachable LangSmith address." .Values.config.hostname) }}
 {{- end }}
 {{- if regexMatch "\\.svc(\\.[a-zA-Z0-9.-]+)?(:[0-9]+)?(/.*)?$" .Values.config.hostname }}
-{{- fail (printf "engine.enabled is true and config.hostname is the in-cluster address %q, which a sandbox cannot reach: set engine.cliEndpoint to the externally reachable LangSmith URL." .Values.config.hostname) }}
-{{- end }}
+{{- fail (printf "engine.enabled is true and config.hostname is the in-cluster address %q, which a sandbox cannot reach: it must be the externally reachable LangSmith address." .Values.config.hostname) }}
 {{- end }}
 {{- if not .Values.engine.sandboxTenantId }}
 {{- fail "engine.sandboxTenantId is required when engine.enabled is true: the Engine signs its sandbox service key with this workspace id and smith-go rejects a service key without a tenant. Use a workspace reserved for the Engine — its sandboxes consume that workspace's sandbox quota and are visible to anyone with access to it." }}

--- a/charts/langsmith/tests/engine_cli_endpoint_test.yaml
+++ b/charts/langsmith/tests/engine_cli_endpoint_test.yaml
@@ -3,7 +3,9 @@ templates:
   - templates/agent-features/insights/api-server/deployment.yaml
   - templates/agent-features/insights/queue/deployment.yaml
 tests:
-  - it: should derive the CLI endpoint from config.hostname
+  # The agent derives it from LANGCHAIN_PLATFORM_ENDPOINT, which the shared
+  # config map already carries, so the chart sets no CLI-specific variable.
+  - it: should not set a CLI endpoint on either engine pod
     values:
       - ./values/sandboxes-enabled.yaml
     set:
@@ -12,70 +14,9 @@ tests:
       engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
       engine.sandboxTenantId: 00000000-0000-0000-0000-000000000000
       images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: LANGSMITH_CLI_ENDPOINT
-            value: https://langsmith.example.com/api
-
-  - it: should include config.basePath in the derived CLI endpoint
-    values:
-      - ./values/sandboxes-enabled.yaml
-    set:
-      config.basePath: /langsmith
-      engine.enabled: true
-      engine.encryptionKey: test-key
-      engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
-      engine.sandboxTenantId: 00000000-0000-0000-0000-000000000000
-      images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: LANGSMITH_CLI_ENDPOINT
-            value: https://langsmith.example.com/langsmith/api
-
-  - it: should keep the scheme when config.hostname already has one
-    values:
-      - ./values/sandboxes-enabled.yaml
-    set:
-      config.hostname: http://langsmith.internal.example.com
-      engine.enabled: true
-      engine.encryptionKey: test-key
-      engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
-      engine.sandboxTenantId: 00000000-0000-0000-0000-000000000000
-      images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: LANGSMITH_CLI_ENDPOINT
-            value: http://langsmith.internal.example.com/api
-
-  - it: should prefer engine.cliEndpoint over the derived value
-    values:
-      - ./values/sandboxes-enabled.yaml
-    set:
-      engine.enabled: true
-      engine.encryptionKey: test-key
-      engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
-      engine.sandboxTenantId: 00000000-0000-0000-0000-000000000000
-      engine.cliEndpoint: https://tunnel.example.com
-      images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: LANGSMITH_CLI_ENDPOINT
-            value: https://tunnel.example.com
-
-  - it: should omit the CLI endpoint when engine is disabled
-    values:
-      - ./values/sandboxes-enabled.yaml
     asserts:
       - notContains:
           path: spec.template.spec.containers[0].env
           content:
             name: LANGSMITH_CLI_ENDPOINT
-            value: https://langsmith.example.com/api
+          any: true

--- a/charts/langsmith/tests/engine_insights_agent_test.yaml
+++ b/charts/langsmith/tests/engine_insights_agent_test.yaml
@@ -79,7 +79,7 @@ tests:
       images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
     asserts:
       - failedTemplate:
-          errorMessage: "engine.enabled is true but neither config.hostname nor engine.cliEndpoint is set: the sandbox runs the langsmith CLI against an externally reachable LangSmith URL, derived from config.hostname unless engine.cliEndpoint overrides it."
+          errorMessage: "engine.enabled is true but config.hostname is not set: the sandbox runs the langsmith CLI against an externally reachable LangSmith URL, which is derived from it."
 
   - it: should fail when engine is enabled and hostname is loopback
     values:
@@ -93,7 +93,7 @@ tests:
       images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
     asserts:
       - failedTemplate:
-          errorMessage: "engine.enabled is true and config.hostname is \"http://localhost:1980\", which a sandbox cannot reach: set engine.cliEndpoint to a LangSmith URL routable from the sandbox network (e.g. a tunnel to your local smith-go)."
+          errorMessage: "engine.enabled is true and config.hostname is \"http://localhost:1980\", which a sandbox cannot reach: it must be the externally reachable LangSmith address."
 
   - it: should fail when engine is enabled and hostname is an in-cluster address
     values:
@@ -107,18 +107,5 @@ tests:
       images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
     asserts:
       - failedTemplate:
-          errorMessage: "engine.enabled is true and config.hostname is the in-cluster address \"langsmith-frontend.default.svc.cluster.local\", which a sandbox cannot reach: set engine.cliEndpoint to the externally reachable LangSmith URL."
+          errorMessage: "engine.enabled is true and config.hostname is the in-cluster address \"langsmith-frontend.default.svc.cluster.local\", which a sandbox cannot reach: it must be the externally reachable LangSmith address."
 
-  - it: should accept a loopback hostname when engine.cliEndpoint overrides it
-    values:
-      - ./values/sandboxes-enabled.yaml
-    set:
-      config.hostname: http://localhost:1980
-      engine.enabled: true
-      engine.encryptionKey: test-key
-      engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
-      engine.sandboxTenantId: 00000000-0000-0000-0000-000000000000
-      engine.cliEndpoint: https://tunnel.example.com
-      images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
-    asserts:
-      - notFailedTemplate: {}

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -428,12 +428,6 @@ engine:
   # can be stopped by anyone with access, while each one runs agent-generated
   # code and holds a GitHub token for the repo under analysis.
   sandboxTenantId: ""
-  # -- Override for the LangSmith URL the sandbox runs the langsmith CLI
-  # against. Defaults to <config.hostname>/api. Set this only when that is not
-  # routable from the sandbox network (e.g. a tunnel to a local smith-go); an
-  # in-cluster service URL will not work. The sandbox proxy allow-lists this
-  # host and injects LangSmith credentials for it.
-  cliEndpoint: ""
 
 insights:
   enabled: true


### PR DESCRIPTION
> **Do not merge until an image containing langchainplus #32399 is pinned here.** Until then the agent still reads `LANGSMITH_CLI_ENDPOINT`; with the chart no longer setting it, it would fall back to the in-cluster `GO_ENDPOINT` and sandboxes would get a URL they cannot reach.

Stacked on #882. That PR makes `engine.cliEndpoint` optional so `self-hosted-ci` deploys **today**, with any agent image. This one removes it entirely, and needs the new agent first.

## Why it can go

langchainplus #32399 removes `LANGSMITH_CLI_ENDPOINT` from the agent, which now derives the in-sandbox CLI URL from `LANGCHAIN_PLATFORM_ENDPOINT`. That is already on the pod through the shared config map whenever `config.sandboxes.enabled` is true — which `validate.yaml` already requires for Engine — so the chart has nothing left to supply.

The agent tolerates the `/api` suffix: `langsmith-go`'s `normalizeBaseURL` strips a trailing `/api` or `/api/v1`.

## What changed

- `engine.cliEndpoint` removed from `values.yaml`
- the `LANGSMITH_CLI_ENDPOINT` env var and the `langsmith.engine.cliEndpoint` helper removed
- validation kept, keyed off `config.hostname` alone — still rejects an unset, loopback, or `.svc` hostname, since that is what the platform endpoint derives from

## Ordering

1. #882 merges → `self-hosted-ci` unblocked
2. #32399 merges → backport to `v16-stable` → version bump → image
3. pinned `engineInsightsAgentImage.tag` bumped to that image
4. this merges

## Test Plan

- [x] `helm unittest charts/langsmith` — 200/200
- [x] `helm lint` clean
- [x] Rendered with engine + sandboxes on: no `LANGSMITH_CLI_ENDPOINT`, and `LANGCHAIN_PLATFORM_ENDPOINT=https://eks.smith.langchain.dev/api` still present
- [x] Validation suite updated for the reworded failures; the `engine.cliEndpoint` override case dropped with the key
- [x] README regenerated with helm-docs