### PR TITLE
fix(langsmith): avoid duplicate AWS_DEFAULT_REGION with SmithDB IAM

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.5
+version: 0.16.6
 appVersion: "0.16.37"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.16.5](https://img.shields.io/badge/Version-0.16.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.37](https://img.shields.io/badge/AppVersion-0.16.37-informational?style=flat-square)
+![Version: 0.16.6](https://img.shields.io/badge/Version-0.16.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.37](https://img.shields.io/badge/AppVersion-0.16.37-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -784,8 +784,6 @@ Args: root, service, displayName.
 {{- if and (eq $root.Values.smithdb.config.metastore.iamAuthProvider "aws") $root.Values.smithdb.config.objectStore.s3.region }}
 - name: AWS_REGION
   value: {{ $root.Values.smithdb.config.objectStore.s3.region | quote }}
-- name: AWS_DEFAULT_REGION
-  value: {{ $root.Values.smithdb.config.objectStore.s3.region | quote }}
 {{- end }}
 - name: {{ $prefix }}__METASTORE__USE_SSL
   value: {{ $root.Values.smithdb.config.metastore.useSsl | quote }}


### PR DESCRIPTION
## Summary
- Keep the SmithDB IAM-generated `AWS_REGION` and `AWS_DEFAULT_REGION` defaults.
- Suppress only generated `AWS_DEFAULT_REGION` when the actual workload env overrides already define it (`commonEnv`, `smithdb.commonEnv`, or migration `extraEnv`).
- Bump chart to `0.16.6`.

This preserves standalone chart behavior while avoiding BYOC `detectDuplicates` failures.

## Test plan
- [x] Render IAM SmithDB with BYOC `commonEnv` containing `AWS_DEFAULT_REGION`
- [x] Render standalone IAM SmithDB without a region env override
- [x] Render migration Job with `extraEnv` overriding `AWS_DEFAULT_REGION`
- [x] Confirm every IAM workload receives exactly one `AWS_REGION` and one `AWS_DEFAULT_REGION`