### PR TITLE
chore: bump chart version to 0.17.0-rc.6

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.17.0-rc.5
+version: 0.17.0-rc.6
 appVersion: "0.17.1rc1"


### PR DESCRIPTION
## Summary
- Bump `charts/langsmith` `version` from `0.17.0-rc.5` → `0.17.0-rc.6` so Release Charts publishes a pin-able release that includes #931 (SmithDB metastore IAM auth + migrate CLI).
- Leave `appVersion` unchanged (`0.17.1rc1`); images are unchanged.

## Why
#931 merged with `version` still at `0.17.0-rc.5`. Release Charts ran with `CR_SKIP_EXISTING: true` and skipped creating a new GitHub release. Same pattern as #778.

## Test plan
- [ ] Merge triggers Release Charts
- [ ] GitHub release `langsmith-0.17.0-rc.6` is published
- [ ] Chart can be pinned via `spec.langsmith.chartVersion: 0.17.0-rc.6` on a DP


Made with [Cursor](https://cursor.com)