### PR TITLE
fix(langsmith): avoid duplicate AWS_DEFAULT_REGION with SmithDB IAM

### DIFF
--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -778,8 +778,6 @@ Args: root, service, displayName.
 {{- if and (eq $root.Values.smithdb.config.metastore.iamAuthProvider "aws") $root.Values.smithdb.config.objectStore.s3.region }}
 - name: AWS_REGION
   value: {{ $root.Values.smithdb.config.objectStore.s3.region | quote }}
-- name: AWS_DEFAULT_REGION
-  value: {{ $root.Values.smithdb.config.objectStore.s3.region | quote }}
 {{- end }}
 - name: {{ $prefix }}__METASTORE__USE_SSL
   value: {{ $root.Values.smithdb.config.metastore.useSsl | quote }}

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -611,11 +611,12 @@ Args: root, service, displayName.
 {{- define "langsmith.smithdb.componentEnv" -}}
 {{- $root := .root -}}
 {{- $service := .service -}}
-{{- $envVars := include "langsmith.smithdb.serviceEnv" (dict "root" $root "service" $service "displayName" .displayName) | fromYamlArray -}}
+{{- $envOverrides := concat $root.Values.commonEnv $root.Values.smithdb.commonEnv -}}
+{{- $envVars := include "langsmith.smithdb.serviceEnv" (dict "root" $root "service" $service "displayName" .displayName "envOverrides" $envOverrides) | fromYamlArray -}}
 {{- if $root.Values.smithdb.enabled }}
 {{- $envVars = concat $envVars (include "langsmith.smithdb.clusterManagerClientEnv" (dict "root" $root "service" $service) | fromYamlArray) -}}
 {{- end }}
-{{- $envVars = concat $envVars $root.Values.commonEnv $root.Values.smithdb.commonEnv -}}
+{{- $envVars = concat $envVars $envOverrides -}}
 {{- toYaml $envVars }}
 {{- end }}
 
@@ -775,9 +776,17 @@ Args: root, service, displayName.
 - name: {{ $prefix }}__METASTORE__IAM_AUTH_PROVIDER
   value: {{ . | quote }}
 {{- end }}
+{{- $envOverrideKeys := list -}}
+{{- range $envVar := .envOverrides | default (list) -}}
+{{- $envOverrideKeys = append $envOverrideKeys $envVar.name -}}
+{{- end }}
 {{- if and (eq $root.Values.smithdb.config.metastore.iamAuthProvider "aws") $root.Values.smithdb.config.objectStore.s3.region }}
 - name: AWS_REGION
   value: {{ $root.Values.smithdb.config.objectStore.s3.region | quote }}
+{{- if not (has "AWS_DEFAULT_REGION" $envOverrideKeys) }}
+- name: AWS_DEFAULT_REGION
+  value: {{ $root.Values.smithdb.config.objectStore.s3.region | quote }}
+{{- end }}
 {{- end }}
 - name: {{ $prefix }}__METASTORE__USE_SSL
   value: {{ $root.Values.smithdb.config.metastore.useSsl | quote }}

--- a/charts/langsmith/templates/smithdb/metastore-migration.yaml
+++ b/charts/langsmith/templates/smithdb/metastore-migration.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.smithdb.enabled }}
-{{- $envVars := concat (include "langsmith.smithdb.serviceEnv" (dict "root" . "service" "METASTORE_MIGRATE" "displayName" "smithdb-metastore-migrate") | fromYamlArray) .Values.smithdb.metastoreMigration.job.extraEnv -}}
+{{- $envOverrides := .Values.smithdb.metastoreMigration.job.extraEnv -}}
+{{- $envVars := concat (include "langsmith.smithdb.serviceEnv" (dict "root" . "service" "METASTORE_MIGRATE" "displayName" "smithdb-metastore-migrate" "envOverrides" $envOverrides) | fromYamlArray) $envOverrides -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: batch/v1
 kind: Job


### PR DESCRIPTION
## Summary
- Keep the SmithDB IAM-generated `AWS_REGION` and `AWS_DEFAULT_REGION` defaults.
- Suppress only generated `AWS_DEFAULT_REGION` when the actual workload env overrides already define it (`commonEnv`, `smithdb.commonEnv`, or migration `extraEnv`).

This preserves standalone chart behavior while avoiding BYOC `detectDuplicates` failures.

## Test plan
- [x] Render IAM SmithDB with BYOC `commonEnv` containing `AWS_DEFAULT_REGION`
- [x] Render standalone IAM SmithDB without a region env override
- [x] Render migration Job with `extraEnv` overriding `AWS_DEFAULT_REGION`
- [x] Confirm every IAM workload receives exactly one `AWS_REGION` and one `AWS_DEFAULT_REGION`