### PR TITLE
chore(mission-control): bump chart to 1.2.4, appVersion to 1.2.5

### DIFF
--- a/charts/mission-control/Chart.yaml
+++ b/charts/mission-control/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: mission-control
 description: Mission Control to deploy and manage Langsmith in EKS
-version: 1.2.3
-appVersion: "1.2.4"
+version: 1.2.4
+appVersion: "1.2.5"


### PR DESCRIPTION
## Summary
Updates the Mission Control Helm chart to version 1.2.5, which includes security fixes for a few known vulnerabilities in third-party components used by the app (see langchain-ai/langchain-mission-control#145 for details).

The chart's internal version number is also bumped so our release automation actually publishes this update, since we've already published a 1.2.3 release and it would otherwise get skipped.

No functional or configuration changes are included, this only updates version numbers.