### PR TITLE
feat(langgraph-cloud): configure trusted CORS origins

### DIFF
--- a/charts/langgraph-cloud/README.md
+++ b/charts/langgraph-cloud/README.md
@@ -499,6 +499,7 @@ If you are upgrading from a chart revision that used the old flat MongoDB values
 | config.auth.enabled | bool | `false` |  |
 | config.auth.langSmithAuthEndpoint | string | `""` |  |
 | config.auth.langSmithTenantId | string | `""` |  |
+| config.corsAllowOrigins | list | `[]` | Trusted browser origins allowed to make credentialed cross-origin requests to the API server. Use exact origins including scheme and optional port, for example https://langsmith.example.com. Wildcard origins are rejected because they cannot safely support cookie authentication. |
 | config.existingSecretName | string | `""` |  |
 | config.httpMaxRequestBodyBytes | string | `""` | Set this to override the default limit. Requests exceeding this limit receive HTTP 413. |
 | config.langGraphCloudLicenseKey | string | `""` | Optional LangGraph Cloud license key loaded from the chart secret. |

--- a/charts/langgraph-cloud/templates/_helpers.tpl
+++ b/charts/langgraph-cloud/templates/_helpers.tpl
@@ -175,6 +175,22 @@ Set config.skipValidation to true to bypass these checks (e.g. for helm template
 {{- end }}
 
 {{/*
+Validates trusted browser origins used for credentialed CORS.
+*/}}
+{{- define "langGraphCloud.validateCorsAllowOrigins" -}}
+{{- if not .Values.config.skipValidation -}}
+{{- range .Values.config.corsAllowOrigins -}}
+{{- if eq . "*" -}}
+{{- fail "config.corsAllowOrigins must contain exact origins; wildcard origins cannot support credentialed CORS" -}}
+{{- end -}}
+{{- if not (regexMatch `^https?://[^/]+$` .) -}}
+{{- fail (printf "config.corsAllowOrigins entry %q must be an exact http(s) origin without a path or trailing slash" .) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Environment variables used to default agent server checkpointers without overriding app-level LANGGRAPH_CHECKPOINTER.
 */}}
 {{- define "langGraphCloud.checkpointerEnv" -}}

--- a/charts/langgraph-cloud/templates/api-server/deployment.yaml
+++ b/charts/langgraph-cloud/templates/api-server/deployment.yaml
@@ -1,4 +1,5 @@
 {{- $volumes := concat .Values.commonVolumes .Values.apiServer.deployment.volumes -}}
+{{- include "langGraphCloud.validateCorsAllowOrigins" . -}}
 {{- $volumeMounts := concat .Values.commonVolumeMounts .Values.apiServer.deployment.volumeMounts -}}
 {{- $checkpointerEnv := include "langGraphCloud.checkpointerEnv" . -}}
 apiVersion: apps/v1
@@ -101,6 +102,10 @@ spec:
             {{- if .Values.config.httpMaxRequestBodyBytes }}
             - name: HTTP_MAX_REQUEST_BODY_BYTES
               value: {{ .Values.config.httpMaxRequestBodyBytes | quote }}
+            {{- end }}
+            {{- with .Values.config.corsAllowOrigins }}
+            - name: CORS_ALLOW_ORIGINS
+              value: {{ join "," . | quote }}
             {{- end }}
             {{- with .Values.apiServer.deployment.extraEnv }}
               {{- toYaml . | nindent 12 }}

--- a/charts/langgraph-cloud/tests/cors_test.yaml
+++ b/charts/langgraph-cloud/tests/cors_test.yaml
@@ -1,0 +1,38 @@
+suite: API server CORS configuration
+templates:
+  - api-server/deployment.yaml
+tests:
+  - it: does not configure allowed origins by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CORS_ALLOW_ORIGINS
+
+  - it: renders trusted browser origins as a comma-separated environment variable
+    set:
+      config.corsAllowOrigins:
+        - https://langsmith.example.com
+        - http://localhost:3000
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CORS_ALLOW_ORIGINS
+            value: https://langsmith.example.com,http://localhost:3000
+
+  - it: rejects wildcard origins
+    set:
+      config.corsAllowOrigins:
+        - "*"
+    asserts:
+      - failedTemplate:
+          errorMessage: "config.corsAllowOrigins must contain exact origins; wildcard origins cannot support credentialed CORS"
+
+  - it: rejects origins with paths
+    set:
+      config.corsAllowOrigins:
+        - https://langsmith.example.com/path
+    asserts:
+      - failedTemplate:
+          errorMessage: 'config.corsAllowOrigins entry "https://langsmith.example.com/path" must be an exact http(s) origin without a path or trailing slash'

--- a/charts/langgraph-cloud/values.yaml
+++ b/charts/langgraph-cloud/values.yaml
@@ -64,6 +64,10 @@ config:
     enabled: false
     langSmithAuthEndpoint: ""
     langSmithTenantId: ""
+  # -- Trusted browser origins allowed to make credentialed cross-origin requests to the API server.
+  # Use exact origins including scheme and optional port, for example https://langsmith.example.com.
+  # Wildcard origins are rejected because they cannot safely support cookie authentication.
+  corsAllowOrigins: []
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Summary

- adds `config.corsAllowOrigins` to the `langgraph-cloud` chart
- renders trusted origins as `CORS_ALLOW_ORIGINS` on the Agent Server API deployment
- rejects wildcard origins and values containing paths or trailing slashes
- documents the value and adds Helm unit coverage

## Motivation

Supports the self-hosted migration for langchain-ai/langgraph-api#3135. Direct self-hosted browser clients using cookie authentication need explicit trusted origins once credentialed wildcard CORS is disabled.

Example:

```yaml
config:
  corsAllowOrigins:
    - https://langsmith.example.com
```

Multiple entries are rendered as the comma-separated format expected by Agent Server.

## Validation

- `helm lint charts/langgraph-cloud`
- rendered no-value and multi-origin configurations with Helm 3.12.1
- verified wildcard and path-bearing origins fail rendering
- `git diff --check`

The Helm unittest plugin could not be installed locally because its release checksum download failed; CI runs the added suite with the repository-pinned plugin.

Release Notes: Added `config.corsAllowOrigins` to configure explicit trusted browser origins for credentialed Agent Server requests.