### PR TITLE
fix(langsmith): disable nginx request buffering on the frontend (v16)

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.3
+version: 0.16.4
 appVersion: "0.16.36"

--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -216,6 +216,7 @@ data:
             rewrite /{{ .Values.config.basePath }}/api/v1/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
+            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -225,6 +226,7 @@ data:
             rewrite /{{ .Values.config.basePath }}/api/v1/runs/batch /runs/batch  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
+            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -497,6 +499,7 @@ data:
             rewrite /{{ .Values.config.basePath }}/api/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
+            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -506,6 +509,7 @@ data:
             rewrite /{{ .Values.config.basePath }}/api/runs/batch /runs/batch  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
+            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -834,6 +838,7 @@ data:
             rewrite /api/v1/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
+            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -843,6 +848,7 @@ data:
             rewrite /api/v1/runs/batch /runs/batch  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
+            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -1044,6 +1050,7 @@ data:
             rewrite /api/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
+            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -1053,6 +1060,7 @@ data:
             rewrite /api/runs/batch /runs/batch  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
+            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};

--- a/charts/langsmith/templates/frontend/config-map.yaml
+++ b/charts/langsmith/templates/frontend/config-map.yaml
@@ -77,6 +77,7 @@ data:
         proxy_read_timeout {{ .Values.frontend.proxyReadTimeout }};
         proxy_connect_timeout {{ .Values.frontend.proxyConnectTimeout }};
         proxy_send_timeout {{ .Values.frontend.proxyWriteTimeout }};
+        proxy_request_buffering off;
         keepalive_timeout {{ .Values.frontend.keepAliveTimeout }};
 
         add_header Content-Security-Policy "{{ .Values.frontend.cspHeader }}" always;
@@ -216,7 +217,6 @@ data:
             rewrite /{{ .Values.config.basePath }}/api/v1/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
-            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -226,7 +226,6 @@ data:
             rewrite /{{ .Values.config.basePath }}/api/v1/runs/batch /runs/batch  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
-            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -499,7 +498,6 @@ data:
             rewrite /{{ .Values.config.basePath }}/api/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
-            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -509,7 +507,6 @@ data:
             rewrite /{{ .Values.config.basePath }}/api/runs/batch /runs/batch  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
-            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -681,6 +678,7 @@ data:
         proxy_read_timeout {{ .Values.frontend.proxyReadTimeout }};
         proxy_connect_timeout {{ .Values.frontend.proxyConnectTimeout }};
         proxy_send_timeout {{ .Values.frontend.proxyWriteTimeout }};
+        proxy_request_buffering off;
         keepalive_timeout {{ .Values.frontend.keepAliveTimeout }};
 
         add_header Content-Security-Policy "{{ .Values.frontend.cspHeader }}" always;
@@ -838,7 +836,6 @@ data:
             rewrite /api/v1/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
-            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -848,7 +845,6 @@ data:
             rewrite /api/v1/runs/batch /runs/batch  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
-            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -1050,7 +1046,6 @@ data:
             rewrite /api/runs/multipart /runs/multipart  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
-            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};
@@ -1060,7 +1055,6 @@ data:
             rewrite /api/runs/batch /runs/batch  break;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
-            proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
             proxy_pass http://{{ include "langsmith.fullname" . }}-{{ .Values.platformBackend.name }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.platformBackend.service.port }};

--- a/charts/langsmith/tests/frontend_nginx_test.yaml
+++ b/charts/langsmith/tests/frontend_nginx_test.yaml
@@ -1,41 +1,34 @@
-suite: frontend nginx run ingest proxying
+suite: frontend nginx request buffering
 templates:
   - frontend/config-map.yaml
 tests:
-  - it: streams run ingest bodies to the backend instead of spooling them to disk
+  - it: disables request buffering once at server scope so every route inherits it
     asserts:
       - matchRegex:
           path: data["nginx.conf"]
-          pattern: 'location = /api/v1/runs/multipart \{[^}]*proxy_request_buffering off;'
-      - matchRegex:
+          pattern: 'proxy_send_timeout \d+;\n\s*proxy_request_buffering off;'
+      # inherited from the server block; never repeated per location
+      - notMatchRegex:
           path: data["nginx.conf"]
-          pattern: 'location = /api/v1/runs/batch \{[^}]*proxy_request_buffering off;'
-      - matchRegex:
-          path: data["nginx.conf"]
-          pattern: 'location = /api/runs/multipart \{[^}]*proxy_request_buffering off;'
-      - matchRegex:
-          path: data["nginx.conf"]
-          pattern: 'location = /api/runs/batch \{[^}]*proxy_request_buffering off;'
+          pattern: 'location [^\n]*\{[^}]*proxy_request_buffering'
 
-  - it: streams run ingest bodies when a basePath is configured
+  - it: disables request buffering when a basePath is configured
     set:
       config.basePath: "langsmith"
     asserts:
       - matchRegex:
           path: data["nginx.conf"]
-          pattern: 'location = /langsmith/api/v1/runs/multipart \{[^}]*proxy_request_buffering off;'
-      - matchRegex:
-          path: data["nginx.conf"]
-          pattern: 'location = /langsmith/api/v1/runs/batch \{[^}]*proxy_request_buffering off;'
-      - matchRegex:
-          path: data["nginx.conf"]
-          pattern: 'location = /langsmith/api/runs/multipart \{[^}]*proxy_request_buffering off;'
-      - matchRegex:
-          path: data["nginx.conf"]
-          pattern: 'location = /langsmith/api/runs/batch \{[^}]*proxy_request_buffering off;'
-
-  - it: leaves request buffering on for other proxied routes
-    asserts:
+          pattern: 'proxy_send_timeout \d+;\n\s*proxy_request_buffering off;'
       - notMatchRegex:
           path: data["nginx.conf"]
-          pattern: 'location = /api/v1/runs \{[^}]*proxy_request_buffering off;'
+          pattern: 'location [^\n]*\{[^}]*proxy_request_buffering'
+
+  - it: disables request buffering on the ssl server block
+    set:
+      frontend.ssl.enabled: true
+      frontend.ssl.certificatePath: /certs/tls.crt
+      frontend.ssl.keyPath: /certs/tls.key
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'proxy_send_timeout \d+;\n\s*proxy_request_buffering off;'

--- a/charts/langsmith/tests/frontend_nginx_test.yaml
+++ b/charts/langsmith/tests/frontend_nginx_test.yaml
@@ -1,0 +1,41 @@
+suite: frontend nginx run ingest proxying
+templates:
+  - frontend/config-map.yaml
+tests:
+  - it: streams run ingest bodies to the backend instead of spooling them to disk
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /api/v1/runs/multipart \{[^}]*proxy_request_buffering off;'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /api/v1/runs/batch \{[^}]*proxy_request_buffering off;'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /api/runs/multipart \{[^}]*proxy_request_buffering off;'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /api/runs/batch \{[^}]*proxy_request_buffering off;'
+
+  - it: streams run ingest bodies when a basePath is configured
+    set:
+      config.basePath: "langsmith"
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /langsmith/api/v1/runs/multipart \{[^}]*proxy_request_buffering off;'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /langsmith/api/v1/runs/batch \{[^}]*proxy_request_buffering off;'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /langsmith/api/runs/multipart \{[^}]*proxy_request_buffering off;'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /langsmith/api/runs/batch \{[^}]*proxy_request_buffering off;'
+
+  - it: leaves request buffering on for other proxied routes
+    asserts:
+      - notMatchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /api/v1/runs \{[^}]*proxy_request_buffering off;'


### PR DESCRIPTION
Backport of #933 to `v16-stable`. Chart `0.16.3` → `0.16.4`.

The frontend nginx proxies with request buffering on (the default), so any request body larger than `client_body_buffer_size` (16k on 64-bit, and we set it nowhere) gets spooled to a temp file before it reaches the upstream — a disk write + read per affected request, the full upload duration added to latency, and a warn per request:

```
[warn] a client request body is buffered to a temporary file /var/lib/nginx/tmp/client_body/0000629461, request: "POST /api/v1/runs/multipart HTTP/1.1"
```

This sets `proxy_request_buffering off` once at server scope, alongside `client_max_body_size` and the `proxy_*` timeouts, so every proxied route inherits it. Two lines, both server blocks (`basePath` and non-`basePath` variants).

Not to be confused with `proxy_buffering off`, which is already set per-location: that governs the **response** direction and is load-bearing for streaming responses. `proxy_request_buffering` governs the **request** direction and is invisible to the client either way.

See #933 for the full tradeoff discussion (slow clients, truncated bodies, upstream retry).

### Test plan

- New `charts/langsmith/tests/frontend_nginx_test.yaml` asserts the directive is declared at server scope in the default, `basePath`, and `ssl` renderings, and never repeated inside a location block.
- Verified both assertions fail when they should.
- `helm unittest charts/langsmith` — 24 suites / 307 tests pass on this branch.