### PR TITLE
chore(langsmith): default to the combined insights-engine image

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -560,7 +560,7 @@ The chart-managed frontend owns public API route rewrites for LangSmith services
 | images.clickhouseImage.repository | string | `"docker.io/clickhouse/clickhouse-server"` |  |
 | images.clickhouseImage.tag | string | `"25.12"` |  |
 | images.engineInsightsAgentImage.pullPolicy | string | `"IfNotPresent"` |  |
-| images.engineInsightsAgentImage.repository | string | `"docker.io/langchain/langsmith-clio"` |  |
+| images.engineInsightsAgentImage.repository | string | `"docker.io/langchain/langsmith-insights-engine"` |  |
 | images.engineInsightsAgentImage.tag | string | `"0.16.32rc1"` |  |
 | images.frontendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.frontendImage.repository | string | `"docker.io/langchain/langsmith-frontend"` |  |

--- a/charts/langsmith/templates/backend/deployment.yaml
+++ b/charts/langsmith/templates/backend/deployment.yaml
@@ -12,9 +12,6 @@
 {{- if .Values.insights.enabled }}
 - name: CLIO_LANGGRAPH_URL
   value: "http://{{ include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "engineInsightsAgent") }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.engineInsightsAgent.apiServer.service.httpPort }}"
-{{- /* Follows the image, not engine.enabled: the combined image names its
-       graphs `insights` and `engine`, and lc_config still defaults to the
-       `agent` graph that only the retired clio image had. */}}
 - name: CLIO_ASSISTANT_ID
   value: "insights"
 {{- end }}

--- a/charts/langsmith/templates/backend/deployment.yaml
+++ b/charts/langsmith/templates/backend/deployment.yaml
@@ -12,10 +12,11 @@
 {{- if .Values.insights.enabled }}
 - name: CLIO_LANGGRAPH_URL
   value: "http://{{ include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "engineInsightsAgent") }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.engineInsightsAgent.apiServer.service.httpPort }}"
-{{- if .Values.engine.enabled }}
+{{- /* Follows the image, not engine.enabled: the combined image names its
+       graphs `insights` and `engine`, and lc_config still defaults to the
+       `agent` graph that only the retired clio image had. */}}
 - name: CLIO_ASSISTANT_ID
   value: "insights"
-{{- end }}
 {{- end }}
 {{- end -}}
 {{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "backendEnvVars" . | fromYamlArray) .Values.backend.deployment.extraEnv -}}

--- a/charts/langsmith/templates/queue/deployment.yaml
+++ b/charts/langsmith/templates/queue/deployment.yaml
@@ -8,10 +8,11 @@
 {{- if .Values.insights.enabled }}
 - name: CLIO_LANGGRAPH_URL
   value: "http://{{ include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "engineInsightsAgent") }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.engineInsightsAgent.apiServer.service.httpPort }}"
-{{- if .Values.engine.enabled }}
+{{- /* Follows the image, not engine.enabled: the combined image names its
+       graphs `insights` and `engine`, and lc_config still defaults to the
+       `agent` graph that only the retired clio image had. */}}
 - name: CLIO_ASSISTANT_ID
   value: "insights"
-{{- end }}
 {{- end }}
 {{- end -}}
 {{- $envVars := concat .Values.commonEnv (include "langsmith.commonEnv" . | fromYamlArray) (include "queueEnvVars" . | fromYamlArray) .Values.queue.deployment.extraEnv -}}

--- a/charts/langsmith/templates/queue/deployment.yaml
+++ b/charts/langsmith/templates/queue/deployment.yaml
@@ -8,9 +8,6 @@
 {{- if .Values.insights.enabled }}
 - name: CLIO_LANGGRAPH_URL
   value: "http://{{ include "langsmith.agentFeatures.apiServerK8sServiceName" (dict "root" . "product" "engineInsightsAgent") }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.engineInsightsAgent.apiServer.service.httpPort }}"
-{{- /* Follows the image, not engine.enabled: the combined image names its
-       graphs `insights` and `engine`, and lc_config still defaults to the
-       `agent` graph that only the retired clio image had. */}}
 - name: CLIO_ASSISTANT_ID
   value: "insights"
 {{- end }}

--- a/charts/langsmith/tests/engine_insights_agent_image_test.yaml
+++ b/charts/langsmith/tests/engine_insights_agent_image_test.yaml
@@ -5,14 +5,29 @@ suite: engine/insights shared deployment image
 templates:
   - templates/agent-features/insights/api-server/deployment.yaml
   - templates/agent-features/insights/queue/deployment.yaml
+  - templates/backend/deployment.yaml
+  - templates/queue/deployment.yaml
+  # Pulled in by langsmith.checksumAnnotations on the backend and queue.
+  - templates/config-map.yaml
+  - templates/frontend/config-map.yaml
+  - templates/secrets.yaml
+  - templates/redis/secrets.yaml
+  - templates/postgres/secrets.yaml
+  - templates/clickhouse/secrets.yaml
 tests:
   - it: should default to the combined image with insights alone
+    templates:
+      - templates/agent-features/insights/api-server/deployment.yaml
+      - templates/agent-features/insights/queue/deployment.yaml
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
           pattern: langsmith-insights-engine
 
   - it: should need no image change to enable Engine
+    templates:
+      - templates/agent-features/insights/api-server/deployment.yaml
+      - templates/agent-features/insights/queue/deployment.yaml
     values:
       - ./values/sandboxes-enabled.yaml
     set:
@@ -24,3 +39,47 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].image
           pattern: langsmith-insights-engine
+
+  # The combined image has no `agent` graph, so its consumers must name
+  # `insights` whether or not Engine is enabled.
+  - it: should name the insights graph with engine disabled
+    templates:
+      - templates/backend/deployment.yaml
+      - templates/queue/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLIO_ASSISTANT_ID
+            value: "insights"
+
+  - it: should name the insights graph with engine enabled
+    templates:
+      - templates/backend/deployment.yaml
+      - templates/queue/deployment.yaml
+    values:
+      - ./values/sandboxes-enabled.yaml
+    set:
+      engine.enabled: true
+      engine.encryptionKey: test-key
+      engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
+      config.hostname: https://langsmith.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLIO_ASSISTANT_ID
+            value: "insights"
+
+  - it: should not name a graph when insights is disabled
+    templates:
+      - templates/backend/deployment.yaml
+      - templates/queue/deployment.yaml
+    set:
+      insights.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLIO_ASSISTANT_ID
+            value: "insights"

--- a/charts/langsmith/tests/engine_insights_agent_image_test.yaml
+++ b/charts/langsmith/tests/engine_insights_agent_image_test.yaml
@@ -1,0 +1,26 @@
+suite: engine/insights shared deployment image
+# One image serves both graphs, so enabling Engine is engine.enabled alone —
+# no accompanying image change, which is what the validate.yaml guard exists
+# to catch for installs that pinned the insights-only image in their values.
+templates:
+  - templates/agent-features/insights/api-server/deployment.yaml
+  - templates/agent-features/insights/queue/deployment.yaml
+tests:
+  - it: should default to the combined image with insights alone
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: langsmith-insights-engine
+
+  - it: should need no image change to enable Engine
+    values:
+      - ./values/sandboxes-enabled.yaml
+    set:
+      engine.enabled: true
+      engine.encryptionKey: test-key
+      engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
+      config.hostname: https://langsmith.example.com
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: langsmith-insights-engine

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -70,11 +70,11 @@ images:
     repository: "docker.io/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
     tag: "0.16.32rc1"
-  # Image for the shared Engine/Insights agent deployment. When engine.enabled
-  # is true this must point at the combined insights-engine image, which serves
-  # both the `insights` and `engine` graphs.
+  # Image for the shared Engine/Insights agent deployment. Serves both the
+  # `insights` and `engine` graphs; which of them run is set by insights.enabled
+  # and engine.enabled.
   engineInsightsAgentImage:
-    repository: "docker.io/langchain/langsmith-clio"
+    repository: "docker.io/langchain/langsmith-insights-engine"
     pullPolicy: IfNotPresent
     tag: "0.16.32rc1"
   frontendImage:


### PR DESCRIPTION
Enabling Engine currently takes two settings that have to agree:

```yaml
engine:
  enabled: true
images:
  engineInsightsAgentImage:
    repository: docker.io/langchain/langsmith-insights-engine   # or the render fails
```

because the default served only the `insights` graph. Those two disagreeing is what surfaced as a chart demanding an image customers had no way to pull.

## Change

Default `images.engineInsightsAgentImage.repository` to `langsmith-insights-engine`. `engine.enabled` is now sufficient on its own.

**The combined image is no larger:**

```
langsmith-clio              amd64 compressed:  397.0 MB   (amd64, arm64)
langsmith-insights-engine   amd64 compressed:  392.2 MB   (amd64, arm64)
```

5 MB smaller, same architectures — so insights-only installs pay nothing for a default that also carries the engine graph. Which of the two graphs actually runs is still `insights.enabled` / `engine.enabled`; the image only decides which are available.

## The validate guard stays

I had expected to delete it as unreachable. It isn't: an install that pinned `langsmith-clio` in its **own** values keeps that pin across the upgrade, and if it then enables Engine the guard is exactly what explains why. It only stops firing for installs that never overrode the default.

## Upgrade impact

Insights-only installs move to a different image on their next chart upgrade — same size, same graphs served, but a pod roll and a new image name in their registry. Anyone mirroring needs `langsmith-insights-engine` present first: that is #900 (merged) plus the Docker Hub repository now being public, so the prerequisites are in place.

## Test plan

- [x] New `engine_insights_agent_image_test.yaml`: the default is the combined image with insights alone, and enabling Engine needs no image change
- [x] Full chart suite: 291 passed (22 suites)
- [x] `helm lint` clean
- [x] `helm template` with `engine.enabled=true` and **no image override** now renders — that combination failed before
- [x] README regenerated with helm-docs v1.14.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)