### PR TITLE
chore: bump chart version to 0.17.0-rc.7

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.17.0-rc.6
+version: 0.17.0-rc.7
 appVersion: "0.17.1rc1"


### PR DESCRIPTION
Same situation as #935, one PR later.

## Summary
- Bump `charts/langsmith` `version` from `0.17.0-rc.6` → `0.17.0-rc.7` so Release Charts publishes an artifact that actually contains #933 (disable nginx request buffering).
- `appVersion` unchanged (`0.17.1rc1`); images are unchanged.

## Why
#933 branched from `0.17.0-rc.5` and bumped to `0.17.0-rc.6`. #935 landed the same bump 90 minutes earlier, so the merge auto-resolved with no conflict — but chart-releaser had already published `0.17.0-rc.6` at 18:34, and with `CR_SKIP_EXISTING: true` the release job on my merge exited green while skipping the upload.

Verified against the published tarballs:

| chart | `proxy_request_buffering` occurrences |
|---|---|
| `langsmith-0.17.0-rc.6.tgz` (published 18:34) | 0 |
| `langsmith-0.16.4.tgz` (v16-stable) | 2 |
| `origin/main` working tree | 2 |

So the main line currently has no published chart containing the fix. `v16-stable` is unaffected — `0.16.4` was a fresh version and published correctly.