### PR TITLE
chore(langsmith): bump chart to 0.16.0-rc.30 / appVersion 0.16.34

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.0-rc.29
-appVersion: "0.16.33rc1"
+version: 0.16.0-rc.30
+appVersion: "0.16.34"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.16.0-rc.29](https://img.shields.io/badge/Version-0.16.0--rc.29-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.33rc1](https://img.shields.io/badge/AppVersion-0.16.33rc1-informational?style=flat-square)
+![Version: 0.16.0-rc.30](https://img.shields.io/badge/Version-0.16.0--rc.30-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.34](https://img.shields.io/badge/AppVersion-0.16.34-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -567,22 +567,22 @@ Two things worth planning for before you enable it:
 | gateway.sectionName | string | `""` |  |
 | images.aceBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.aceBackendImage.repository | string | `"docker.io/langchain/langsmith-ace-backend"` |  |
-| images.aceBackendImage.tag | string | `"0.16.33rc1"` |  |
+| images.aceBackendImage.tag | string | `"0.16.34"` |  |
 | images.agentBuilderImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.agentBuilderImage.repository | string | `"docker.io/langchain/agent-builder-deep-agent"` |  |
-| images.agentBuilderImage.tag | string | `"0.16.33rc1"` |  |
+| images.agentBuilderImage.tag | string | `"0.16.34"` |  |
 | images.backendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.backendImage.repository | string | `"docker.io/langchain/langsmith-backend"` |  |
-| images.backendImage.tag | string | `"0.16.33rc1"` |  |
+| images.backendImage.tag | string | `"0.16.34"` |  |
 | images.clickhouseImage.pullPolicy | string | `"Always"` |  |
 | images.clickhouseImage.repository | string | `"docker.io/clickhouse/clickhouse-server"` |  |
 | images.clickhouseImage.tag | string | `"25.12"` |  |
 | images.engineInsightsAgentImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.engineInsightsAgentImage.repository | string | `"docker.io/langchain/langsmith-insights-engine"` |  |
-| images.engineInsightsAgentImage.tag | string | `"0.16.33rc1"` |  |
+| images.engineInsightsAgentImage.tag | string | `"0.16.34"` |  |
 | images.frontendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.frontendImage.repository | string | `"docker.io/langchain/langsmith-frontend"` |  |
-| images.frontendImage.tag | string | `"0.16.33rc1"` |  |
+| images.frontendImage.tag | string | `"0.16.34"` |  |
 | images.imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Specified as name: value. |
 | images.juicefsCSIImage | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/juicedata/juicefs-csi-driver","tag":"v0.31.4"}` | JuiceFS CSI driver image. Only used when config.sandboxes.enabled is true. |
 | images.juicefsCSINodeDriverRegistrarImage | object | `{"pullPolicy":"IfNotPresent","repository":"registry.k8s.io/sig-storage/csi-node-driver-registrar","tag":"v2.9.0"}` | JuiceFS CSI node-driver-registrar sidecar image. Only used when config.sandboxes.enabled is true. |
@@ -592,7 +592,7 @@ Two things worth planning for before you enable it:
 | images.operatorImage.tag | string | `"0.1.47"` |  |
 | images.pollyAgentImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.pollyAgentImage.repository | string | `"docker.io/langchain/langsmith-polly"` |  |
-| images.pollyAgentImage.tag | string | `"0.16.33rc1"` |  |
+| images.pollyAgentImage.tag | string | `"0.16.34"` |  |
 | images.postgresImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.postgresImage.repository | string | `"docker.io/postgres"` |  |
 | images.postgresImage.tag | string | `"14.7"` |  |
@@ -606,7 +606,7 @@ Two things worth planning for before you enable it:
 | images.sandboxHostImage | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/langchain/sandbox-host","tag":""}` | sandbox-host image. Only used when config.sandboxes.enabled is true. |
 | images.smithdbImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.smithdbImage.repository | string | `"docker.io/langchain/smithdb"` |  |
-| images.smithdbImage.tag | string | `"0.16.33rc1"` |  |
+| images.smithdbImage.tag | string | `"0.16.34"` |  |
 | ingestQueue.autoscaling.hpa.enabled | bool | `false` |  |
 | ingestQueue.autoscaling.hpa.maxReplicas | int | `10` |  |
 | ingestQueue.autoscaling.hpa.minReplicas | int | `3` |  |

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -65,22 +65,22 @@ images:
   aceBackendImage:
     repository: "docker.io/langchain/langsmith-ace-backend"
     pullPolicy: IfNotPresent
-    tag: "0.16.33rc1"
+    tag: "0.16.34"
   backendImage:
     repository: "docker.io/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
-    tag: "0.16.33rc1"
+    tag: "0.16.34"
   # Image for the shared Engine/Insights agent deployment. Serves both the
   # `insights` and `engine` graphs; which of them run is set by insights.enabled
   # and engine.enabled.
   engineInsightsAgentImage:
     repository: "docker.io/langchain/langsmith-insights-engine"
     pullPolicy: IfNotPresent
-    tag: "0.16.33rc1"
+    tag: "0.16.34"
   frontendImage:
     repository: "docker.io/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
-    tag: "0.16.33rc1"
+    tag: "0.16.34"
   operatorImage:
     repository: "docker.io/langchain/langgraph-operator"
     pullPolicy: IfNotPresent
@@ -104,15 +104,15 @@ images:
   agentBuilderImage:
     repository: "docker.io/langchain/agent-builder-deep-agent"
     pullPolicy: IfNotPresent
-    tag: "0.16.33rc1"
+    tag: "0.16.34"
   pollyAgentImage:
     repository: "docker.io/langchain/langsmith-polly"
     pullPolicy: IfNotPresent
-    tag: "0.16.33rc1"
+    tag: "0.16.34"
   smithdbImage:
     repository: "docker.io/langchain/smithdb"
     pullPolicy: IfNotPresent
-    tag: "0.16.33rc1"
+    tag: "0.16.34"
   # Optional: only mirror/pull when presidioAnalyzer.enabled is true
   presidioAnalyzerImage:
     repository: "mcr.microsoft.com/presidio-analyzer"


### PR DESCRIPTION
Cuts a chart release carrying everything that has landed on `v16-stable` since `rc.29`, and moves onto the `0.16.34` images.

### What this releases

**Chart changes** — both landed after the `rc.29` bump (#911) and are currently unpublished:

- #910 — drop the `langsmith-clio` image (and fix the marketplace scripts, which published clio and not the combined image)
- #914 — opt orgs out of Engine when Engine is not deployed

**App changes** — `appVersion` moves `0.16.33rc1` → `0.16.34`, which picks up:

- #33034 — self-hosted Engine license entitlement gate
- #33035 — hide Engine settings where Engine is not deployed

Both merged at 09:36/09:38 UTC, before the `0.16.34` cut (#33021) at 16:25 UTC, and I confirmed `EngineEnabledClaim` is present in the tree at that bump commit — so the gate really is in these images.

### Verification

- All seven images the chart references confirmed present at `0.16.34` on Docker Hub.
- 299 tests pass across 22 suites; `helm lint` clean; README regenerated.
- No stale `0.16.33rc1` tags remain in `values.yaml`.

### Before merging — the entitlement gate is live in these images

Any cluster that upgrades to this chart with `SMITH_INTELLIGENCE_ENDPOINT` set (i.e. `engine.enabled=true`) will **refuse to start** unless its license carries `engine_enabled`.

Our internal clusters are already covered: the entitlement was added to the `eks-smith-langchain` customer, I verified beacon mints it (`engine_enabled: true` alongside `sandbox_enabled`), and all three clusters had their cached license refreshed. Any other install enabling Engine needs the same treatment first.

### Note on versioning

`0.16.34` dropped the `rc` suffix, which by convention means the v16 app train has gone GA. I've kept the chart on the `rc.N` series as asked, but if the chart should follow the app to a GA `0.16.0`, that's a release-management call worth making deliberately rather than inheriting from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)