### PR TITLE
feat(langgraph-dataplane): run the listener on the consolidated backend image

### DIFF
--- a/charts/langgraph-dataplane/Chart.yaml
+++ b/charts/langgraph-dataplane/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
 description: Helm chart to deploy a langgraph dataplane on kubernetes.
 type: application
 version: 0.2.22
-appVersion: "0.13.9"
+appVersion: "0.16.36"

--- a/charts/langgraph-dataplane/Chart.yaml
+++ b/charts/langgraph-dataplane/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy a langgraph dataplane on kubernetes.
 type: application
-version: 0.2.21
+version: 0.2.22
 appVersion: "0.13.9"

--- a/charts/langgraph-dataplane/README.md
+++ b/charts/langgraph-dataplane/README.md
@@ -1,6 +1,6 @@
 # langgraph-dataplane
 
-![Version: 0.2.22](https://img.shields.io/badge/Version-0.2.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.9](https://img.shields.io/badge/AppVersion-0.13.9-informational?style=flat-square)
+![Version: 0.2.22](https://img.shields.io/badge/Version-0.2.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.36](https://img.shields.io/badge/AppVersion-0.16.36-informational?style=flat-square)
 
 Helm chart to deploy a langgraph dataplane on kubernetes.
 

--- a/charts/langgraph-dataplane/README.md
+++ b/charts/langgraph-dataplane/README.md
@@ -1,6 +1,6 @@
 # langgraph-dataplane
 
-![Version: 0.2.21](https://img.shields.io/badge/Version-0.2.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.9](https://img.shields.io/badge/AppVersion-0.13.9-informational?style=flat-square)
+![Version: 0.2.22](https://img.shields.io/badge/Version-0.2.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.9](https://img.shields.io/badge/AppVersion-0.13.9-informational?style=flat-square)
 
 Helm chart to deploy a langgraph dataplane on kubernetes.
 
@@ -29,8 +29,8 @@ You can find the guide to deploy a LangGraph Dataplane [here](https://langchain-
 | gateway | object | `{"basePath":"","enabled":false,"hostname":"","name":"","namespace":""}` | Whether to use the Gateway API for ingress. Will create an HTTPRoute for each LangGraph platform deployment. Recommended for production use / if deploying multiple releases in the same cluster. |
 | images.imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Specified as name: value. |
 | images.listenerImage.pullPolicy | string | `"IfNotPresent"` |  |
-| images.listenerImage.repository | string | `"docker.io/langchain/hosted-langserve-backend"` |  |
-| images.listenerImage.tag | string | `"0.13.9"` |  |
+| images.listenerImage.repository | string | `"docker.io/langchain/langsmith-backend"` |  |
+| images.listenerImage.tag | string | `"0.16.36"` |  |
 | images.operatorImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.operatorImage.repository | string | `"docker.io/langchain/langgraph-operator"` |  |
 | images.operatorImage.tag | string | `"0.1.36"` |  |
@@ -128,7 +128,8 @@ You can find the guide to deploy a LangGraph Dataplane [here](https://langchain-
 | listener.deployment.affinity | object | `{}` |  |
 | listener.deployment.annotations | object | `{}` |  |
 | listener.deployment.autoRestart | bool | `true` |  |
-| listener.deployment.command[0] | string | `"./listener_entrypoint.sh"` |  |
+| listener.deployment.command[0] | string | `"host_backend_entrypoint.sh"` |  |
+| listener.deployment.command[1] | string | `"./listener_entrypoint.sh"` |  |
 | listener.deployment.extraContainerConfig | object | `{}` |  |
 | listener.deployment.extraEnv | list | `[]` |  |
 | listener.deployment.labels | object | `{}` |  |

--- a/charts/langgraph-dataplane/values.yaml
+++ b/charts/langgraph-dataplane/values.yaml
@@ -32,9 +32,9 @@ images:
    # -- Secrets with credentials to pull images from a private registry. Specified as name: value.
   imagePullSecrets: []
   listenerImage:
-    repository: "docker.io/langchain/hosted-langserve-backend"
+    repository: "docker.io/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
-    tag: "0.13.9"
+    tag: "0.16.36"
   redisImage:
     repository: "docker.io/redis"
     pullPolicy: IfNotPresent
@@ -114,6 +114,7 @@ listener:
         cpu: 1000m
         memory: 2Gi
     command:
+      - "host_backend_entrypoint.sh"
       - "./listener_entrypoint.sh"
     startupProbe:
       httpGet:


### PR DESCRIPTION
## What

Point the LangGraph dataplane listener at the consolidated `langsmith-backend` image.

| | before | after |
|---|---|---|
| `images.listenerImage.repository` | `docker.io/langchain/hosted-langserve-backend` | `docker.io/langchain/langsmith-backend` |
| `images.listenerImage.tag` | `0.13.9` | `0.16.36` |
| `listener.deployment.command` | `["./listener_entrypoint.sh"]` | `["host_backend_entrypoint.sh", "./listener_entrypoint.sh"]` |

Chart version `0.2.21` → `0.2.22`, `appVersion` `0.13.9` → `0.16.36`; README regenerated with helm-docs.

## Why

The standalone `hosted-langserve-backend` image is being retired — the listener now ships inside the consolidated backend image, which is where every other LangSmith workload already runs (langchain-ai/helm#828, langchain-ai/deployments#34387). Our own dataplane CI environment is cut over in langchain-ai/deployments#35403; this is the same change for the published chart.

**On the tag.** Both repositories publish on the same LangSmith version line — `hosted-langserve-backend` and `langsmith-backend` share tags `0.16.36`, `0.16.35`, `0.16.34`, … The chart's `0.13.9` default was stale (published Feb 2026) and predates the consolidation, so it had to move regardless; `0.16.36` is the current GA tag and exists for both repositories. `appVersion` is bumped to match, so the chart again advertises the version it actually deploys. Deployments that pin `listenerImage.tag` explicitly, as ours does, are unaffected either way.

**On the command.** The standalone image ran `./listener_entrypoint.sh` from its own WORKDIR. In the consolidated image host-backend is reached through `host_backend_entrypoint.sh` on `PATH`, which `cd`s to `/code/host-backend` and execs the args it is given. `listener_entrypoint.sh` is present there (`smith-backend/Dockerfile` copies it alongside `entrypoint.sh`), and this is the same command the langsmith chart uses for its own listener.

## Verification

- `helm lint` passes (0 failed).
- `helm template` renders the listener as:

  ```yaml
  command:
    - host_backend_entrypoint.sh
    - ./listener_entrypoint.sh
  image: "docker.io/langchain/langsmith-backend:0.16.36"
  ```
- Confirmed `langsmith-backend:0.16.36` is published on Docker Hub.
- Chart version incremented so `ct lint --check-version-increment` passes.
- The `appVersion` bump changes only `app.kubernetes.io/version` labels (and the config checksum derived from them): every image in the chart pins its own tag, so `appVersion` is not an image fallback here, and `selectorLabels` is name+instance only, so no immutable selector is touched. Diffing the rendered output before/after shows nothing else.

## Reviewer note

This changes which image LangGraph Platform dataplane installs pull by default: the consolidated LangSmith backend rather than the smaller single-purpose one. That is the intended direction, but the size/mirroring implications are worth a LangGraph-team sanity check before release.
