### PR TITLE
fix(engine): opt orgs out of Engine when Engine is not deployed

### DIFF
--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -45,6 +45,10 @@ data:
   {{- if .Values.engine.enabled }}
   SMITH_INTELLIGENCE_ENDPOINT: {{ .Values.engine.intelligenceBaseUrl | trimSuffix "/" | trimSuffix "/intelligence" | quote }}
   FORGE_AGENT_LANGGRAPH_URL: "http://{{ include "langsmith.agentFeatures.fullname" (dict "root" . "product" "engineInsightsAgent") }}-{{ .Values.engineInsightsAgent.apiServer.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.engineInsightsAgent.apiServer.service.httpPort }}"
+  {{- else }}
+  {{- /* Org-level Engine enrollment defaults on for a self-hosted plan tier, so
+         without this the UI offers Engine on installs that never deployed it. */}}
+  DEFAULT_ORG_FEATURE_ENGINE_DEFAULT_ENABLED: "false"
   {{- end }}
   GO_ACE_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.aceBackend.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.aceBackend.service.port }}"
   PLAYGROUND_ENDPOINT: "http://{{ include "langsmith.fullname" . }}-{{.Values.playground.name}}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.playground.service.port }}"

--- a/charts/langsmith/tests/platform_endpoint_test.yaml
+++ b/charts/langsmith/tests/platform_endpoint_test.yaml
@@ -61,3 +61,19 @@ tests:
     asserts:
       - notExists:
           path: data.SMITH_INTELLIGENCE_ENDPOINT
+
+  # Org-level Engine enrollment defaults on for the self-hosted plan tier, so an
+  # install that never deployed Engine must be opted out explicitly.
+  - it: should disable Engine enrollment by default when Engine is off
+    asserts:
+      - equal:
+          path: data.DEFAULT_ORG_FEATURE_ENGINE_DEFAULT_ENABLED
+          value: "false"
+
+  - it: should leave Engine enrollment alone when Engine is on
+    set:
+      engine.enabled: true
+      engine.intelligenceBaseUrl: https://beacon.aws.langchain.com/intelligence
+    asserts:
+      - notExists:
+          path: data.DEFAULT_ORG_FEATURE_ENGINE_DEFAULT_ENABLED


### PR DESCRIPTION
An install that never deployed Engine still offers it in the UI.

Org-level enrollment falls back to plan eligibility when `engine_enabled` is unset:

```go
if engineEnabled != nil { return *engineEnabled }
return planEligible
```

Self-hosted reports `enterprise_legacy`, which is eligible, so Engine resolves **on** by default. `useEngineEnabledResult` mirrors the same fallback, so the project Issues tab renders and smith-go agrees the org is enrolled — nothing fails until a scan actually runs and finds no Engine deployment behind it.

Setting `DEFAULT_ORG_FEATURE_ENGINE_DEFAULT_ENABLED: "false"` when `engine.enabled` is false flips the existing kill-switch, which is the *first* branch of both `useEngineEnabledResult` and `resolveEngineEnabled`. Backend and frontend go quiet together, with no new concept and no risk of the two drifting.

When `engine.enabled` is true the variable is not set at all, leaving the existing resolution untouched.

### Verification

- 299 chart tests pass across 22 suites (297 + 2 new pinning both directions); `helm lint` clean.
- `helm template` with Engine off renders `DEFAULT_ORG_FEATURE_ENGINE_DEFAULT_ENABLED: "false"`; with Engine on it is absent.

### Follow-up

This does not cover the Settings → Engine nav link, which gates only on `organization:manage` and never consults `useEngineEnabledResult`. With this change the page renders its entitlement banner with locked controls, but the copy is written for a LangChain plan entitlement and reads oddly on a self-hosted install that simply did not deploy Engine. That is frontend work, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)