### PR TITLE
fix(engine): restore platform endpoint on main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,12 @@ test*.yaml
 charts/langsmith-observability/charts/*
 test*.csv
 .tmp/
+.env
+.env.*
+*.pem
+*.key
+*.crt
+credentials.json
+node_modules/
+__pycache__/
+.venv/

--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -35,6 +35,11 @@ data:
   {{- end }}
   LANGCHAIN_ENV: "local_kubernetes"
   LANGCHAIN_ENDPOINT: "/{{ if .Values.config.basePath }}{{ .Values.config.basePath }}/{{ end }}api/v1"
+  {{- if .Values.sandboxes.enabled }}
+  {{- /* smith-go builds the Engine run webhook callback from this; a relative
+         value makes langgraph-api reject run creation as a loopback webhook. */}}
+  LANGCHAIN_PLATFORM_ENDPOINT: {{ include "langsmith.publicApiEndpoint" . | quote }}
+  {{- end }}
   GO_ENDPOINT: {{ include "langsmith.platformBackendEndpoint" . | quote }}
   LANGSMITH_PUBLIC_API_ENDPOINT: {{ include "langsmith.publicApiEndpoint" . | quote }}
   GO_ACE_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.aceBackend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.aceBackend.service.port }}"

--- a/charts/langsmith/tests/platform_endpoint_test.yaml
+++ b/charts/langsmith/tests/platform_endpoint_test.yaml
@@ -1,0 +1,40 @@
+suite: LANGCHAIN_PLATFORM_ENDPOINT shared config
+# smith-go builds the Engine run webhook callback URL from
+# LANGCHAIN_PLATFORM_ENDPOINT, falling back to LANGCHAIN_ENDPOINT ("/api/v1")
+# when it is unset. langgraph-api rejects run creation with HTTP 422 when the
+# webhook is relative, so dropping this variable breaks every non-shadow
+# Engine run. It also backs signed download links, SCIM $refs, and MCP
+# resource URLs.
+templates:
+  - templates/config-map.yaml
+tests:
+  - it: should be absolute when sandboxes are enabled
+    values:
+      - ./values/sandboxes-enabled.yaml
+    set:
+      config.hostname: https://langsmith.example.com
+    asserts:
+      - equal:
+          path: data.LANGCHAIN_PLATFORM_ENDPOINT
+          value: "https://langsmith.example.com/api"
+
+  - it: should include the base path when one is set
+    values:
+      - ./values/sandboxes-enabled.yaml
+    set:
+      config.hostname: https://langsmith.example.com
+      config.basePath: langsmith
+    asserts:
+      - equal:
+          path: data.LANGCHAIN_PLATFORM_ENDPOINT
+          value: "https://langsmith.example.com/langsmith/api"
+
+  - it: should not be set when sandboxes are disabled
+    set:
+      config.existingSecretName: langsmith-secrets
+      config.oauth.enabled: true
+      config.authType: oauth
+      config.hostname: https://langsmith.example.com
+    asserts:
+      - notExists:
+          path: data.LANGCHAIN_PLATFORM_ENDPOINT


### PR DESCRIPTION
## what

- sets `LANGCHAIN_PLATFORM_ENDPOINT` on `main` when sandboxes are enabled.

## why

- without it, engine uses a relative callback url that langgraph rejects.

## how

- reuses the existing public api url. this matches #897 on `v16-stable`.

## testing

- `git diff --check` passed
- added helm tests
- helm was unavailable locally, so the tests were not run