### PR TITLE
fix(langsmith): backport SmithDB chart fixes to v16

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.2
+version: 0.16.3
 appVersion: "0.16.36"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.16.2](https://img.shields.io/badge/Version-0.16.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.36](https://img.shields.io/badge/AppVersion-0.16.36-informational?style=flat-square)
+![Version: 0.16.3](https://img.shields.io/badge/Version-0.16.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.36](https://img.shields.io/badge/AppVersion-0.16.36-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -1198,7 +1198,6 @@ Two things worth planning for before you enable it:
 | smithdb.metastoreMigration.job.tolerations | list | `[]` |  |
 | smithdb.metastoreMigration.job.ttlSecondsAfterFinished | int | `3600` |  |
 | smithdb.metastoreMigration.name | string | `"metastore-migration"` |  |
-| smithdb.metastoreMigration.useSsl | bool | `false` |  |
 | smithdb.migration.containerPort | int | `9040` |  |
 | smithdb.migration.deployment.affinity | object | `{}` |  |
 | smithdb.migration.deployment.annotations | object | `{}` |  |
@@ -1335,8 +1334,10 @@ Two things worth planning for before you enable it:
 | smithdb.query.deployment.strategy.type | string | `"RollingUpdate"` |  |
 | smithdb.query.deployment.tolerations | list | `[]` |  |
 | smithdb.query.deployment.topologySpreadConstraints | list | `[]` |  |
-| smithdb.query.deployment.volumeMounts | list | `[]` |  |
-| smithdb.query.deployment.volumes | list | `[]` |  |
+| smithdb.query.deployment.volumeMounts[0].mountPath | string | `"/data"` |  |
+| smithdb.query.deployment.volumeMounts[0].name | string | `"local-ssd-storage"` |  |
+| smithdb.query.deployment.volumes[0].emptyDir.sizeLimit | string | `"200Gi"` |  |
+| smithdb.query.deployment.volumes[0].name | string | `"local-ssd-storage"` |  |
 | smithdb.query.name | string | `"query"` |  |
 | smithdb.query.pdb.annotations | object | `{}` |  |
 | smithdb.query.pdb.enabled | bool | `false` |  |

--- a/charts/langsmith/templates/smithdb/metastore-migration.yaml
+++ b/charts/langsmith/templates/smithdb/metastore-migration.yaml
@@ -7,7 +7,7 @@
   (dict "name" "DATABASE_NAME" "valueFrom" (dict "secretKeyRef" (dict "name" $secret "key" $cfg.metastore.databaseSecretKey)))
   (dict "name" "DATABASE_USERNAME" "valueFrom" (dict "secretKeyRef" (dict "name" $secret "key" $cfg.metastore.usernameSecretKey)))
   (dict "name" "DATABASE_PASSWORD" "valueFrom" (dict "secretKeyRef" (dict "name" $secret "key" $cfg.metastore.passwordSecretKey)))
-  (dict "name" "DATABASE_USE_SSL" "value" (.Values.smithdb.metastoreMigration.useSsl | toString))
+  (dict "name" "DATABASE_USE_SSL" "value" ($cfg.metastore.useSsl | toString))
 -}}
 {{- $envVars = concat $envVars .Values.smithdb.metastoreMigration.job.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -79,6 +79,19 @@ tests:
           path: spec.template.spec.containers[0].resources.requests.ephemeral-storage
           value: "200Gi"
 
+  - it: should enable TLS for metastore migrations when metastore TLS is enabled
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.config.metastore.useSsl: true
+    template: smithdb/metastore-migration.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_USE_SSL
+            value: "true"
+
   - it: should size the SmithDB query disk cache from its ephemeral storage limit
     values:
       - ./values/smithdb-enabled.yaml
@@ -108,6 +121,23 @@ tests:
             valueFrom:
               resourceFieldRef:
                 resource: limits.memory
+
+  - it: should back the SmithDB query disk cache with a writable /data volume
+    values:
+      - ./values/smithdb-enabled.yaml
+    template: smithdb/query-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: local-ssd-storage
+            emptyDir:
+              sizeLimit: 200Gi
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: local-ssd-storage
+            mountPath: /data
 
   - it: should derive the plaintext SmithDB OTLP endpoint from chart-level tracing
     values:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1522,8 +1522,13 @@ smithdb:
       tolerations: []
       affinity: {}
       topologySpreadConstraints: []
-      volumes: []
-      volumeMounts: []
+      volumes:
+        - name: local-ssd-storage
+          emptyDir:
+            sizeLimit: 200Gi
+      volumeMounts:
+        - name: local-ssd-storage
+          mountPath: /data
       initContainers: []
     service:
       port: 8080
@@ -1980,7 +1985,6 @@ smithdb:
 
   metastoreMigration:
     name: "metastore-migration"
-    useSsl: false
     command:
       - "/usr/local/bin/smithdb-metastore-migrate-entrypoint.sh"
     job:


### PR DESCRIPTION
## Summary
- backport #920 to mount the SmithDB query disk cache at `/data`
- backport #929 to make metastore migrations inherit the shared TLS setting
- bump the v16 chart to `0.16.3`

## Test plan
- [ ] CI

Local tests were intentionally skipped; CI will verify the backport.

Made with [Cursor](https://cursor.com)