### PR TITLE
fix(engine): derive spend endpoint from intelligence URL

### DIFF
--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -43,6 +43,7 @@ data:
   GO_ENDPOINT: {{ include "langsmith.platformBackendEndpoint" . | quote }}
   LANGSMITH_PUBLIC_API_ENDPOINT: {{ include "langsmith.publicApiEndpoint" . | quote }}
   {{- if .Values.engine.enabled }}
+  SMITH_INTELLIGENCE_ENDPOINT: {{ .Values.engine.intelligenceBaseUrl | trimSuffix "/" | trimSuffix "/intelligence" | quote }}
   FORGE_AGENT_LANGGRAPH_URL: "http://{{ include "langsmith.agentFeatures.fullname" (dict "root" . "product" "engineInsightsAgent") }}-{{ .Values.engineInsightsAgent.apiServer.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.engineInsightsAgent.apiServer.service.httpPort }}"
   {{- end }}
   GO_ACE_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.aceBackend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.aceBackend.service.port }}"

--- a/charts/langsmith/tests/platform_endpoint_test.yaml
+++ b/charts/langsmith/tests/platform_endpoint_test.yaml
@@ -1,4 +1,4 @@
-suite: LANGCHAIN_PLATFORM_ENDPOINT shared config
+suite: shared platform endpoint config
 # smith-go builds the Engine run webhook callback URL from
 # LANGCHAIN_PLATFORM_ENDPOINT, falling back to LANGCHAIN_ENDPOINT ("/api/v1")
 # when it is unset. langgraph-api rejects run creation with HTTP 422 when the
@@ -38,3 +38,26 @@ tests:
     asserts:
       - notExists:
           path: data.LANGCHAIN_PLATFORM_ENDPOINT
+
+  - it: should derive the intelligence endpoint from the Engine URL
+    set:
+      engine.enabled: true
+      engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
+    asserts:
+      - equal:
+          path: data.SMITH_INTELLIGENCE_ENDPOINT
+          value: "https://beacon.aws.langchain.com"
+
+  - it: should handle a trailing slash on the Engine URL
+    set:
+      engine.enabled: true
+      engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence/
+    asserts:
+      - equal:
+          path: data.SMITH_INTELLIGENCE_ENDPOINT
+          value: "https://beacon.aws.langchain.com"
+
+  - it: should omit the intelligence endpoint when Engine is disabled
+    asserts:
+      - notExists:
+          path: data.SMITH_INTELLIGENCE_ENDPOINT


### PR DESCRIPTION
## What

- derive `SMITH_INTELLIGENCE_ENDPOINT` from the existing required `engine.intelligenceBaseUrl`

## Test Plan

- [ ] Deploy to self-hosted CI and confirm Engine spend is read from LSI