### PR TITLE
fix(langsmith): honor config.customCa in sandbox-host

### DIFF
--- a/charts/langsmith/templates/sandboxes/sandbox-host-deployment.yaml
+++ b/charts/langsmith/templates/sandboxes/sandbox-host-deployment.yaml
@@ -1,6 +1,8 @@
 {{- if .Values.config.sandboxes.enabled }}
 {{- $namespace := .Values.namespace | default .Release.Namespace }}
 {{- $autoscaling := .Values.config.sandboxes.sandboxHost.autoscaling }}
+{{- $tlsVolumes := include "langsmith.tlsVolumes" . | fromYamlArray }}
+{{- $tlsVolumeMounts := include "langsmith.tlsVolumeMounts" . | fromYamlArray }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -94,6 +96,10 @@ spec:
                   optional: {{ .Values.config.disableSecretCreation }}
             - name: SANDBOX_HOST_PROXY_CA_DIR
               value: /certs
+            {{- if and .Values.config.customCa.secretName .Values.config.customCa.secretKey }}
+            - name: SSL_CERT_FILE
+              value: /etc/ssl/certs/custom-ca-certificates.crt
+            {{- end }}
             {{- if or (not (empty .Values.config.existingSecretName)) .Values.config.sandboxes.callbackSigningJwk }}
             - name: LANGSMITH_SANDBOX_CALLBACK_SIGNING_JWK
               valueFrom:
@@ -160,6 +166,9 @@ spec:
             - name: proxy-ca
               mountPath: /certs
               readOnly: true
+            {{- with $tlsVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: juicefs
           persistentVolumeClaim:
@@ -171,5 +180,8 @@ spec:
           hostPath:
             path: /var/lib/sandbox-host
             type: DirectoryOrCreate
+        {{- with $tlsVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       terminationGracePeriodSeconds: {{ .Values.config.sandboxes.sandboxHost.deployment.terminationGracePeriodSeconds }}
 {{- end }}

--- a/charts/langsmith/tests/sandboxes_test.yaml
+++ b/charts/langsmith/tests/sandboxes_test.yaml
@@ -1076,3 +1076,49 @@ tests:
       - hasDocuments:
           count: 0
 
+
+  - it: should trust a custom CA bundle in sandbox-host
+    values:
+      - ./values/sandboxes-enabled.yaml
+    set:
+      config.customCa.secretName: my-ca
+      config.customCa.secretKey: ca.crt
+    template: sandboxes/sandbox-host-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SSL_CERT_FILE
+            value: /etc/ssl/certs/custom-ca-certificates.crt
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: langsmith-custom-ca
+            mountPath: /etc/ssl/certs/custom-ca-certificates.crt
+            subPath: ca-certificates.crt
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: langsmith-custom-ca
+            secret:
+              secretName: my-ca
+              items:
+                - key: ca.crt
+                  path: ca-certificates.crt
+
+  - it: should not mount a custom CA in sandbox-host by default
+    values:
+      - ./values/sandboxes-enabled.yaml
+    template: sandboxes/sandbox-host-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SSL_CERT_FILE
+          any: true
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: langsmith-custom-ca
+          any: true


### PR DESCRIPTION
`sandbox-host` was the only workload in the chart not wired to `config.customCa`, so an install that serves TLS from a private CA had no way to make the host trust it. Mounts the bundle and sets `SSL_CERT_FILE` via the same `langsmith.tlsVolumes` / `langsmith.tlsVolumeMounts` helpers every other component uses.

`LANGSMITH_SANDBOX_INTERNAL_ENDPOINT` is unchanged — still the in-cluster `platform-backend` Service.

Note for operators: `SSL_CERT_FILE` *replaces* the system trust store rather than adding to it, which is how the rest of the chart already behaves. The secret must therefore hold a full bundle, not just the private CA, or the host loses trust for anything else it talks to over TLS.

Stacked on `daniel/self-hosted-sandboxes-helm`.

## Test Plan

- [x] `helm unittest charts/langsmith` — 152 pass (2 new: CA mounted when configured, absent by default)
- [x] `helm lint`
- [x] Rendered with `config.customCa` set: `SSL_CERT_FILE` env, the `langsmith-custom-ca` volume, and a `subPath` mount that does not shadow `/etc/ssl/certs` or the `/certs` proxy-CA mount
- [ ] Confirm against a private-CA install that the host's calls to platform-backend and its snapshot pulls succeed