### PR TITLE
feat(langsmith): use unified JuiceFS sandbox image [v16-stable]

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -566,9 +566,7 @@ The chart-managed frontend owns public API route rewrites for LangSmith services
 | images.frontendImage.repository | string | `"docker.io/langchain/langsmith-frontend"` |  |
 | images.frontendImage.tag | string | `"0.16.31rc1"` |  |
 | images.imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Specified as name: value. |
-| images.juicefsCSIImage | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/juicedata/juicefs-csi-driver","tag":"v0.31.4"}` | JuiceFS CSI driver image. Only used when config.sandboxes.enabled is true. |
-| images.juicefsCSINodeDriverRegistrarImage | object | `{"pullPolicy":"IfNotPresent","repository":"registry.k8s.io/sig-storage/csi-node-driver-registrar","tag":"v2.9.0"}` | JuiceFS CSI node-driver-registrar sidecar image. Only used when config.sandboxes.enabled is true. |
-| images.juicefsMountImage | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/juicedata/mount","tag":"ce-v1.3.0"}` | Optional JuiceFS CE mount image used by runtime mount pods. Set this when mirroring images for restricted networks. |
+| images.juicefsImage | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/langchain/sandbox-juicefs","tag":""}` | Sandbox JuiceFS image containing the CSI driver, node-driver-registrar, and mount binaries. Only used when sandboxes.enabled is true. |
 | images.operatorImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.operatorImage.repository | string | `"docker.io/langchain/langgraph-operator"` |  |
 | images.operatorImage.tag | string | `"0.1.47"` |  |

--- a/charts/langsmith/scripts/mirror_langsmith_images.sh
+++ b/charts/langsmith/scripts/mirror_langsmith_images.sh
@@ -91,6 +91,7 @@ if $INCLUDE_SANDBOXES; then
 
     IMAGES+=(
         "docker.io/langchain/sandbox-host:${VERSION}"
+        "docker.io/langchain/sandbox-juicefs:${VERSION}"
     )
 fi
 

--- a/charts/langsmith/templates/sandboxes/juicefs-csi-driver/configmap.yaml
+++ b/charts/langsmith/templates/sandboxes/juicefs-csi-driver/configmap.yaml
@@ -1,4 +1,4 @@
-{{- /* Vendored from the upstream juicefs-csi-driver chart; re-sync when bumping images.juicefsCSIImage. */}}
+{{- /* Vendored from the upstream juicefs-csi-driver chart; re-sync when bumping images.juicefsImage. */}}
 {{- if and .Values.sandboxes.enabled .Values.sandboxes.juicefs.csi.install }}
 {{- $namespace := .Values.namespace | default .Release.Namespace }}
 apiVersion: v1

--- a/charts/langsmith/templates/sandboxes/juicefs-csi-driver/controller-statefulset.yaml
+++ b/charts/langsmith/templates/sandboxes/juicefs-csi-driver/controller-statefulset.yaml
@@ -1,7 +1,7 @@
-{{- /* Vendored from the upstream juicefs-csi-driver chart; re-sync when bumping images.juicefsCSIImage. */}}
+{{- /* Vendored from the upstream juicefs-csi-driver chart; re-sync when bumping images.juicefsImage. */}}
 {{- if and .Values.sandboxes.enabled .Values.sandboxes.juicefs.csi.install }}
 {{- $namespace := .Values.namespace | default .Release.Namespace }}
-{{- $mountImage := include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "juicefsMountImage") }}
+{{- $juicefsImage := include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "juicefsImage") }}
 {{- $controllerAnnotations := .Values.sandboxes.juicefs.csi.controller.annotations }}
 {{- $podAnnotations := mergeOverwrite (dict) (default dict .Values.commonPodAnnotations) $controllerAnnotations }}
 apiVersion: apps/v1
@@ -42,8 +42,8 @@ spec:
       {{- end }}
       containers:
         - name: juicefs-plugin
-          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "juicefsCSIImage") | quote }}
-          imagePullPolicy: {{ .Values.images.juicefsCSIImage.pullPolicy }}
+          image: {{ $juicefsImage | quote }}
+          imagePullPolicy: {{ .Values.images.juicefsImage.pullPolicy }}
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
@@ -72,7 +72,7 @@ spec:
             - name: JUICEFS_CONFIG_PATH
               value: /var/lib/juicefs/config
             - name: JUICEFS_CE_MOUNT_IMAGE
-              value: {{ $mountImage | quote }}
+              value: {{ $juicefsImage | quote }}
             - name: JUICEFS_CSI_WEB_PORT
               value: "9567"
             - name: DRIVER_NAME

--- a/charts/langsmith/templates/sandboxes/juicefs-csi-driver/csidriver.yaml
+++ b/charts/langsmith/templates/sandboxes/juicefs-csi-driver/csidriver.yaml
@@ -1,4 +1,4 @@
-{{- /* Vendored from the upstream juicefs-csi-driver chart; re-sync when bumping images.juicefsCSIImage. */}}
+{{- /* Vendored from the upstream juicefs-csi-driver chart; re-sync when bumping images.juicefsImage. */}}
 {{- if and .Values.sandboxes.enabled .Values.sandboxes.juicefs.csi.install }}
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver

--- a/charts/langsmith/templates/sandboxes/juicefs-csi-driver/node-daemonset.yaml
+++ b/charts/langsmith/templates/sandboxes/juicefs-csi-driver/node-daemonset.yaml
@@ -142,6 +142,8 @@ spec:
         - name: node-driver-registrar
           image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "juicefsCSINodeDriverRegistrarImage") | quote }}
           imagePullPolicy: {{ .Values.images.juicefsCSINodeDriverRegistrarImage.pullPolicy }}
+          command:
+            - /csi-node-driver-registrar
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)

--- a/charts/langsmith/templates/sandboxes/juicefs-csi-driver/node-daemonset.yaml
+++ b/charts/langsmith/templates/sandboxes/juicefs-csi-driver/node-daemonset.yaml
@@ -1,7 +1,7 @@
-{{- /* Vendored from the upstream juicefs-csi-driver chart; re-sync when bumping images.juicefsCSIImage. */}}
+{{- /* Vendored from the upstream juicefs-csi-driver chart; re-sync when bumping images.juicefsImage. */}}
 {{- if and .Values.sandboxes.enabled .Values.sandboxes.juicefs.csi.install }}
 {{- $namespace := .Values.namespace | default .Release.Namespace }}
-{{- $mountImage := include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "juicefsMountImage") }}
+{{- $juicefsImage := include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "juicefsImage") }}
 {{- $nodeAnnotations := .Values.sandboxes.juicefs.csi.node.annotations }}
 {{- $podAnnotations := mergeOverwrite (dict) (default dict .Values.commonPodAnnotations) $nodeAnnotations }}
 apiVersion: apps/v1
@@ -43,8 +43,8 @@ spec:
       {{- end }}
       containers:
         - name: juicefs-plugin
-          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "juicefsCSIImage") | quote }}
-          imagePullPolicy: {{ .Values.images.juicefsCSIImage.pullPolicy }}
+          image: {{ $juicefsImage | quote }}
+          imagePullPolicy: {{ .Values.images.juicefsImage.pullPolicy }}
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
@@ -79,7 +79,7 @@ spec:
             - name: FS_SHARE_MOUNT
               value: "true"
             - name: JUICEFS_CE_MOUNT_IMAGE
-              value: {{ $mountImage | quote }}
+              value: {{ $juicefsImage | quote }}
             - name: JUICEFS_CSI_WEB_PORT
               value: "9567"
             - name: DRIVER_NAME
@@ -140,8 +140,8 @@ spec:
             - mountPath: /etc/config
               name: juicefs-config
         - name: node-driver-registrar
-          image: {{ include "langsmith.image" (dict "Values" .Values "Chart" .Chart "component" "juicefsCSINodeDriverRegistrarImage") | quote }}
-          imagePullPolicy: {{ .Values.images.juicefsCSINodeDriverRegistrarImage.pullPolicy }}
+          image: {{ $juicefsImage | quote }}
+          imagePullPolicy: {{ .Values.images.juicefsImage.pullPolicy }}
           command:
             - /csi-node-driver-registrar
           args:

--- a/charts/langsmith/templates/sandboxes/juicefs-csi-driver/rbac.yaml
+++ b/charts/langsmith/templates/sandboxes/juicefs-csi-driver/rbac.yaml
@@ -1,4 +1,4 @@
-{{- /* Vendored from the upstream juicefs-csi-driver chart; re-sync when bumping images.juicefsCSIImage. */}}
+{{- /* Vendored from the upstream juicefs-csi-driver chart; re-sync when bumping images.juicefsImage. */}}
 {{- if and .Values.sandboxes.enabled .Values.sandboxes.juicefs.csi.install }}
 {{- $namespace := .Values.namespace | default .Release.Namespace }}
 {{- $controllerServiceAccountAnnotations := mergeOverwrite (dict) (include "langsmith.sandboxes.juicefsCSIAnnotations" . | fromYaml) (default dict .Values.sandboxes.juicefs.csi.controller.serviceAccount.annotations) }}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -177,17 +177,11 @@ AWS Marketplace Helm template verification).
 {{- fail "images.sandboxHostImage.tag is required when sandboxes.enabled is true." -}}
 {{- end -}}
 {{- if .Values.sandboxes.juicefs.csi.install -}}
-{{- range $imageName := list "juicefsCSIImage" "juicefsCSINodeDriverRegistrarImage" -}}
-{{- $image := index $.Values.images $imageName -}}
-{{- if not $image.repository -}}
-{{- fail (printf "images.%s.repository is required when sandboxes.enabled is true." $imageName) -}}
+{{- if not .Values.images.juicefsImage.repository -}}
+{{- fail "images.juicefsImage.repository is required when sandboxes.enabled is true." -}}
 {{- end -}}
-{{- if not $image.tag -}}
-{{- fail (printf "images.%s.tag is required when sandboxes.enabled is true." $imageName) -}}
-{{- end -}}
-{{- end -}}
-{{- if and .Values.images.juicefsMountImage.tag (not .Values.images.juicefsMountImage.repository) -}}
-{{- fail "images.juicefsMountImage.repository is required when images.juicefsMountImage.tag is set." -}}
+{{- if not .Values.images.juicefsImage.tag -}}
+{{- fail "images.juicefsImage.tag is required when sandboxes.enabled is true." -}}
 {{- end -}}
 {{- end -}}
 {{- /* The host needs netns, iptables and mount propagation. Fail here, not at CrashLoop. */ -}}

--- a/charts/langsmith/tests/sandbox_juicefs_csi_driver_test.yaml
+++ b/charts/langsmith/tests/sandbox_juicefs_csi_driver_test.yaml
@@ -354,6 +354,10 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].image
           value: mirror.example.com/sig-storage/csi-node-driver-registrar:v2.9.0
+      - equal:
+          path: spec.template.spec.containers[1].command
+          value:
+            - /csi-node-driver-registrar
       - matchRegex:
           path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
           pattern: "--unix-socket /csi/csi\\.sock"

--- a/charts/langsmith/tests/sandbox_juicefs_csi_driver_test.yaml
+++ b/charts/langsmith/tests/sandbox_juicefs_csi_driver_test.yaml
@@ -307,19 +307,15 @@ tests:
           path: metadata.name
           value: csi.juicefs.com
 
-  - it: should render the JuiceFS CSI node daemonset with mirrored images
+  - it: should render every JuiceFS CSI node role with the mirrored image
     values:
       - ./values/sandboxes-enabled.yaml
     set:
       images.registry: mirror.example.com
       images.imagePullSecrets:
         - name: mirror-pull-secret
-      images.juicefsCSIImage.repository: juicedata/juicefs-csi-driver
-      images.juicefsCSIImage.tag: v0.31.4
-      images.juicefsCSINodeDriverRegistrarImage.repository: sig-storage/csi-node-driver-registrar
-      images.juicefsCSINodeDriverRegistrarImage.tag: v2.9.0
-      images.juicefsMountImage.repository: juicedata/mount
-      images.juicefsMountImage.tag: ce-v1.3.0
+      images.juicefsImage.repository: langchain/sandbox-juicefs
+      images.juicefsImage.tag: test-juicefs
     template: sandboxes/juicefs-csi-driver/node-daemonset.yaml
     asserts:
       - isKind:
@@ -339,7 +335,7 @@ tests:
             - name: mirror-pull-secret
       - equal:
           path: spec.template.spec.containers[0].image
-          value: mirror.example.com/juicedata/juicefs-csi-driver:v0.31.4
+          value: mirror.example.com/langchain/sandbox-juicefs:test-juicefs
       - matchRegex:
           path: spec.template.metadata.annotations["checksum/juicefs-csi-config"]
           pattern: "^[a-f0-9]{64}$"
@@ -350,10 +346,10 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: JUICEFS_CE_MOUNT_IMAGE
-            value: mirror.example.com/juicedata/mount:ce-v1.3.0
+            value: mirror.example.com/langchain/sandbox-juicefs:test-juicefs
       - equal:
           path: spec.template.spec.containers[1].image
-          value: mirror.example.com/sig-storage/csi-node-driver-registrar:v2.9.0
+          value: mirror.example.com/langchain/sandbox-juicefs:test-juicefs
       - equal:
           path: spec.template.spec.containers[1].command
           value:
@@ -367,13 +363,13 @@ tests:
       - notExists:
           path: spec.template.spec.containers[2]
 
-  - it: should render the JuiceFS CSI controller with mirrored images
+  - it: should render every JuiceFS CSI controller role with the mirrored image
     values:
       - ./values/sandboxes-enabled.yaml
     set:
       images.registry: mirror.example.com
-      images.juicefsCSIImage.repository: juicedata/juicefs-csi-driver
-      images.juicefsCSIImage.tag: v0.31.4
+      images.juicefsImage.repository: langchain/sandbox-juicefs
+      images.juicefsImage.tag: test-juicefs
     template: sandboxes/juicefs-csi-driver/controller-statefulset.yaml
     asserts:
       - isKind:
@@ -389,7 +385,12 @@ tests:
           value: juicefs-csi-driver
       - equal:
           path: spec.template.spec.containers[0].image
-          value: mirror.example.com/juicedata/juicefs-csi-driver:v0.31.4
+          value: mirror.example.com/langchain/sandbox-juicefs:test-juicefs
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: JUICEFS_CE_MOUNT_IMAGE
+            value: mirror.example.com/langchain/sandbox-juicefs:test-juicefs
       - matchRegex:
           path: spec.template.metadata.annotations["checksum/juicefs-csi-config"]
           pattern: "^[a-f0-9]{64}$"
@@ -411,15 +412,15 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --provisioner=true
 
-  - it: should fail when the JuiceFS CSI driver image tag is missing
+  - it: should fail when the unified JuiceFS image tag is missing
     values:
       - ./values/sandboxes-enabled.yaml
     set:
-      images.juicefsCSIImage.tag: ""
+      images.juicefsImage.tag: ""
     template: validate.yaml
     asserts:
       - failedTemplate:
-          errorMessage: "images.juicefsCSIImage.tag is required when sandboxes.enabled is true."
+          errorMessage: "images.juicefsImage.tag is required when sandboxes.enabled is true."
 
   - it: should render JuiceFS CSI node observability annotations
     values:

--- a/charts/langsmith/tests/sandboxes_test.yaml
+++ b/charts/langsmith/tests/sandboxes_test.yaml
@@ -247,6 +247,8 @@ tests:
       sandboxes.juicefs.bucket: https://langsmith-sandboxes-test.s3.us-west-2.amazonaws.com
       images.sandboxHostImage.repository: example.com/langsmith/sandbox-host
       images.sandboxHostImage.tag: test-sandbox-host
+      images.juicefsImage.repository: example.com/langsmith/sandbox-juicefs
+      images.juicefsImage.tag: test-sandbox-juicefs
       insights.encryptionKey: test-insights-encryption-key
       polly.encryptionKey: test-polly-encryption-key
     template: secrets.yaml
@@ -786,6 +788,8 @@ tests:
       sandboxes.juicefs.bucket: https://langsmith-sandboxes-test.s3.us-west-2.amazonaws.com
       images.sandboxHostImage.repository: example.com/langsmith/sandbox-host
       images.sandboxHostImage.tag: test-sandbox-host
+      images.juicefsImage.repository: example.com/langsmith/sandbox-juicefs
+      images.juicefsImage.tag: test-sandbox-juicefs
       insights.encryptionKey: test-insights-encryption-key
       polly.encryptionKey: test-polly-encryption-key
     template: validate.yaml

--- a/charts/langsmith/tests/values/sandboxes-enabled-no-scheduling.yaml
+++ b/charts/langsmith/tests/values/sandboxes-enabled-no-scheduling.yaml
@@ -8,6 +8,9 @@ images:
   sandboxHostImage:
     repository: example.com/langsmith/sandbox-host
     tag: test-sandbox-host
+  juicefsImage:
+    repository: example.com/langsmith/sandbox-juicefs
+    tag: test-sandbox-juicefs
 
 sandboxes:
   enabled: true

--- a/charts/langsmith/tests/values/sandboxes-enabled.yaml
+++ b/charts/langsmith/tests/values/sandboxes-enabled.yaml
@@ -8,6 +8,9 @@ images:
   sandboxHostImage:
     repository: example.com/langsmith/sandbox-host
     tag: test-sandbox-host
+  juicefsImage:
+    repository: example.com/langsmith/sandbox-juicefs
+    tag: test-sandbox-juicefs
 
 sandboxes:
   enabled: true

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -123,21 +123,11 @@ images:
     repository: "docker.io/langchain/sandbox-host"
     pullPolicy: IfNotPresent
     tag: ""
-  # -- JuiceFS CSI driver image. Only used when config.sandboxes.enabled is true.
-  juicefsCSIImage:
-    repository: "docker.io/juicedata/juicefs-csi-driver"
+  # -- Sandbox JuiceFS image containing the CSI driver, node-driver-registrar, and mount binaries. Only used when sandboxes.enabled is true.
+  juicefsImage:
+    repository: "docker.io/langchain/sandbox-juicefs"
     pullPolicy: IfNotPresent
-    tag: "v0.31.4"
-  # -- JuiceFS CSI node-driver-registrar sidecar image. Only used when config.sandboxes.enabled is true.
-  juicefsCSINodeDriverRegistrarImage:
-    repository: "registry.k8s.io/sig-storage/csi-node-driver-registrar"
-    pullPolicy: IfNotPresent
-    tag: "v2.9.0"
-  # -- Optional JuiceFS CE mount image used by runtime mount pods. Set this when mirroring images for restricted networks.
-  juicefsMountImage:
-    repository: "docker.io/juicedata/mount"
-    pullPolicy: IfNotPresent
-    tag: "ce-v1.3.0"
+    tag: ""
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Summary

- backport the unified sandbox JuiceFS image configuration from #904 to `v16-stable`
- use `images.juicefsImage` for the CSI driver, node-driver-registrar, and runtime mount pods
- include the unified image in sandbox image mirroring

## Testing

- `helm unittest charts/langsmith`
- `helm lint charts/langsmith` with sandbox-enabled values
- rendered the chart and validated it with kubeconform
- ran the image mirroring script with `--include-sandboxes --dry-run`