### PR TITLE
chore: enable LLM gateway feature via env var when agent-gateway deployment is enabled

### DIFF
--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -133,6 +133,7 @@ data:
   {{- end }}
   {{- if .Values.agentGateway.enabled }}
   AGENT_GATEWAY_URL: "http://{{ include "langsmith.fullname" . }}-{{ .Values.agentGateway.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.agentGateway.service.port }}"
+  DEFAULT_ORG_FEATURE_LLM_GATEWAY_ENABLED: "true"
   {{- end }}
   # Usage backfill export gating
   {{- if .Values.config.superAdmins }}

--- a/charts/langsmith/tests/agent_gateway_test.yaml
+++ b/charts/langsmith/tests/agent_gateway_test.yaml
@@ -1,0 +1,19 @@
+suite: agent gateway shared configuration
+set:
+  config.existingSecretName: langsmith-secrets
+  config.skipValidation: true
+tests:
+  - it: enables the LLM gateway feature when the agent gateway is enabled
+    template: templates/config-map.yaml
+    set:
+      agentGateway.enabled: true
+    asserts:
+      - equal:
+          path: data.DEFAULT_ORG_FEATURE_LLM_GATEWAY_ENABLED
+          value: "true"
+
+  - it: leaves the LLM gateway feature disabled when the agent gateway is disabled
+    template: templates/config-map.yaml
+    asserts:
+      - notExists:
+          path: data.DEFAULT_ORG_FEATURE_LLM_GATEWAY_ENABLED


### PR DESCRIPTION
## Description
Enable the default organization LLM gateway feature whenever the LangSmith agent gateway is enabled. The shared ConfigMap now supplies the flag to all consuming workloads while leaving the application default unchanged when the gateway is disabled.

## Test Plan
- [x] Assert the shared ConfigMap includes the flag when `agentGateway.enabled=true`
- [x] Assert the flag is absent when the agent gateway is disabled

Made by [Open SWE](https://openswe.vercel.app/agents/2a481a3f-9a85-93e0-95a7-023139172cae)