### PR TITLE
feat(langsmith): wire SmithDB metastore IAM auth and migrate CLI

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1045,6 +1045,8 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.config.existingSecretName | string | `""` | Existing secret containing SmithDB metastore credentials. |
 | smithdb.config.metastore.databaseSecretKey | string | `""` |  |
 | smithdb.config.metastore.hostSecretKey | string | `""` |  |
+| smithdb.config.metastore.iamAuthProvider | string | `""` |  |
+| smithdb.config.metastore.iamUsername | string | `""` |  |
 | smithdb.config.metastore.passwordSecretKey | string | `""` |  |
 | smithdb.config.metastore.port | string | `"5432"` |  |
 | smithdb.config.metastore.useSsl | bool | `false` |  |
@@ -1125,7 +1127,8 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | smithdb.langsmith.ingestion.enabled | bool | `false` | Enables LangSmith run ingestion via SmithDB. When ClickHouse is enabled, ingestion writes to both backends. Requires smithdb.enabled. |
 | smithdb.langsmith.migration.enabled | bool | `false` | Detailed migration and taskdb configuration lives under smithdb.migration. |
 | smithdb.langsmith.query.enabled | bool | `false` | Enables SmithDB-powered queries. Requires smithdb.enabled. |
-| smithdb.metastoreMigration.command[0] | string | `"/usr/local/bin/smithdb-metastore-migrate-entrypoint.sh"` |  |
+| smithdb.metastoreMigration.command[0] | string | `"./smithdb"` |  |
+| smithdb.metastoreMigration.command[1] | string | `"metastore-migrate"` |  |
 | smithdb.metastoreMigration.job.activeDeadlineSeconds | int | `600` |  |
 | smithdb.metastoreMigration.job.affinity | object | `{}` |  |
 | smithdb.metastoreMigration.job.annotations | object | `{}` |  |

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -756,10 +756,14 @@ Args: root, service, displayName.
       name: {{ $root.Values.smithdb.config.existingSecretName }}
       key: {{ $root.Values.smithdb.config.metastore.databaseSecretKey }}
 - name: {{ $prefix }}__METASTORE__USERNAME
+{{- if $root.Values.smithdb.config.metastore.iamUsername }}
+  value: {{ $root.Values.smithdb.config.metastore.iamUsername | quote }}
+{{- else }}
   valueFrom:
     secretKeyRef:
       name: {{ $root.Values.smithdb.config.existingSecretName }}
       key: {{ $root.Values.smithdb.config.metastore.usernameSecretKey }}
+{{- end }}
 {{- if $root.Values.smithdb.config.metastore.passwordSecretKey }}
 - name: {{ $prefix }}__METASTORE__PASSWORD
   valueFrom:

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -760,11 +760,23 @@ Args: root, service, displayName.
     secretKeyRef:
       name: {{ $root.Values.smithdb.config.existingSecretName }}
       key: {{ $root.Values.smithdb.config.metastore.usernameSecretKey }}
+{{- if $root.Values.smithdb.config.metastore.passwordSecretKey }}
 - name: {{ $prefix }}__METASTORE__PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ $root.Values.smithdb.config.existingSecretName }}
       key: {{ $root.Values.smithdb.config.metastore.passwordSecretKey }}
+{{- end }}
+{{- with $root.Values.smithdb.config.metastore.iamAuthProvider }}
+- name: {{ $prefix }}__METASTORE__IAM_AUTH_PROVIDER
+  value: {{ . | quote }}
+{{- end }}
+{{- if and (eq $root.Values.smithdb.config.metastore.iamAuthProvider "aws") $root.Values.smithdb.config.objectStore.s3.region }}
+- name: AWS_REGION
+  value: {{ $root.Values.smithdb.config.objectStore.s3.region | quote }}
+- name: AWS_DEFAULT_REGION
+  value: {{ $root.Values.smithdb.config.objectStore.s3.region | quote }}
+{{- end }}
 - name: {{ $prefix }}__METASTORE__USE_SSL
   value: {{ $root.Values.smithdb.config.metastore.useSsl | quote }}
 {{ include "langsmith.smithdb.baseEnv" (dict "root" $root "service" $service "displayName" $displayName) }}

--- a/charts/langsmith/templates/smithdb/metastore-migration.yaml
+++ b/charts/langsmith/templates/smithdb/metastore-migration.yaml
@@ -1,29 +1,5 @@
 {{- if .Values.smithdb.enabled }}
-{{- $cfg := .Values.smithdb.config -}}
-{{- $secret := $cfg.existingSecretName -}}
-{{- $useIam := $cfg.metastore.iamAuthProvider -}}
-{{- $defaultPasswordCommand := list "/usr/local/bin/smithdb-metastore-migrate-entrypoint.sh" -}}
-{{- $defaultIamCommand := list "./smithdb" "metastore-migrate" -}}
-{{- $command := .Values.smithdb.metastoreMigration.command -}}
-{{- if and $useIam (eq ($command | toJson) ($defaultPasswordCommand | toJson)) -}}
-{{- $command = $defaultIamCommand -}}
-{{- end -}}
-{{- $envVars := list -}}
-{{- if $useIam }}
-{{- $envVars = concat (include "langsmith.smithdb.serviceEnv" (dict "root" . "service" "METASTORE_MIGRATE" "displayName" "smithdb-metastore-migrate") | fromYamlArray) .Values.smithdb.metastoreMigration.job.extraEnv -}}
-{{- else }}
-{{- $envVars = list
-  (dict "name" "DATABASE_HOST" "valueFrom" (dict "secretKeyRef" (dict "name" $secret "key" $cfg.metastore.hostSecretKey)))
-  (dict "name" "DATABASE_PORT" "value" ($cfg.metastore.port | toString))
-  (dict "name" "DATABASE_NAME" "valueFrom" (dict "secretKeyRef" (dict "name" $secret "key" $cfg.metastore.databaseSecretKey)))
-  (dict "name" "DATABASE_USERNAME" "valueFrom" (dict "secretKeyRef" (dict "name" $secret "key" $cfg.metastore.usernameSecretKey)))
-  (dict "name" "DATABASE_USE_SSL" "value" ($cfg.metastore.useSsl | toString))
--}}
-{{- if $cfg.metastore.passwordSecretKey }}
-{{- $envVars = append $envVars (dict "name" "DATABASE_PASSWORD" "valueFrom" (dict "secretKeyRef" (dict "name" $secret "key" $cfg.metastore.passwordSecretKey))) -}}
-{{- end }}
-{{- $envVars = concat $envVars .Values.smithdb.metastoreMigration.job.extraEnv -}}
-{{- end }}
+{{- $envVars := concat (include "langsmith.smithdb.serviceEnv" (dict "root" . "service" "METASTORE_MIGRATE" "displayName" "smithdb-metastore-migrate") | fromYamlArray) .Values.smithdb.metastoreMigration.job.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: batch/v1
 kind: Job
@@ -77,7 +53,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Values.smithdb.metastoreMigration.name }}
-          {{- with $command }}
+          {{- with .Values.smithdb.metastoreMigration.command }}
           command:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/langsmith/templates/smithdb/metastore-migration.yaml
+++ b/charts/langsmith/templates/smithdb/metastore-migration.yaml
@@ -1,15 +1,32 @@
 {{- if .Values.smithdb.enabled }}
 {{- $cfg := .Values.smithdb.config -}}
 {{- $secret := $cfg.existingSecretName -}}
-{{- $envVars := list
+{{- $useIam := $cfg.metastore.iamAuthProvider -}}
+{{- /* Password installs keep the bash/refinery entrypoint + DATABASE_* env.
+     IAM installs use `smithdb metastore-migrate` with the same METASTORE__*
+     config shape as runtime services. Explicit command overrides still win. */ -}}
+{{- $defaultPasswordCommand := list "/usr/local/bin/smithdb-metastore-migrate-entrypoint.sh" -}}
+{{- $defaultIamCommand := list "./smithdb" "metastore-migrate" -}}
+{{- $command := .Values.smithdb.metastoreMigration.command -}}
+{{- if and $useIam (eq ($command | toJson) ($defaultPasswordCommand | toJson)) -}}
+{{- $command = $defaultIamCommand -}}
+{{- end -}}
+{{- $envVars := list -}}
+{{- if $useIam }}
+{{- $envVars = concat (include "langsmith.smithdb.serviceEnv" (dict "root" . "service" "METASTORE_MIGRATE" "displayName" "smithdb-metastore-migrate") | fromYamlArray) .Values.smithdb.metastoreMigration.job.extraEnv -}}
+{{- else }}
+{{- $envVars = list
   (dict "name" "DATABASE_HOST" "valueFrom" (dict "secretKeyRef" (dict "name" $secret "key" $cfg.metastore.hostSecretKey)))
   (dict "name" "DATABASE_PORT" "value" ($cfg.metastore.port | toString))
   (dict "name" "DATABASE_NAME" "valueFrom" (dict "secretKeyRef" (dict "name" $secret "key" $cfg.metastore.databaseSecretKey)))
   (dict "name" "DATABASE_USERNAME" "valueFrom" (dict "secretKeyRef" (dict "name" $secret "key" $cfg.metastore.usernameSecretKey)))
-  (dict "name" "DATABASE_PASSWORD" "valueFrom" (dict "secretKeyRef" (dict "name" $secret "key" $cfg.metastore.passwordSecretKey)))
   (dict "name" "DATABASE_USE_SSL" "value" ($cfg.metastore.useSsl | toString))
 -}}
+{{- if $cfg.metastore.passwordSecretKey }}
+{{- $envVars = append $envVars (dict "name" "DATABASE_PASSWORD" "valueFrom" (dict "secretKeyRef" (dict "name" $secret "key" $cfg.metastore.passwordSecretKey))) -}}
+{{- end }}
 {{- $envVars = concat $envVars .Values.smithdb.metastoreMigration.job.extraEnv -}}
+{{- end }}
 {{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: batch/v1
 kind: Job
@@ -63,7 +80,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Values.smithdb.metastoreMigration.name }}
-          {{- with .Values.smithdb.metastoreMigration.command }}
+          {{- with $command }}
           command:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/langsmith/templates/smithdb/metastore-migration.yaml
+++ b/charts/langsmith/templates/smithdb/metastore-migration.yaml
@@ -2,9 +2,6 @@
 {{- $cfg := .Values.smithdb.config -}}
 {{- $secret := $cfg.existingSecretName -}}
 {{- $useIam := $cfg.metastore.iamAuthProvider -}}
-{{- /* Password installs keep the bash/refinery entrypoint + DATABASE_* env.
-     IAM installs use `smithdb metastore-migrate` with the same METASTORE__*
-     config shape as runtime services. Explicit command overrides still win. */ -}}
 {{- $defaultPasswordCommand := list "/usr/local/bin/smithdb-metastore-migrate-entrypoint.sh" -}}
 {{- $defaultIamCommand := list "./smithdb" "metastore-migrate" -}}
 {{- $command := .Values.smithdb.metastoreMigration.command -}}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -352,11 +352,18 @@ AWS Marketplace Helm template verification).
 {{- if not .Values.smithdb.config.existingSecretName -}}
 {{- fail "smithdb.config.existingSecretName is required when smithdb.enabled is true." -}}
 {{- end -}}
-{{- range $keyName := list "hostSecretKey" "databaseSecretKey" "usernameSecretKey" "passwordSecretKey" -}}
+{{- range $keyName := list "hostSecretKey" "databaseSecretKey" "usernameSecretKey" -}}
 {{- $keyValue := get $.Values.smithdb.config.metastore $keyName -}}
 {{- if not $keyValue -}}
 {{- fail (printf "smithdb.config.metastore.%s is required when smithdb.enabled is true." $keyName) -}}
 {{- end -}}
+{{- end -}}
+{{- $iamAuthProvider := .Values.smithdb.config.metastore.iamAuthProvider -}}
+{{- if and (not .Values.smithdb.config.metastore.passwordSecretKey) (not $iamAuthProvider) -}}
+{{- fail "smithdb.config.metastore.passwordSecretKey is required when smithdb.enabled is true unless smithdb.config.metastore.iamAuthProvider is set." -}}
+{{- end -}}
+{{- if and $iamAuthProvider (not .Values.smithdb.config.metastore.useSsl) -}}
+{{- fail "smithdb.config.metastore.useSsl must be true when smithdb.config.metastore.iamAuthProvider is set." -}}
 {{- end -}}
 {{- $objectStoreType := lower .Values.smithdb.config.objectStore.type -}}
 {{- if not (or (eq $objectStoreType "s3") (eq $objectStoreType "gcs")) -}}

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -86,10 +86,15 @@ tests:
       smithdb.config.metastore.useSsl: true
     template: smithdb/metastore-migration.yaml
     asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - ./smithdb
+            - metastore-migrate
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: DATABASE_USE_SSL
+            name: SMITHDB_METASTORE_MIGRATE__METASTORE__USE_SSL
             value: "true"
 
   - it: should size the SmithDB query disk cache from its ephemeral storage limit

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -230,7 +230,6 @@ sandboxes:
           mountOptions:
             - cache-dir=/var/cache/juicefs-csi
             - cache-size=307200
-            - cache-large-write
       pvName: "smithbox-juicefs-csi"
       pvcName: "smithbox-juicefs-csi"
   sandboxHost:
@@ -1413,12 +1412,8 @@ smithdb:
       hostSecretKey: ""
       databaseSecretKey: ""
       usernameSecretKey: ""
-      # -- Leave empty when using iamAuthProvider so pods do not mount a static password.
       passwordSecretKey: ""
-      # -- Cloud IAM auth for the metastore (e.g. "aws"). Empty disables IAM and uses passwordSecretKey.
       iamAuthProvider: ""
-      # -- Optional IAM database username. When set, overrides usernameSecretKey for SmithDB
-      # connections (useful when the secret still holds the master user for break-glass).
       iamUsername: ""
       port: "5432"
       useSsl: false
@@ -1955,10 +1950,6 @@ smithdb:
 
   metastoreMigration:
     name: "metastore-migration"
-    # -- Replaces the image ENTRYPOINT.
-    # Password installs: bash/refinery entrypoint (default).
-    # When smithdb.config.metastore.iamAuthProvider is set and this still has
-    # the default value, the chart switches to `./smithdb metastore-migrate`.
     command:
       - "/usr/local/bin/smithdb-metastore-migrate-entrypoint.sh"
     job:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1417,6 +1417,9 @@ smithdb:
       passwordSecretKey: ""
       # -- Cloud IAM auth for the metastore (e.g. "aws"). Empty disables IAM and uses passwordSecretKey.
       iamAuthProvider: ""
+      # -- Optional IAM database username. When set, overrides usernameSecretKey for SmithDB
+      # connections (useful when the secret still holds the master user for break-glass).
+      iamUsername: ""
       port: "5432"
       useSsl: false
     objectStore:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -230,6 +230,7 @@ sandboxes:
           mountOptions:
             - cache-dir=/var/cache/juicefs-csi
             - cache-size=307200
+            - cache-large-write
       pvName: "smithbox-juicefs-csi"
       pvcName: "smithbox-juicefs-csi"
   sandboxHost:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1952,7 +1952,8 @@ smithdb:
   metastoreMigration:
     name: "metastore-migration"
     command:
-      - "/usr/local/bin/smithdb-metastore-migrate-entrypoint.sh"
+      - "./smithdb"
+      - "metastore-migrate"
     job:
       ttlSecondsAfterFinished: 3600
       backoffLimit: 0

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1413,7 +1413,10 @@ smithdb:
       hostSecretKey: ""
       databaseSecretKey: ""
       usernameSecretKey: ""
+      # -- Leave empty when using iamAuthProvider so pods do not mount a static password.
       passwordSecretKey: ""
+      # -- Cloud IAM auth for the metastore (e.g. "aws"). Empty disables IAM and uses passwordSecretKey.
+      iamAuthProvider: ""
       port: "5432"
       useSsl: false
     objectStore:
@@ -1949,6 +1952,10 @@ smithdb:
 
   metastoreMigration:
     name: "metastore-migration"
+    # -- Replaces the image ENTRYPOINT.
+    # Password installs: bash/refinery entrypoint (default).
+    # When smithdb.config.metastore.iamAuthProvider is set and this still has
+    # the default value, the chart switches to `./smithdb metastore-migrate`.
     command:
       - "/usr/local/bin/smithdb-metastore-migrate-entrypoint.sh"
     job:


### PR DESCRIPTION
## Summary
- Emits `METASTORE__IAM_AUTH_PROVIDER`  from SmithDB service env
- Allows empty `passwordSecretKey` when IAM is set
- Auto-switches the metastore migration job to `./smithdb metastore-migrate` when IAM is enabled

## Test plan
- [x] Helm template IAM path: command is `metastore-migrate`, `IAM_AUTH_PROVIDER=aws`, no `PASSWORD`