### PR TITLE
feat(langsmith): wire SmithDB Beacon logging and metrics cron flags

### DIFF
--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -681,6 +681,9 @@ Args: root, service, displayName.
 - name: OTEL_EXPORTER_OTLP_PROTOCOL
   value: "grpc"
 {{- end }}
+{{- /* Beacon phone-home for BYOC/self-hosted. BEACON_ENDPOINT / DATA_PLANE_* come from commonEnv. */}}
+- name: BEACON_LOGGING_ENABLED
+  value: {{ $root.Values.config.telemetry.logs | quote }}
 - name: OTEL_SERVICE_NAME
   value: {{ $displayName | quote }}
 - name: OTEL_RESOURCE_ATTRIBUTES

--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -120,6 +120,7 @@ data:
   ENABLE_POSTGRES_METRICS_CRON: {{ ternary "true" "false" .Values.config.telemetry.metrics | quote }}
   ENABLE_REDIS_METRICS_CRON: {{ ternary "true" "false" .Values.config.telemetry.metrics | quote }}
   ENABLE_CLICKHOUSE_METRICS_CRON: {{ and .Values.clickhouse.enabled .Values.config.telemetry.metrics | quote }}
+  ENABLE_SMITHDB_METRICS_CRON: {{ and .Values.smithdb.enabled .Values.config.telemetry.metrics | quote }}
   BEACON_LOGGING_ENABLED: {{ ternary "true" "false" .Values.config.telemetry.logs | quote }}
   BEACON_METRICS_ENABLED: {{ ternary "true" "false" .Values.config.telemetry.metrics | quote }}
   BEACON_TRACING_ENABLED: {{ ternary "true" "false" .Values.config.telemetry.traces | quote }}


### PR DESCRIPTION
## Summary
- Set `BEACON_LOGGING_ENABLED` on SmithDB pods from `config.telemetry.logs` (`BEACON_ENDPOINT` / data-plane creds still come from `commonEnv`).
- Set `ENABLE_SMITHDB_METRICS_CRON` in the config map when SmithDB and metrics telemetry are enabled.
- Companion PRs: smithdb (OTLP/HTTP log exporter), langchainplus (metrics scrape), deployments (allowlist + BYOC composition).

## Test Plan
- [ ] Render chart with `smithdb.enabled=true` and `config.telemetry.logs/metrics=true`; confirm env/config-map flags
- [ ] Render with SmithDB disabled; confirm metrics cron flag stays false


Made with [Cursor](https://cursor.com)