### PR TITLE
fix(langsmith): mount /data for the SmithDB query disk cache

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.17.0-rc.3
+version: 0.17.0-rc.4
 appVersion: "0.17.1rc1"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.17.0-rc.3](https://img.shields.io/badge/Version-0.17.0--rc.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.1rc1](https://img.shields.io/badge/AppVersion-0.17.1rc1-informational?style=flat-square)
+![Version: 0.17.0-rc.4](https://img.shields.io/badge/Version-0.17.0--rc.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.1rc1](https://img.shields.io/badge/AppVersion-0.17.1rc1-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -1278,8 +1278,10 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.query.deployment.strategy.type | string | `"RollingUpdate"` |  |
 | smithdb.query.deployment.tolerations | list | `[]` |  |
 | smithdb.query.deployment.topologySpreadConstraints | list | `[]` |  |
-| smithdb.query.deployment.volumeMounts | list | `[]` |  |
-| smithdb.query.deployment.volumes | list | `[]` |  |
+| smithdb.query.deployment.volumeMounts[0].mountPath | string | `"/data"` |  |
+| smithdb.query.deployment.volumeMounts[0].name | string | `"local-ssd-storage"` |  |
+| smithdb.query.deployment.volumes[0].emptyDir.sizeLimit | string | `"200Gi"` |  |
+| smithdb.query.deployment.volumes[0].name | string | `"local-ssd-storage"` |  |
 | smithdb.query.name | string | `"query"` |  |
 | smithdb.query.pdb.annotations | object | `{}` |  |
 | smithdb.query.pdb.enabled | bool | `false` |  |

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -109,6 +109,23 @@ tests:
               resourceFieldRef:
                 resource: limits.memory
 
+  - it: should back the SmithDB query disk cache with a writable /data volume
+    values:
+      - ./values/smithdb-enabled.yaml
+    template: smithdb/query-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: local-ssd-storage
+            emptyDir:
+              sizeLimit: 200Gi
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: local-ssd-storage
+            mountPath: /data
+
   - it: should derive the plaintext SmithDB OTLP endpoint from chart-level tracing
     values:
       - ./values/smithdb-enabled.yaml

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1485,8 +1485,16 @@ smithdb:
       tolerations: []
       affinity: {}
       topologySpreadConstraints: []
-      volumes: []
-      volumeMounts: []
+      # The Vortex disk cache writes to /data. Without a writable mount the
+      # cache silently degrades to memory-only and every miss goes to object
+      # storage. Keep sizeLimit aligned with resources.limits.ephemeral-storage.
+      volumes:
+        - name: local-ssd-storage
+          emptyDir:
+            sizeLimit: 200Gi
+      volumeMounts:
+        - name: local-ssd-storage
+          mountPath: /data
       initContainers: []
     service:
       port: 8080

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1485,9 +1485,6 @@ smithdb:
       tolerations: []
       affinity: {}
       topologySpreadConstraints: []
-      # The Vortex disk cache writes to /data. Without a writable mount the
-      # cache silently degrades to memory-only and every miss goes to object
-      # storage. Keep sizeLimit aligned with resources.limits.ephemeral-storage.
       volumes:
         - name: local-ssd-storage
           emptyDir:


### PR DESCRIPTION
## Summary
The SmithDB `query` deployment enables the Vortex disk cache but never gets a writable `/data` volume, so the cache silently never initialises.


## Changes
- `values.yaml`: give `smithdb.query.deployment` an emptyDir `local-ssd-storage` mounted at `/data`, `sizeLimit` matching the 200Gi ephemeral-storage limit, mirroring `ingestion`.


## Test plan

- [x] `helm unittest charts/langsmith -f 'tests/langsmith_smithdb_test.yaml'` — 39 passed, including the new case
- [x] `helm lint charts/langsmith` clean
