### PR TITLE
feat(operator): ship managed resource support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,16 @@ test*.yaml
 charts/langsmith-observability/charts/*
 test*.csv
 .tmp/
+
+# Local environments and secrets
+.env
+.env.*
+*.pem
+*.key
+*.crt
+credentials.json
+
+# Dependency and Python caches
+node_modules/
+__pycache__/
+.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,3 @@ test*.csv
 *.key
 *.crt
 credentials.json
-
-# Dependency and Python caches
-node_modules/
-__pycache__/
-.venv/

--- a/charts/langgraph-dataplane/Chart.yaml
+++ b/charts/langgraph-dataplane/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy a langgraph dataplane on kubernetes.
 type: application
-version: 0.2.21
+version: 0.2.22
 appVersion: "0.13.9"

--- a/charts/langgraph-dataplane/README.md
+++ b/charts/langgraph-dataplane/README.md
@@ -33,7 +33,7 @@ You can find the guide to deploy a LangGraph Dataplane [here](https://langchain-
 | images.listenerImage.tag | string | `"0.13.9"` |  |
 | images.operatorImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.operatorImage.repository | string | `"docker.io/langchain/langgraph-operator"` |  |
-| images.operatorImage.tag | string | `"0.1.36"` |  |
+| images.operatorImage.tag | string | `"0.1.59"` |  |
 | images.redisImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.redisImage.repository | string | `"docker.io/redis"` |  |
 | images.redisImage.tag | string | `"7"` |  |

--- a/charts/langgraph-dataplane/templates/operator/crds.yaml
+++ b/charts/langgraph-dataplane/templates/operator/crds.yaml
@@ -1098,6 +1098,56 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              managedResources:
+                description: ManagedResources defines namespaced Kubernetes resources
+                  owned by this LGP.
+                minProperties: 1
+                properties:
+                  secretProviderClass:
+                    description: SecretProviderClass creates one Secrets Store CSI
+                      Driver resource.
+                    properties:
+                      name:
+                        description: Name is the SecretProviderClass metadata.name.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      parameters:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Parameters are passed directly to the Azure provider. Values remain
+                          strings so multiline provider configuration such as objects is preserved.
+                        minProperties: 1
+                        type: object
+                      provider:
+                        description: Provider is the Secrets Store CSI provider. Only
+                          Azure is supported.
+                        enum:
+                        - azure
+                        type: string
+                    required:
+                    - name
+                    - parameters
+                    - provider
+                    type: object
+                  serviceAccount:
+                    description: |-
+                      ServiceAccount creates a ServiceAccount named <lgp-name>-sa and configures
+                      all LGP pods to use it.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations applied to the managed ServiceAccount.
+                        type: object
+                      automountServiceAccountToken:
+                        description: |-
+                          AutomountServiceAccountToken controls automatic token mounting for pods
+                          using the managed ServiceAccount.
+                        type: boolean
+                    type: object
+                type: object
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/charts/langgraph-dataplane/templates/operator/rbac.yaml
+++ b/charts/langgraph-dataplane/templates/operator/rbac.yaml
@@ -149,6 +149,18 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -314,6 +326,18 @@ rules:
   - networking.istio.io
   resources:
   - virtualservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasses
   verbs:
   - create
   - delete

--- a/charts/langgraph-dataplane/values.yaml
+++ b/charts/langgraph-dataplane/values.yaml
@@ -42,7 +42,7 @@ images:
   operatorImage:
     repository: "docker.io/langchain/langgraph-operator"
     pullPolicy: IfNotPresent
-    tag: "0.1.36"
+    tag: "0.1.59"
 
 ingress:
   enabled: true

--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.17.0-rc.4
+version: 0.17.0-rc.5
 appVersion: "0.17.1rc1"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -369,7 +369,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | images.juicefsMountImage | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/juicedata/mount","tag":"ce-v1.3.0"}` | JuiceFS CE mount image used by the runtime mount pods the CSI driver creates. Only used when sandboxes.enabled is true. |
 | images.operatorImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.operatorImage.repository | string | `"docker.io/langchain/langgraph-operator"` |  |
-| images.operatorImage.tag | string | `"0.1.47"` |  |
+| images.operatorImage.tag | string | `"0.1.59"` |  |
 | images.pollyAgentImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.pollyAgentImage.repository | string | `"docker.io/langchain/langsmith-polly"` |  |
 | images.pollyAgentImage.tag | string | `"0.17.1rc1"` |  |

--- a/charts/langsmith/templates/operator/crds.yaml
+++ b/charts/langsmith/templates/operator/crds.yaml
@@ -1098,6 +1098,56 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              managedResources:
+                description: ManagedResources defines namespaced Kubernetes resources
+                  owned by this LGP.
+                minProperties: 1
+                properties:
+                  secretProviderClass:
+                    description: SecretProviderClass creates one Secrets Store CSI
+                      Driver resource.
+                    properties:
+                      name:
+                        description: Name is the SecretProviderClass metadata.name.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      parameters:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Parameters are passed directly to the Azure provider. Values remain
+                          strings so multiline provider configuration such as objects is preserved.
+                        minProperties: 1
+                        type: object
+                      provider:
+                        description: Provider is the Secrets Store CSI provider. Only
+                          Azure is supported.
+                        enum:
+                        - azure
+                        type: string
+                    required:
+                    - name
+                    - parameters
+                    - provider
+                    type: object
+                  serviceAccount:
+                    description: |-
+                      ServiceAccount creates a ServiceAccount named <lgp-name>-sa and configures
+                      all LGP pods to use it.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations applied to the managed ServiceAccount.
+                        type: object
+                      automountServiceAccountToken:
+                        description: |-
+                          AutomountServiceAccountToken controls automatic token mounting for pods
+                          using the managed ServiceAccount.
+                        type: boolean
+                    type: object
+                type: object
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/charts/langsmith/templates/operator/rbac.yaml
+++ b/charts/langsmith/templates/operator/rbac.yaml
@@ -149,6 +149,18 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -314,6 +326,18 @@ rules:
   - networking.istio.io
   resources:
   - virtualservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasses
   verbs:
   - create
   - delete

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -81,7 +81,7 @@ images:
   operatorImage:
     repository: "docker.io/langchain/langgraph-operator"
     pullPolicy: IfNotPresent
-    tag: "0.1.47"
+    tag: "0.1.59"
   # For production environments, we strongly recommend connecting to a managed PostgreSQL instance instead of using the one provided by the chart.
   # Docs: https://docs.langchain.com/langsmith/self-host-external-postgres
   postgresImage:


### PR DESCRIPTION
## Summary

Self-hosted LangGraph deployments can use operator-managed ServiceAccounts and Azure SecretProviderClasses once operator `0.1.59` is available. Both supported charts now ship the matching LGP schema and controller permissions.

- Add typed `managedResources` fields to the bundled LGP CRD.
- Grant namespaced and cluster-scoped operator roles lifecycle access to SecretProviderClasses; existing ServiceAccount permissions are unchanged.
- Pin both charts to operator `0.1.59` and increment their chart versions.

This must follow the operator release from https://github.com/langchain-ai/lgp-operator/pull/262. Tracks https://linear.app/langchain/issue/LSD-1798/lsd-operator-provision-customer-defined-resources-secretproviderclass.

## Test Plan

- [x] Run `helm lint charts/langgraph-dataplane`
- [x] Run `helm lint charts/langsmith`
- [x] Render both charts and verify the LGP CRD and operator RBAC include managed-resource support
