### PR TITLE
chore(langsmith): bump chart to 0.16.0-rc.28 / appVersion 0.16.32rc1

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.0-rc.27
-appVersion: "0.16.31rc1"
+version: 0.16.0-rc.28
+appVersion: "0.16.32rc1"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.16.0-rc.27](https://img.shields.io/badge/Version-0.16.0--rc.27-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.31rc1](https://img.shields.io/badge/AppVersion-0.16.31rc1-informational?style=flat-square)
+![Version: 0.16.0-rc.28](https://img.shields.io/badge/Version-0.16.0--rc.28-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.32rc1](https://img.shields.io/badge/AppVersion-0.16.32rc1-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -549,22 +549,22 @@ The chart-managed frontend owns public API route rewrites for LangSmith services
 | gateway.sectionName | string | `""` |  |
 | images.aceBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.aceBackendImage.repository | string | `"docker.io/langchain/langsmith-ace-backend"` |  |
-| images.aceBackendImage.tag | string | `"0.16.31rc1"` |  |
+| images.aceBackendImage.tag | string | `"0.16.32rc1"` |  |
 | images.agentBuilderImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.agentBuilderImage.repository | string | `"docker.io/langchain/agent-builder-deep-agent"` |  |
-| images.agentBuilderImage.tag | string | `"0.16.31rc1"` |  |
+| images.agentBuilderImage.tag | string | `"0.16.32rc1"` |  |
 | images.backendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.backendImage.repository | string | `"docker.io/langchain/langsmith-backend"` |  |
-| images.backendImage.tag | string | `"0.16.31rc1"` |  |
+| images.backendImage.tag | string | `"0.16.32rc1"` |  |
 | images.clickhouseImage.pullPolicy | string | `"Always"` |  |
 | images.clickhouseImage.repository | string | `"docker.io/clickhouse/clickhouse-server"` |  |
 | images.clickhouseImage.tag | string | `"25.12"` |  |
 | images.engineInsightsAgentImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.engineInsightsAgentImage.repository | string | `"docker.io/langchain/langsmith-clio"` |  |
-| images.engineInsightsAgentImage.tag | string | `"0.16.31rc1"` |  |
+| images.engineInsightsAgentImage.tag | string | `"0.16.32rc1"` |  |
 | images.frontendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.frontendImage.repository | string | `"docker.io/langchain/langsmith-frontend"` |  |
-| images.frontendImage.tag | string | `"0.16.31rc1"` |  |
+| images.frontendImage.tag | string | `"0.16.32rc1"` |  |
 | images.imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Specified as name: value. |
 | images.juicefsCSIImage | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/juicedata/juicefs-csi-driver","tag":"v0.31.4"}` | JuiceFS CSI driver image. Only used when config.sandboxes.enabled is true. |
 | images.juicefsCSINodeDriverRegistrarImage | object | `{"pullPolicy":"IfNotPresent","repository":"registry.k8s.io/sig-storage/csi-node-driver-registrar","tag":"v2.9.0"}` | JuiceFS CSI node-driver-registrar sidecar image. Only used when config.sandboxes.enabled is true. |
@@ -574,7 +574,7 @@ The chart-managed frontend owns public API route rewrites for LangSmith services
 | images.operatorImage.tag | string | `"0.1.47"` |  |
 | images.pollyAgentImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.pollyAgentImage.repository | string | `"docker.io/langchain/langsmith-polly"` |  |
-| images.pollyAgentImage.tag | string | `"0.16.31rc1"` |  |
+| images.pollyAgentImage.tag | string | `"0.16.32rc1"` |  |
 | images.postgresImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.postgresImage.repository | string | `"docker.io/postgres"` |  |
 | images.postgresImage.tag | string | `"14.7"` |  |
@@ -588,7 +588,7 @@ The chart-managed frontend owns public API route rewrites for LangSmith services
 | images.sandboxHostImage | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/langchain/sandbox-host","tag":""}` | sandbox-host image. Only used when config.sandboxes.enabled is true. |
 | images.smithdbImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.smithdbImage.repository | string | `"docker.io/langchain/smithdb"` |  |
-| images.smithdbImage.tag | string | `"0.16.31rc1"` |  |
+| images.smithdbImage.tag | string | `"0.16.32rc1"` |  |
 | ingestQueue.autoscaling.hpa.enabled | bool | `false` |  |
 | ingestQueue.autoscaling.hpa.maxReplicas | int | `10` |  |
 | ingestQueue.autoscaling.hpa.minReplicas | int | `3` |  |

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -65,22 +65,22 @@ images:
   aceBackendImage:
     repository: "docker.io/langchain/langsmith-ace-backend"
     pullPolicy: IfNotPresent
-    tag: "0.16.31rc1"
+    tag: "0.16.32rc1"
   backendImage:
     repository: "docker.io/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
-    tag: "0.16.31rc1"
+    tag: "0.16.32rc1"
   # Image for the shared Engine/Insights agent deployment. When engine.enabled
   # is true this must point at the combined insights-engine image, which serves
   # both the `insights` and `engine` graphs.
   engineInsightsAgentImage:
     repository: "docker.io/langchain/langsmith-clio"
     pullPolicy: IfNotPresent
-    tag: "0.16.31rc1"
+    tag: "0.16.32rc1"
   frontendImage:
     repository: "docker.io/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
-    tag: "0.16.31rc1"
+    tag: "0.16.32rc1"
   operatorImage:
     repository: "docker.io/langchain/langgraph-operator"
     pullPolicy: IfNotPresent
@@ -104,15 +104,15 @@ images:
   agentBuilderImage:
     repository: "docker.io/langchain/agent-builder-deep-agent"
     pullPolicy: IfNotPresent
-    tag: "0.16.31rc1"
+    tag: "0.16.32rc1"
   pollyAgentImage:
     repository: "docker.io/langchain/langsmith-polly"
     pullPolicy: IfNotPresent
-    tag: "0.16.31rc1"
+    tag: "0.16.32rc1"
   smithdbImage:
     repository: "docker.io/langchain/smithdb"
     pullPolicy: IfNotPresent
-    tag: "0.16.31rc1"
+    tag: "0.16.32rc1"
   # Optional: only mirror/pull when presidioAnalyzer.enabled is true
   presidioAnalyzerImage:
     repository: "mcr.microsoft.com/presidio-analyzer"


### PR DESCRIPTION
Chart bump for the `v16-stable` train: `0.16.0-rc.27` → `0.16.0-rc.28`, appVersion `0.16.31rc1` → `0.16.32rc1`.

**Do not merge until the images exist.** Paired with langchain-ai/langchainplus#32879, which publishes `0.16.32rc1`. Merging this first would point customers at tags that do not resolve.

## What it delivers

The backend bump releases 13 commits sitting unreleased on `v16-stable`, nine of them Engine / issues-API backports — the dedup gate keyed on root cause (#32738), the board fetch carrying category + description (#32739), the reconciled dedup block (#32594), the `issues update` flag reference (#32597), the five-status spec + error message (#32735, #32736), the sandbox endpoint derivation (#32737), and the public API base resolver (#32740).

## Changes

- `Chart.yaml`: `version` → `0.16.0-rc.28`, `appVersion` → `0.16.32rc1`
- `values.yaml`: the 7 app image tags pinned to the app version (ace-backend, backend, engineInsightsAgent, frontend, agentBuilder, polly, smithdb)
- `README.md`: regenerated by `helm-docs`

## How the Engine changes actually reach a deployment

Worth recording, because it is not obvious from this diff. `images.engineInsightsAgentImage` defaults to `langsmith-clio`, which serves only the insights graph. Deployments that run Engine override the *repository* to `langsmith-insights-engine` (the combined image) while inheriting the *tag* from this chart — so this tag bump is what carries the Engine prompt changes to them. #900 added that image to `mirror_langsmith_images.sh` so the per-version tag exists to be pulled.

## Test Plan

- [x] `helm lint charts/langsmith`: **1 chart linted, 0 failed** (the `polly.encryptionKey is required` message is the expected required-value output when linting without values; `icon is recommended` is INFO)
- [x] `helm-docs` regenerated `charts/langsmith/README.md`; diff is version badges and the 7 tag rows, nothing else
- [x] **Reverted unrelated README drift.** `helm-docs` also rewrote `langgraph-cloud`, `langgraph-dataplane`, `langsmith-auth-proxy`, and `mission-control` READMEs — pre-existing drift on this branch, not from this change, so those are excluded rather than swept in
- [x] Confirmed only the `0.16.31rc1` pins moved: the third-party pins (postgres `14.7`, redis `7`, clickhouse `25.12`, presidio `2.2.354`, operator `0.1.47`) and the deliberately-pinned `sandboxHostImage` are untouched
- [ ] Not verified: that `0.16.32rc1` images are published — they are not yet. That is the gate on merging this