### PR TITLE
chore(engine): make engine.sandboxTenantId optional

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -30,7 +30,7 @@ The chart-managed frontend owns public API route rewrites for LangSmith services
 | engine.encryptionKey | string | `""` |  |
 | engine.encryptionKeyPrevious | string | `""` |  |
 | engine.intelligenceBaseUrl | string | `""` |  |
-| engine.sandboxTenantId | string | `""` | Workspace id that owns Engine sandboxes. Required when sandboxes are enabled: the Engine signs a service key with this tenant and smith-go rejects one without it.  Use a workspace reserved for the Engine, not one people work in. Sandboxes land in this workspace, so they consume its sandbox quota — an Engine run can be refused because the workspace is at its cap, and Engine sandboxes count against a cap bought for other work. They are also listed in it and can be stopped by anyone with access, while each one runs agent-generated code and holds a GitHub token for the repo under analysis. |
+| engine.sandboxTenantId | string | `""` | Override for the workspace that owns Engine sandboxes. Optional: smith-go resolves the install's workspace when this is unset, and only declines when the install has more than one non-personal org.  Use a workspace reserved for the Engine, not one people work in. Sandboxes land in this workspace, so they consume its sandbox quota — an Engine run can be refused because the workspace is at its cap, and Engine sandboxes count against a cap bought for other work. They are also listed in it and can be stopped by anyone with access, while each one runs agent-generated code and holds a GitHub token for the repo under analysis. |
 | engineInsightsAgent.apiServer.autoscaling.enabled | bool | `false` |  |
 | engineInsightsAgent.apiServer.autoscaling.keda.cooldownPeriod | int | `300` |  |
 | engineInsightsAgent.apiServer.autoscaling.keda.enabled | bool | `false` |  |

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -558,9 +558,6 @@ AWS Marketplace Helm template verification).
 {{- if regexMatch "\\.svc(\\.[a-zA-Z0-9.-]+)?(:[0-9]+)?(/.*)?$" .Values.config.hostname }}
 {{- fail (printf "engine.enabled is true and config.hostname is the in-cluster address %q, which a sandbox cannot reach: it must be the externally reachable LangSmith address." .Values.config.hostname) }}
 {{- end }}
-{{- if not .Values.engine.sandboxTenantId }}
-{{- fail "engine.sandboxTenantId is required when engine.enabled is true: the Engine signs its sandbox service key with this workspace id and smith-go rejects a service key without a tenant. Use a workspace reserved for the Engine — its sandboxes consume that workspace's sandbox quota and are visible to anyone with access to it." }}
-{{- end }}
 {{- end }}
 
 {{- /* Validate agent feature (fleet/insights/polly) configuration */ -}}

--- a/charts/langsmith/tests/engine_insights_agent_test.yaml
+++ b/charts/langsmith/tests/engine_insights_agent_test.yaml
@@ -41,7 +41,7 @@ tests:
       - failedTemplate:
           errorMessage: "engine.intelligenceBaseUrl is required when engine.enabled is true: the self-hosted Engine has no ANTHROPIC_API_KEY and routes model calls through the LSI gateway for its cloud/region (e.g. AWS: https://beacon.aws.langchain.com/intelligence)."
 
-  - it: should fail when engine and sandboxes are enabled without a sandbox tenant
+  - it: should render without a sandbox tenant, which smith-go resolves
     values:
       - ./values/sandboxes-enabled.yaml
     set:
@@ -51,8 +51,7 @@ tests:
       engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
       images.engineInsightsAgentImage.repository: docker.io/langchain/langsmith-insights-engine
     asserts:
-      - failedTemplate:
-          errorMessage: "engine.sandboxTenantId is required when engine.enabled is true: the Engine signs its sandbox service key with this workspace id and smith-go rejects a service key without a tenant. Use a workspace reserved for the Engine — its sandboxes consume that workspace's sandbox quota and are visible to anyone with access to it."
+      - notFailedTemplate: {}
 
   - it: should fail when engine is enabled without sandboxes
     values:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -557,9 +557,9 @@ engine:
   # Prior key, accepted for decryption only, so encryptionKey can be rotated
   # without failing runs encrypted just before the swap.
   encryptionKeyPrevious: ""
-  # -- Workspace id that owns Engine sandboxes. Required when sandboxes are
-  # enabled: the Engine signs a service key with this tenant and smith-go
-  # rejects one without it.
+  # -- Override for the workspace that owns Engine sandboxes. Optional: smith-go
+  # resolves the install's workspace when this is unset, and only declines when
+  # the install has more than one non-personal org.
   #
   # Use a workspace reserved for the Engine, not one people work in. Sandboxes
   # land in this workspace, so they consume its sandbox quota — an Engine run


### PR DESCRIPTION
smith-go resolves the install's workspace and passes it to the agent (langchainplus #32433), so the chart no longer has to require `engine.sandboxTenantId`. That shipped in `0.16.30rc1`, which this chart now points at, so the guard can go.

This is the follow-up noted in langchainplus #32385: the guard was deliberately left in place until an image containing the resolver existed, so a deploy could not go green while runs still failed.

It stays available as an override for installs that want a dedicated workspace. smith-go declines to guess when there is more than one non-personal org, and the agent then errors naming the setting — so the failure mode is a clear message, not a wrong workspace.

## Changes

- drop the `fail` from `validate.yaml`
- reword the `values.yaml` doc from required to override
- replace the "should fail without a sandbox tenant" test with one asserting it renders
- README regenerated

## Test Plan

- [x] `helm unittest charts/langsmith` — 283/283
- [x] `helm lint` clean
- [x] Renders with engine enabled and no `sandboxTenantId`

## Why now

`stable-dual` just had sandboxes enabled (deployments#34738) and is the first cluster running released 0.16 artifacts with the infrastructure for Engine. Leaving it unset there exercises the resolver end to end, which nothing has yet done — `self-hosted-ci` sets the value explicitly.