### PR TITLE
chore(langsmith): cut chart 0.16.0 GA

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
 version: 0.16.0
-appVersion: "0.16.33"
+appVersion: "0.16.34"

--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.0-rc.29
-appVersion: "0.16.33rc1"
+version: 0.16.0
+appVersion: "0.16.33"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.33](https://img.shields.io/badge/AppVersion-0.16.33-informational?style=flat-square)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.34](https://img.shields.io/badge/AppVersion-0.16.34-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -567,22 +567,22 @@ Two things worth planning for before you enable it:
 | gateway.sectionName | string | `""` |  |
 | images.aceBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.aceBackendImage.repository | string | `"docker.io/langchain/langsmith-ace-backend"` |  |
-| images.aceBackendImage.tag | string | `"0.16.33rc1"` |  |
+| images.aceBackendImage.tag | string | `"0.16.34"` |  |
 | images.agentBuilderImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.agentBuilderImage.repository | string | `"docker.io/langchain/agent-builder-deep-agent"` |  |
-| images.agentBuilderImage.tag | string | `"0.16.33rc1"` |  |
+| images.agentBuilderImage.tag | string | `"0.16.34"` |  |
 | images.backendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.backendImage.repository | string | `"docker.io/langchain/langsmith-backend"` |  |
-| images.backendImage.tag | string | `"0.16.33rc1"` |  |
+| images.backendImage.tag | string | `"0.16.34"` |  |
 | images.clickhouseImage.pullPolicy | string | `"Always"` |  |
 | images.clickhouseImage.repository | string | `"docker.io/clickhouse/clickhouse-server"` |  |
 | images.clickhouseImage.tag | string | `"25.12"` |  |
 | images.engineInsightsAgentImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.engineInsightsAgentImage.repository | string | `"docker.io/langchain/langsmith-insights-engine"` |  |
-| images.engineInsightsAgentImage.tag | string | `"0.16.33rc1"` |  |
+| images.engineInsightsAgentImage.tag | string | `"0.16.34"` |  |
 | images.frontendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.frontendImage.repository | string | `"docker.io/langchain/langsmith-frontend"` |  |
-| images.frontendImage.tag | string | `"0.16.33rc1"` |  |
+| images.frontendImage.tag | string | `"0.16.34"` |  |
 | images.imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Specified as name: value. |
 | images.juicefsCSIImage | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/juicedata/juicefs-csi-driver","tag":"v0.31.4"}` | JuiceFS CSI driver image. Only used when config.sandboxes.enabled is true. |
 | images.juicefsCSINodeDriverRegistrarImage | object | `{"pullPolicy":"IfNotPresent","repository":"registry.k8s.io/sig-storage/csi-node-driver-registrar","tag":"v2.9.0"}` | JuiceFS CSI node-driver-registrar sidecar image. Only used when config.sandboxes.enabled is true. |
@@ -592,7 +592,7 @@ Two things worth planning for before you enable it:
 | images.operatorImage.tag | string | `"0.1.47"` |  |
 | images.pollyAgentImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.pollyAgentImage.repository | string | `"docker.io/langchain/langsmith-polly"` |  |
-| images.pollyAgentImage.tag | string | `"0.16.33rc1"` |  |
+| images.pollyAgentImage.tag | string | `"0.16.34"` |  |
 | images.postgresImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.postgresImage.repository | string | `"docker.io/postgres"` |  |
 | images.postgresImage.tag | string | `"14.7"` |  |
@@ -606,7 +606,7 @@ Two things worth planning for before you enable it:
 | images.sandboxHostImage | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/langchain/sandbox-host","tag":""}` | sandbox-host image. Only used when config.sandboxes.enabled is true. |
 | images.smithdbImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.smithdbImage.repository | string | `"docker.io/langchain/smithdb"` |  |
-| images.smithdbImage.tag | string | `"0.16.33rc1"` |  |
+| images.smithdbImage.tag | string | `"0.16.34"` |  |
 | ingestQueue.autoscaling.hpa.enabled | bool | `false` |  |
 | ingestQueue.autoscaling.hpa.maxReplicas | int | `10` |  |
 | ingestQueue.autoscaling.hpa.minReplicas | int | `3` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.16.0-rc.29](https://img.shields.io/badge/Version-0.16.0--rc.29-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.33rc1](https://img.shields.io/badge/AppVersion-0.16.33rc1-informational?style=flat-square)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.33](https://img.shields.io/badge/AppVersion-0.16.33-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -65,22 +65,22 @@ images:
   aceBackendImage:
     repository: "docker.io/langchain/langsmith-ace-backend"
     pullPolicy: IfNotPresent
-    tag: "0.16.33rc1"
+    tag: "0.16.34"
   backendImage:
     repository: "docker.io/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
-    tag: "0.16.33rc1"
+    tag: "0.16.34"
   # Image for the shared Engine/Insights agent deployment. Serves both the
   # `insights` and `engine` graphs; which of them run is set by insights.enabled
   # and engine.enabled.
   engineInsightsAgentImage:
     repository: "docker.io/langchain/langsmith-insights-engine"
     pullPolicy: IfNotPresent
-    tag: "0.16.33rc1"
+    tag: "0.16.34"
   frontendImage:
     repository: "docker.io/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
-    tag: "0.16.33rc1"
+    tag: "0.16.34"
   operatorImage:
     repository: "docker.io/langchain/langgraph-operator"
     pullPolicy: IfNotPresent
@@ -104,15 +104,15 @@ images:
   agentBuilderImage:
     repository: "docker.io/langchain/agent-builder-deep-agent"
     pullPolicy: IfNotPresent
-    tag: "0.16.33rc1"
+    tag: "0.16.34"
   pollyAgentImage:
     repository: "docker.io/langchain/langsmith-polly"
     pullPolicy: IfNotPresent
-    tag: "0.16.33rc1"
+    tag: "0.16.34"
   smithdbImage:
     repository: "docker.io/langchain/smithdb"
     pullPolicy: IfNotPresent
-    tag: "0.16.33rc1"
+    tag: "0.16.34"
   # Optional: only mirror/pull when presidioAnalyzer.enabled is true
   presidioAnalyzerImage:
     repository: "mcr.microsoft.com/presidio-analyzer"


### PR DESCRIPTION
First GA cut of the v16 train: drops the release-candidate suffix from the chart version and points the chart at the first GA application release on `v16-stable`.

| | before | after |
|---|---|---|
| `version` | `0.16.0-rc.29` | `0.16.0` |
| `appVersion` | `0.16.33rc1` | `0.16.34` |

`0.16.0-rc.29` sorts below `0.16.0` under semver, so this is a genuine version bump as well as a suffix drop.

## Why appVersion is 0.16.34, not 0.16.33

`0.16.33` only ever shipped as a release candidate. The first bare `x.y.z` self-hosted release on the v16 line is `0.16.34` (langchain-ai/langchainplus release `0.16.34`), and it is the only non-rc `0.16.x` tag that exists:

```
langchain/langsmith-backend:0.16.33      -> 404
langchain/langsmith-backend:0.16.33rc1   -> 200
langchain/langsmith-backend:0.16.34      -> 200
```

All 22 images in the self-hosted publish matrix are live on DockerHub and ACR at `0.16.34`.

## values.yaml image tags

The seven langsmith image tags in `values.yaml` are bumped from `0.16.33rc1` to `0.16.34` alongside the appVersion. `Chart.yaml` and `values.yaml` have to move together — a GA chart that still pins `rcN` tags would deploy RC images while advertising a GA appVersion. This mirrors `v15-stable`, where every langsmith tag equals the appVersion (`0.15.24`), and the langchainplus bump automation, which rewrites both files in one commit.

Images left with an empty `tag` (e.g. `sandboxHostImage`) fall back to `.Chart.AppVersion` through the `langsmith.image` helper, so they resolve to `0.16.34` too — `langchain/sandbox-host:0.16.34` is published.

This is a manual version edit: the unified bump automation (langchain-ai/langchainplus#31277) is still open, and `create-helm-pr` in the self-hosted release workflow is gated to RC releases on the default branch, so it does not fire for a stable GA.

## Test Plan

- [x] `helm unittest charts/langsmith` — 297 tests / 22 suites pass
- [x] `helm lint charts/langsmith` — clean
- [x] `helm template` renders; every `langchain/*` image resolves to `:0.16.34`
- [x] Verified each referenced image tag exists on DockerHub at `0.16.34`
- [x] `helm-docs --chart-search-root=charts/langsmith` regenerated (badge + 7 values rows)
- [ ] Confirm the published chart index picks up `0.16.0` after merge
