### PR TITLE
fix(langsmith): disable nginx request buffering on the frontend

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.17.0-rc.5
+version: 0.17.0-rc.6
 appVersion: "0.17.1rc1"

--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -77,6 +77,7 @@ data:
         proxy_read_timeout {{ .Values.frontend.proxyReadTimeout }};
         proxy_connect_timeout {{ .Values.frontend.proxyConnectTimeout }};
         proxy_send_timeout {{ .Values.frontend.proxyWriteTimeout }};
+        proxy_request_buffering off;
         keepalive_timeout {{ .Values.frontend.keepAliveTimeout }};
 
         add_header Content-Security-Policy "{{ .Values.frontend.cspHeader }}" always;
@@ -231,7 +232,6 @@ data:
             rewrite /{{ .Values.config.basePath }}/api/v1/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
-            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -241,7 +241,6 @@ data:
             rewrite /{{ .Values.config.basePath }}/api/v1/runs/batch /runs/batch  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
-            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -514,7 +513,6 @@ data:
             rewrite /{{ .Values.config.basePath }}/api/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
-            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -524,7 +522,6 @@ data:
             rewrite /{{ .Values.config.basePath }}/api/runs/batch /runs/batch  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
-            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -696,6 +693,7 @@ data:
         proxy_read_timeout {{ .Values.frontend.proxyReadTimeout }};
         proxy_connect_timeout {{ .Values.frontend.proxyConnectTimeout }};
         proxy_send_timeout {{ .Values.frontend.proxyWriteTimeout }};
+        proxy_request_buffering off;
         keepalive_timeout {{ .Values.frontend.keepAliveTimeout }};
 
         add_header Content-Security-Policy "{{ .Values.frontend.cspHeader }}" always;
@@ -865,7 +863,6 @@ data:
             rewrite /api/v1/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
-            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -875,7 +872,6 @@ data:
             rewrite /api/v1/runs/batch /runs/batch  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
-            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -1077,7 +1073,6 @@ data:
             rewrite /api/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
-            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -1087,7 +1082,6 @@ data:
             rewrite /api/runs/batch /runs/batch  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
-            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};

--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -231,6 +231,7 @@ data:
             rewrite /{{ .Values.config.basePath }}/api/v1/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
+            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -240,6 +241,7 @@ data:
             rewrite /{{ .Values.config.basePath }}/api/v1/runs/batch /runs/batch  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
+            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -512,6 +514,7 @@ data:
             rewrite /{{ .Values.config.basePath }}/api/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
+            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -521,6 +524,7 @@ data:
             rewrite /{{ .Values.config.basePath }}/api/runs/batch /runs/batch  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
+            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -861,6 +865,7 @@ data:
             rewrite /api/v1/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
+            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -870,6 +875,7 @@ data:
             rewrite /api/v1/runs/batch /runs/batch  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
+            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -1071,6 +1077,7 @@ data:
             rewrite /api/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
+            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -1080,6 +1087,7 @@ data:
             rewrite /api/runs/batch /runs/batch  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
+            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};

--- a/charts/langsmith/tests/frontend_nginx_test.yaml
+++ b/charts/langsmith/tests/frontend_nginx_test.yaml
@@ -1,41 +1,34 @@
-suite: frontend nginx run ingest proxying
+suite: frontend nginx request buffering
 templates:
   - frontend/config-map.yaml
 tests:
-  - it: streams run ingest bodies to the backend instead of spooling them to disk
+  - it: disables request buffering once at server scope so every route inherits it
     asserts:
       - matchRegex:
           path: data["nginx.conf"]
-          pattern: 'location = /api/v1/runs/multipart \{[^}]*proxy_request_buffering off;'
-      - matchRegex:
+          pattern: 'proxy_send_timeout \d+;\n\s*proxy_request_buffering off;'
+      # inherited from the server block; never repeated per location
+      - notMatchRegex:
           path: data["nginx.conf"]
-          pattern: 'location = /api/v1/runs/batch \{[^}]*proxy_request_buffering off;'
-      - matchRegex:
-          path: data["nginx.conf"]
-          pattern: 'location = /api/runs/multipart \{[^}]*proxy_request_buffering off;'
-      - matchRegex:
-          path: data["nginx.conf"]
-          pattern: 'location = /api/runs/batch \{[^}]*proxy_request_buffering off;'
+          pattern: 'location [^\n]*\{[^}]*proxy_request_buffering'
 
-  - it: streams run ingest bodies when a basePath is configured
+  - it: disables request buffering when a basePath is configured
     set:
       config.basePath: "langsmith"
     asserts:
       - matchRegex:
           path: data["nginx.conf"]
-          pattern: 'location = /langsmith/api/v1/runs/multipart \{[^}]*proxy_request_buffering off;'
-      - matchRegex:
-          path: data["nginx.conf"]
-          pattern: 'location = /langsmith/api/v1/runs/batch \{[^}]*proxy_request_buffering off;'
-      - matchRegex:
-          path: data["nginx.conf"]
-          pattern: 'location = /langsmith/api/runs/multipart \{[^}]*proxy_request_buffering off;'
-      - matchRegex:
-          path: data["nginx.conf"]
-          pattern: 'location = /langsmith/api/runs/batch \{[^}]*proxy_request_buffering off;'
-
-  - it: leaves request buffering on for other proxied routes
-    asserts:
+          pattern: 'proxy_send_timeout \d+;\n\s*proxy_request_buffering off;'
       - notMatchRegex:
           path: data["nginx.conf"]
-          pattern: 'location = /api/v1/runs \{[^}]*proxy_request_buffering off;'
+          pattern: 'location [^\n]*\{[^}]*proxy_request_buffering'
+
+  - it: disables request buffering on the ssl server block
+    set:
+      frontend.ssl.enabled: true
+      frontend.ssl.certificatePath: /certs/tls.crt
+      frontend.ssl.keyPath: /certs/tls.key
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'proxy_send_timeout \d+;\n\s*proxy_request_buffering off;'

--- a/charts/langsmith/tests/frontend_nginx_test.yaml
+++ b/charts/langsmith/tests/frontend_nginx_test.yaml
@@ -1,0 +1,41 @@
+suite: frontend nginx run ingest proxying
+templates:
+  - frontend/config-map.yaml
+tests:
+  - it: streams run ingest bodies to the backend instead of spooling them to disk
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /api/v1/runs/multipart \{[^}]*proxy_request_buffering off;'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /api/v1/runs/batch \{[^}]*proxy_request_buffering off;'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /api/runs/multipart \{[^}]*proxy_request_buffering off;'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /api/runs/batch \{[^}]*proxy_request_buffering off;'
+
+  - it: streams run ingest bodies when a basePath is configured
+    set:
+      config.basePath: "langsmith"
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /langsmith/api/v1/runs/multipart \{[^}]*proxy_request_buffering off;'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /langsmith/api/v1/runs/batch \{[^}]*proxy_request_buffering off;'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /langsmith/api/runs/multipart \{[^}]*proxy_request_buffering off;'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /langsmith/api/runs/batch \{[^}]*proxy_request_buffering off;'
+
+  - it: leaves request buffering on for other proxied routes
+    asserts:
+      - notMatchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /api/v1/runs \{[^}]*proxy_request_buffering off;'


### PR DESCRIPTION
The frontend nginx proxies with request buffering on (the default), so any request body larger than `client_body_buffer_size` (16k on 64-bit, and we set it nowhere) gets spooled to a temp file before it reaches the upstream. On a live env that means a disk write + read per affected request, the full upload duration added to end-to-end latency, and a warn per request:

```
[warn] a client request body is buffered to a temporary file /var/lib/nginx/tmp/client_body/0000629461, request: "POST /api/v1/runs/multipart HTTP/1.1"
```

This sets `proxy_request_buffering off` once at server scope, alongside `client_max_body_size` and the `proxy_*` timeouts, so every proxied route inherits it. Two lines, both server blocks (`basePath` and non-`basePath` variants).

Not to be confused with `proxy_buffering off`, which is already set per-location: that governs the **response** direction and is load-bearing for streaming responses. `proxy_request_buffering` governs the **request** direction and is invisible to the client either way — turning it off is purely a latency/disk optimization.

### Tradeoffs

- **Slow clients** now hold an upstream connection for the upload duration instead of nginx absorbing it. `client_body_timeout` still cuts off stalled clients. Note the Go backend sets only `IdleTimeout` (no `ReadTimeout`/`ReadHeaderTimeout`) — adding one is a sensible follow-up in `langchainplus`, not a prerequisite.
- **Truncated bodies** now reach handlers when a client aborts mid-upload. Traced for the heaviest path: `ParseMultipartForm` streams attachment parts to blob storage as it walks the body, but runs are only enqueued after a clean parse — so an abort leaves orphaned blobs, not half-ingested runs, and the SDK retry re-uploads the batch.
- **Upstream retry.** With buffering on, nginx can replay a buffered body per `proxy_next_upstream`. `proxy_pass` targets a single ClusterIP Service and nginx does not retry non-idempotent requests once sent, so the practical loss is small.
- Applies to all upstreams, not just Go — `platformBackend`, `backend` (FastAPI), `hostBackend`, `playground`, the fleet servers, and `agentGateway`. Chunked request bodies are standard across those runtimes.

Set at server scope deliberately rather than per-route: uniform settings across ~98 near-identical location blocks are easier to reason about than a subset with divergent buffering behavior.

### Test plan

- New `charts/langsmith/tests/frontend_nginx_test.yaml` asserts the directive is declared at server scope in the default, `basePath`, and `ssl` renderings, and that it is never repeated inside a location block.
- Verified both assertions fail when they should: removing the directive fails all three tests; adding a redundant per-location copy trips the `notMatchRegex`.
- `helm unittest charts/langsmith` — 20 suites / 279 tests pass.
- `helm lint` clean; `helm template` confirms exactly one occurrence, in the server block.