### PR TITLE
fix: pin v16 sandbox-host image in Helm releases

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.4
+version: 0.16.5
 appVersion: "0.16.36"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.16.3](https://img.shields.io/badge/Version-0.16.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.36](https://img.shields.io/badge/AppVersion-0.16.36-informational?style=flat-square)
+![Version: 0.16.5](https://img.shields.io/badge/Version-0.16.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.36](https://img.shields.io/badge/AppVersion-0.16.36-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -603,7 +603,7 @@ Two things worth planning for before you enable it:
 | images.redisImage.repository | string | `"docker.io/redis"` |  |
 | images.redisImage.tag | string | `"7"` |  |
 | images.registry | string | `""` | If supplied, all children <image_name>.repository values will be prepended with this registry name + `/` |
-| images.sandboxHostImage | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/langchain/sandbox-host","tag":""}` | sandbox-host image. Only used when config.sandboxes.enabled is true. |
+| images.sandboxHostImage | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/langchain/sandbox-host","tag":"0.16.36"}` | sandbox-host image. Only used when config.sandboxes.enabled is true. |
 | images.smithdbImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.smithdbImage.repository | string | `"docker.io/langchain/smithdb"` |  |
 | images.smithdbImage.tag | string | `"0.16.36"` |  |

--- a/charts/langsmith/tests/sandboxes_test.yaml
+++ b/charts/langsmith/tests/sandboxes_test.yaml
@@ -656,6 +656,7 @@ tests:
       sandboxes.juicefs.redis.metaURL: redis://langsmith-redis.default.svc.cluster.local:6379/1
       sandboxes.juicefs.bucket: s3://langsmith-sandboxes-test
       images.sandboxHostImage.repository: example.com/langsmith/sandbox-host
+      images.sandboxHostImage.tag: ""
     template: validate.yaml
     asserts:
       - failedTemplate:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -122,7 +122,7 @@ images:
   sandboxHostImage:
     repository: "docker.io/langchain/sandbox-host"
     pullPolicy: IfNotPresent
-    tag: ""
+    tag: "0.16.36"
   # -- JuiceFS CSI driver image. Only used when config.sandboxes.enabled is true.
   juicefsCSIImage:
     repository: "docker.io/juicedata/juicefs-csi-driver"


### PR DESCRIPTION
## Description
The v16 chart leaves `images.sandboxHostImage.tag` empty while every other LangSmith image uses `0.16.36`, causing sandbox enablement to fail required-tag validation. Align sandbox-host with `0.16.36` and bump the chart to `0.16.5` so a corrected artifact is published.

## Test Plan
- [x] Confirmed `docker.io/langchain/sandbox-host:0.16.36` exists
- [x] Focused sandbox Helm tests (79 passed), chart lint, and packaged-values inspection

Made by [Open SWE](https://openswe.vercel.app/agents/ae905c2a-d184-060f-f666-93c369bbe9ab)