### PR TITLE
chore(langsmith): bump chart to 0.16.0-rc.30

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.0-rc.29
+version: 0.16.0-rc.30
 appVersion: "0.16.33rc1"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.16.0-rc.29](https://img.shields.io/badge/Version-0.16.0--rc.29-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.33rc1](https://img.shields.io/badge/AppVersion-0.16.33rc1-informational?style=flat-square)
+![Version: 0.16.0-rc.30](https://img.shields.io/badge/Version-0.16.0--rc.30-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.33rc1](https://img.shields.io/badge/AppVersion-0.16.33rc1-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 


### PR DESCRIPTION
Releases #910 (drop the `langsmith-clio` image), which landed just after the `rc.29` bump in #911 and so isn't in any published chart.

Chart-only change — no new images — so `appVersion` stays `0.16.33rc1` and the `values.yaml` image tags are untouched. Only `version` moves and the README version badge regenerates.

Verified `docker.io/langchain/langsmith-insights-engine:0.16.33rc1` exists on Docker Hub, so the mirror list #910 ships resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)