### PR TITLE
chore(engine): drop the per-service JWT secrets from the co-host

### DIFF
--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -1085,8 +1085,6 @@ Extra env vars for insights api-server and queue pods.
 {{- if $feature.redis.external.iamProvider -}}
 {{- $out = append $out (dict "name" "AGENT_REDIS_IAM_AUTH_PROVIDER" "value" $feature.redis.external.iamProvider) -}}
 {{- end -}}
-{{- $out = append $out (dict "name" "SMITH_BACKEND_SERVICE_JWT_SECRET" "valueFrom" (dict "secretKeyRef" (dict "name" (include "langsmith.secretsName" $root) "key" "api_key_salt" "optional" $root.Values.config.disableSecretCreation))) -}}
-{{- $out = append $out (dict "name" "SMITH_GO_SERVICE_JWT_SECRET" "valueFrom" (dict "secretKeyRef" (dict "name" (include "langsmith.secretsName" $root) "key" "api_key_salt" "optional" $root.Values.config.disableSecretCreation))) -}}
 {{- if $root.Values.engine.enabled -}}
 {{- $out = append $out (dict "name" "ENGINE_INTELLIGENCE_BASE_URL" "value" $root.Values.engine.intelligenceBaseUrl) -}}
 {{- $out = append $out (dict "name" "ISSUES_AGENT_ENCRYPTION_KEY" "valueFrom" (dict "secretKeyRef" (dict "name" (include "langsmith.secretsName" $root) "key" "engine_encryption_key" "optional" $root.Values.config.disableSecretCreation))) -}}
@@ -1573,12 +1571,6 @@ Served through the frontend at /mcp (or /<basePath>/mcp).
 {{- if .Values.engine.enabled }}
 - name: FORGE_AGENT_ASSISTANT_ID
   value: "engine"
-- name: SMITH_GO_SERVICE_JWT_SECRET
-  valueFrom:
-    secretKeyRef:
-      name: {{ include "langsmith.secretsName" . }}
-      key: api_key_salt
-      optional: {{ .Values.config.disableSecretCreation }}
 - name: ISSUES_AGENT_ENCRYPTION_KEY
   valueFrom:
     secretKeyRef:


### PR DESCRIPTION
Replaces #881, whose branch was cut before two `v16-stable` merges and showed a phantom 60-file diff as a result. Same intent, three lines, against current `v16-stable`.

`SMITH_GO_SERVICE_JWT_SECRET` and `SMITH_BACKEND_SERVICE_JWT_SECRET` are redundant: both smith-go and the co-hosted agent fall back to the shared `X_SERVICE_AUTH_JWT_SECRET`, and every affected pod already has it.

## Why this is safe now

The engine dispatch switch used to be the secret's own presence, so removing it would have silently turned service-key auth **off** — no render error, no runtime error. langchainplus #31926 separated them:

```go
func (e Environment) EngineServiceKeyAuth() bool {
    return e.ForgeAgentAssistantID == engineCoHostAssistantID ||
        e.SmithGoServiceJWTSecret != ""
}
```

The chart sets `FORGE_AGENT_ASSISTANT_ID: engine` in `langsmith.engine.smithGoEnv`, so the switch stays on. #31926 is in `0.16.27rc1` and later.

## Verified against self-hosted-ci's real values

| pod | shared secret | per-service | assistant id |
|---|---|---|---|
| `platform-backend` | yes | none | `engine` |
| `standalone-insights-api-server` | yes | none | n/a (smith-go env) |

## Test Plan

- [x] `helm lint` clean
- [x] `helm unittest charts/langsmith` — 248/248
- [x] No references left anywhere under `charts/`
- [x] Rendered against `self-hosted-ci` values: shared secret present, per-service gone, switch intact