### PR TITLE
fix(langsmith): mirror the insights-engine image

### DIFF
--- a/charts/langsmith/scripts/mirror_langsmith_images.sh
+++ b/charts/langsmith/scripts/mirror_langsmith_images.sh
@@ -69,6 +69,9 @@ IMAGES=(
     "docker.io/langchain/langsmith-ace-backend:${VERSION}"
     "docker.io/langchain/langsmith-backend:${VERSION}"
     "docker.io/langchain/langsmith-clio:${VERSION}"
+    # Enabling Engine points images.engineInsightsAgentImage at this combined
+    # image instead of clio, so both are mirrored to cover either setting.
+    "docker.io/langchain/langsmith-insights-engine:${VERSION}"
     "docker.io/langchain/langsmith-frontend:${VERSION}"
     "docker.io/langchain/hosted-langserve-backend:${VERSION}"
     "docker.io/langchain/langgraph-operator:${OPERATOR_VERSION}"

--- a/charts/langsmith/scripts/mirror_langsmith_images.sh
+++ b/charts/langsmith/scripts/mirror_langsmith_images.sh
@@ -69,8 +69,6 @@ IMAGES=(
     "docker.io/langchain/langsmith-ace-backend:${VERSION}"
     "docker.io/langchain/langsmith-backend:${VERSION}"
     "docker.io/langchain/langsmith-clio:${VERSION}"
-    # Enabling Engine points images.engineInsightsAgentImage at this combined
-    # image instead of clio, so both are mirrored to cover either setting.
     "docker.io/langchain/langsmith-insights-engine:${VERSION}"
     "docker.io/langchain/langsmith-frontend:${VERSION}"
     "docker.io/langchain/hosted-langserve-backend:${VERSION}"


### PR DESCRIPTION
A customer who mirrors images into a private registry cannot enable Engine today: the mirror script never pulls the image the chart requires.

## The gap

`validate.yaml` fails the render when Engine is on unless `images.engineInsightsAgentImage.repository` points at `langsmith-insights-engine`:

> Engine requires the combined insights-engine image, which serves both the `insights` and `engine` graphs. Point it at langsmith-insights-engine (or your mirror of it).

But `mirror_langsmith_images.sh` listed only `langsmith-clio`. So the documented mirroring procedure produces an image set that cannot satisfy the chart's own validation.

## Change

One entry, alongside clio. Listed **unconditionally rather than behind a flag** — `--include-sandboxes` exists because those images are published for amd64 only, a platform constraint this image doesn't share, and every other application image here (including agent-builder ones many installs don't use) is unconditional.

## Test plan

- [x] `bash -n` clean
- [x] `--dry-run` default mode → `docker.io/langchain/langsmith-insights-engine:0.16.31rc1 → <registry>/langchain/langsmith-insights-engine:0.16.31rc1`
- [x] `--dry-run --dest-repo` marketplace mode → `<registry>/langchain/repo:langsmith-insights-engine-0.16.31rc1`

## This is half the fix

The image is also **not publicly pullable**, so mirroring it will fail for anyone without our pull secret:

```
langsmith-clio              is_private = False
sandbox-host                is_private = False
langsmith-insights-engine   not visible anonymously
```

The release workflow already promotes it (`- source: langsmith-insights-engine` in `release_self_hosted_on_version_bump.yaml`) and pushes are landing — its siblings were pushed minutes apart in the same run, and our stable clusters pull it with `imagePullSecrets: private-dockerhub-images`. So the build and promote path is fine; the **Docker Hub repository visibility** needs flipping to public to match its siblings. That's an org-admin action, not code — it isn't Terraform-managed.

Until that happens this PR doesn't unblock anyone on its own, but it removes the other half of the problem and documents it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)