### PR TITLE
chore(langsmith): bump chart to 0.16.0-rc.24 / appVersion 0.16.28rc1

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.0-rc.23
-appVersion: "0.16.27rc1"
+version: 0.16.0-rc.24
+appVersion: "0.16.28rc1"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.16.0-rc.23](https://img.shields.io/badge/Version-0.16.0--rc.23-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.27rc1](https://img.shields.io/badge/AppVersion-0.16.27rc1-informational?style=flat-square)
+![Version: 0.16.0-rc.24](https://img.shields.io/badge/Version-0.16.0--rc.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.28rc1](https://img.shields.io/badge/AppVersion-0.16.28rc1-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -549,22 +549,22 @@ The chart-managed frontend owns public API route rewrites for LangSmith services
 | gateway.sectionName | string | `""` |  |
 | images.aceBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.aceBackendImage.repository | string | `"docker.io/langchain/langsmith-ace-backend"` |  |
-| images.aceBackendImage.tag | string | `"0.16.27rc1"` |  |
+| images.aceBackendImage.tag | string | `"0.16.28rc1"` |  |
 | images.agentBuilderImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.agentBuilderImage.repository | string | `"docker.io/langchain/agent-builder-deep-agent"` |  |
-| images.agentBuilderImage.tag | string | `"0.16.27rc1"` |  |
+| images.agentBuilderImage.tag | string | `"0.16.28rc1"` |  |
 | images.backendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.backendImage.repository | string | `"docker.io/langchain/langsmith-backend"` |  |
-| images.backendImage.tag | string | `"0.16.27rc1"` |  |
+| images.backendImage.tag | string | `"0.16.28rc1"` |  |
 | images.clickhouseImage.pullPolicy | string | `"Always"` |  |
 | images.clickhouseImage.repository | string | `"docker.io/clickhouse/clickhouse-server"` |  |
 | images.clickhouseImage.tag | string | `"25.12"` |  |
 | images.engineInsightsAgentImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.engineInsightsAgentImage.repository | string | `"docker.io/langchain/langsmith-clio"` |  |
-| images.engineInsightsAgentImage.tag | string | `"0.16.27rc1"` |  |
+| images.engineInsightsAgentImage.tag | string | `"0.16.28rc1"` |  |
 | images.frontendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.frontendImage.repository | string | `"docker.io/langchain/langsmith-frontend"` |  |
-| images.frontendImage.tag | string | `"0.16.27rc1"` |  |
+| images.frontendImage.tag | string | `"0.16.28rc1"` |  |
 | images.imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Specified as name: value. |
 | images.juicefsCSIImage | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/juicedata/juicefs-csi-driver","tag":"v0.31.4"}` | JuiceFS CSI driver image. Only used when config.sandboxes.enabled is true. |
 | images.juicefsCSINodeDriverRegistrarImage | object | `{"pullPolicy":"IfNotPresent","repository":"registry.k8s.io/sig-storage/csi-node-driver-registrar","tag":"v2.9.0"}` | JuiceFS CSI node-driver-registrar sidecar image. Only used when config.sandboxes.enabled is true. |
@@ -574,7 +574,7 @@ The chart-managed frontend owns public API route rewrites for LangSmith services
 | images.operatorImage.tag | string | `"0.1.47"` |  |
 | images.pollyAgentImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.pollyAgentImage.repository | string | `"docker.io/langchain/langsmith-polly"` |  |
-| images.pollyAgentImage.tag | string | `"0.16.27rc1"` |  |
+| images.pollyAgentImage.tag | string | `"0.16.28rc1"` |  |
 | images.postgresImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.postgresImage.repository | string | `"docker.io/postgres"` |  |
 | images.postgresImage.tag | string | `"14.7"` |  |
@@ -588,7 +588,7 @@ The chart-managed frontend owns public API route rewrites for LangSmith services
 | images.sandboxHostImage | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/langchain/sandbox-host","tag":""}` | sandbox-host image. Only used when config.sandboxes.enabled is true. |
 | images.smithdbImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.smithdbImage.repository | string | `"docker.io/langchain/smithdb"` |  |
-| images.smithdbImage.tag | string | `"0.16.27rc1"` |  |
+| images.smithdbImage.tag | string | `"0.16.28rc1"` |  |
 | ingestQueue.autoscaling.hpa.enabled | bool | `false` |  |
 | ingestQueue.autoscaling.hpa.maxReplicas | int | `10` |  |
 | ingestQueue.autoscaling.hpa.minReplicas | int | `3` |  |

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -65,22 +65,22 @@ images:
   aceBackendImage:
     repository: "docker.io/langchain/langsmith-ace-backend"
     pullPolicy: IfNotPresent
-    tag: "0.16.27rc1"
+    tag: "0.16.28rc1"
   backendImage:
     repository: "docker.io/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
-    tag: "0.16.27rc1"
+    tag: "0.16.28rc1"
   # Image for the shared Engine/Insights agent deployment. When engine.enabled
   # is true this must point at the combined insights-engine image, which serves
   # both the `insights` and `engine` graphs.
   engineInsightsAgentImage:
     repository: "docker.io/langchain/langsmith-clio"
     pullPolicy: IfNotPresent
-    tag: "0.16.27rc1"
+    tag: "0.16.28rc1"
   frontendImage:
     repository: "docker.io/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
-    tag: "0.16.27rc1"
+    tag: "0.16.28rc1"
   operatorImage:
     repository: "docker.io/langchain/langgraph-operator"
     pullPolicy: IfNotPresent
@@ -104,15 +104,15 @@ images:
   agentBuilderImage:
     repository: "docker.io/langchain/agent-builder-deep-agent"
     pullPolicy: IfNotPresent
-    tag: "0.16.27rc1"
+    tag: "0.16.28rc1"
   pollyAgentImage:
     repository: "docker.io/langchain/langsmith-polly"
     pullPolicy: IfNotPresent
-    tag: "0.16.27rc1"
+    tag: "0.16.28rc1"
   smithdbImage:
     repository: "docker.io/langchain/smithdb"
     pullPolicy: IfNotPresent
-    tag: "0.16.27rc1"
+    tag: "0.16.28rc1"
   # Optional: only mirror/pull when presidioAnalyzer.enabled is true
   presidioAnalyzerImage:
     repository: "mcr.microsoft.com/presidio-analyzer"


### PR DESCRIPTION
Cuts the v16 stable chart for the `0.16.28rc1` self-hosted images published by langchainplus #32498. This release contains the Redis 5 compatibility backport from langchainplus #32470 (original fix #32402).

The self-hosted release workflow completed successfully, and the `langsmith-backend:0.16.28rc1` DockerHub manifest is available. The chart version advances from `0.16.0-rc.23` to `0.16.0-rc.24`, and the seven LangSmith image tags advance to `0.16.28rc1`.

## Test Plan

- [x] Regenerated `charts/langsmith/README.md` with helm-docs 1.14.2
- [x] `helm lint charts/langsmith`
- [x] `helm unittest charts/langsmith` — 248/248 passed
- [x] Confirmed no `0.16.27rc1` references remain in the chart