### PR TITLE
fix(langsmith): drop root /oauth/* routes; SPA uses /api/oauth/*

### DIFF
--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -401,23 +401,6 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
 
-        # The OAuth consent page (SPA at /oauth/consent) submits approval and reads client
-        # metadata at the AS's root /oauth/* paths (single-origin leaves the SPA's backend
-        # origin empty). Route those to platform-backend; /oauth/consent stays on the SPA.
-        location = /oauth/authorize/approve {
-            proxy_set_header Connection '';
-            proxy_http_version 1.1;
-            proxy_buffering off;
-            proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
-        }
-        location /oauth/client/ {
-            proxy_set_header Connection '';
-            proxy_http_version 1.1;
-            proxy_buffering off;
-            proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
-        }
     {{- end }}
 
         # Backend Routes
@@ -1035,23 +1018,6 @@ data:
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
         }
 
-        # The OAuth consent page (SPA at /oauth/consent) submits approval and reads client
-        # metadata at the AS's root /oauth/* paths (single-origin leaves the SPA's backend
-        # origin empty). Route those to platform-backend; /oauth/consent stays on the SPA.
-        location = /oauth/authorize/approve {
-            proxy_set_header Connection '';
-            proxy_http_version 1.1;
-            proxy_buffering off;
-            proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
-        }
-        location /oauth/client/ {
-            proxy_set_header Connection '';
-            proxy_http_version 1.1;
-            proxy_buffering off;
-            proxy_cache off;
-            proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
-        }
     {{- end }}
 
         # Backend Routes


### PR DESCRIPTION
Backport of #764 to `v16-stable`.

The SPA consent and device-activation pages call `/api/oauth/*` (the issuer path), so the bare-root `location = /oauth/authorize/approve` and `location /oauth/client/` blocks are unused. Removed from both the basePath and plain variants of the frontend nginx config.

`v16-stable` had these in the same shape as `main`, so the change applied cleanly with no adaptation.

No `Chart.yaml` bump: recent template-only changes on `main` land without one, and this touches no rendered behaviour beyond the removed routes.

## Test Plan

- [x] `helm unittest charts/langsmith` on this branch: 289 tests across 21 suites pass
- [x] Verified `/api/oauth/` (2), the well-known oauth endpoints (12) and `oauth-callback` (2) are all still present, and 0 root `/oauth/{authorize/approve,client/}` locations remain