### PR TITLE
feat(langsmith): give sandbox egress an operator CA for origin verification

### DIFF
--- a/charts/langsmith/docs/ENABLE-SANDBOXES.md
+++ b/charts/langsmith/docs/ENABLE-SANDBOXES.md
@@ -116,6 +116,21 @@ issuer and sandbox egress callbacks fail closed, since receivers fetch the verif
 Service auth between LangSmith and the sandbox runtime reuses `config.apiKeySalt`, the same secret
 the chart already uses for `X_SERVICE_AUTH_JWT_SECRET`. There is nothing extra to set.
 
+## Reaching internal HTTPS services from sandboxes
+
+Sandbox egress is intercepted by a MITM proxy on the host, so code inside a sandbox only ever
+validates the proxy's own CA — nothing in the guest needs your CA. The proxy is what verifies the
+real origin, and it does so against the system trust store.
+
+If sandboxes need to reach an internal service signed by your own CA, set `config.customCa`
+(`secretName` and `secretKey`). The chart mounts it for `sandbox-host` and points
+`SANDBOX_HOST_EGRESS_ORIGIN_CA_FILE` at it, which **adds** your CA to the proxy's trust pool
+rather than replacing it, so public HTTPS keeps working in the same sandbox. Requires a
+`sandbox-host` image containing that variable; an older image ignores it.
+
+A configured CA that cannot be read fails host startup, rather than starting with the CA silently
+absent.
+
 ## The JuiceFS CSI driver
 
 Enabling sandboxes also installs the JuiceFS CSI driver, which creates **cluster-scoped**

--- a/charts/langsmith/templates/sandboxes/sandbox-host-deployment.yaml
+++ b/charts/langsmith/templates/sandboxes/sandbox-host-deployment.yaml
@@ -94,6 +94,12 @@ spec:
                   optional: {{ .Values.config.disableSecretCreation }}
             - name: SANDBOX_HOST_PROXY_CA_DIR
               value: /certs
+            {{- if and .Values.config.customCa.secretName .Values.config.customCa.secretKey }}
+            {{- /* Added to the pool the egress proxy verifies origins with, so sandboxes can
+                   reach internal HTTPS services. Appends to the system roots, unlike SSL_CERT_FILE. */}}
+            - name: SANDBOX_HOST_EGRESS_ORIGIN_CA_FILE
+              value: /etc/langsmith/egress-ca/ca.crt
+            {{- end }}
             {{- if or (not (empty .Values.config.existingSecretName)) .Values.config.sandboxes.callbackSigningJwk }}
             - name: LANGSMITH_SANDBOX_CALLBACK_SIGNING_JWK
               valueFrom:
@@ -160,6 +166,11 @@ spec:
             - name: proxy-ca
               mountPath: /certs
               readOnly: true
+            {{- if and .Values.config.customCa.secretName .Values.config.customCa.secretKey }}
+            - name: egress-origin-ca
+              mountPath: /etc/langsmith/egress-ca
+              readOnly: true
+            {{- end }}
       volumes:
         - name: juicefs
           persistentVolumeClaim:
@@ -171,5 +182,13 @@ spec:
           hostPath:
             path: /var/lib/sandbox-host
             type: DirectoryOrCreate
+        {{- if and .Values.config.customCa.secretName .Values.config.customCa.secretKey }}
+        - name: egress-origin-ca
+          secret:
+            secretName: {{ .Values.config.customCa.secretName }}
+            items:
+              - key: {{ .Values.config.customCa.secretKey }}
+                path: ca.crt
+        {{- end }}
       terminationGracePeriodSeconds: {{ .Values.config.sandboxes.sandboxHost.deployment.terminationGracePeriodSeconds }}
 {{- end }}

--- a/charts/langsmith/tests/sandboxes_test.yaml
+++ b/charts/langsmith/tests/sandboxes_test.yaml
@@ -1076,3 +1076,53 @@ tests:
       - hasDocuments:
           count: 0
 
+
+  - it: should give the egress proxy an operator CA for origin verification
+    values:
+      - ./values/sandboxes-enabled.yaml
+    set:
+      config.customCa.secretName: my-ca
+      config.customCa.secretKey: ca.crt
+    template: sandboxes/sandbox-host-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SANDBOX_HOST_EGRESS_ORIGIN_CA_FILE
+            value: /etc/langsmith/egress-ca/ca.crt
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SSL_CERT_FILE
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: egress-origin-ca
+            mountPath: /etc/langsmith/egress-ca
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: egress-origin-ca
+            secret:
+              secretName: my-ca
+              items:
+                - key: ca.crt
+                  path: ca.crt
+
+  - it: should not mount an egress origin CA when none is configured
+    values:
+      - ./values/sandboxes-enabled.yaml
+    template: sandboxes/sandbox-host-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SANDBOX_HOST_EGRESS_ORIGIN_CA_FILE
+          any: true
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: egress-origin-ca
+          any: true


### PR DESCRIPTION
Chart side of langchain-ai/langchainplus#32452. **Needs a `sandbox-host` image containing that PR** — an older image ignores the variable, so the behavior is simply absent rather than broken.

Mounts `config.customCa` for `sandbox-host` and points `SANDBOX_HOST_EGRESS_ORIGIN_CA_FILE` at it, letting sandboxes reach internal HTTPS services signed by the operator's own CA.

**Why not `SSL_CERT_FILE`** — that's what I tried first in #886 and closed. Go's `x509.SystemCertPool()` honors it, so it *replaces* the trust store the egress proxy verifies origins with. The MITM keeps working (the proxy signs leaf certs from its own CA at `/certs`, unaffected), and the proxy then fails to verify genuine origins — so every public HTTPS host breaks inside sandboxes while the proxy looks healthy. The new variable appends to the system roots instead.

The CA is mounted at `/etc/langsmith/egress-ca/` rather than under `/etc/ssl/certs`, so it can't be mistaken for a trust-store override, and it doesn't collide with the `/certs` proxy-CA mount.

Nothing is needed inside the guest: all sandbox traffic is intercepted, so code in the VM only ever validates the proxy CA already in its trust store.

Also adds a section to `ENABLE-SANDBOXES.md` covering this, including that a configured-but-unreadable CA fails host startup rather than starting without it.

## Test Plan

- [x] `helm unittest charts/langsmith` — 152 pass (2 new: wired when `config.customCa` is set, absent by default, and asserts `SSL_CERT_FILE` is *not* set)
- [x] `helm lint`
- [x] Rendered with `config.customCa`: env, `subPath`-free secret mount at `/etc/langsmith/egress-ca`, no clash with `/certs`
- [ ] On a private-CA install with an image containing #32452: a sandbox reaches an internal HTTPS host, and public HTTPS still works in the same sandbox