### PR TITLE
fix(langsmith): skip SmithDB AWS region env if commonEnv sets it

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.5
+version: 0.16.6
 appVersion: "0.16.37"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.16.5](https://img.shields.io/badge/Version-0.16.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.37](https://img.shields.io/badge/AppVersion-0.16.37-informational?style=flat-square)
+![Version: 0.16.6](https://img.shields.io/badge/Version-0.16.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.37](https://img.shields.io/badge/AppVersion-0.16.37-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -617,11 +617,12 @@ Args: root, service, displayName.
 {{- define "langsmith.smithdb.componentEnv" -}}
 {{- $root := .root -}}
 {{- $service := .service -}}
-{{- $envVars := include "langsmith.smithdb.serviceEnv" (dict "root" $root "service" $service "displayName" .displayName) | fromYamlArray -}}
+{{- $envOverrides := concat $root.Values.commonEnv $root.Values.smithdb.commonEnv -}}
+{{- $envVars := include "langsmith.smithdb.serviceEnv" (dict "root" $root "service" $service "displayName" .displayName "envOverrides" $envOverrides) | fromYamlArray -}}
 {{- if $root.Values.smithdb.enabled }}
 {{- $envVars = concat $envVars (include "langsmith.smithdb.clusterManagerClientEnv" (dict "root" $root "service" $service) | fromYamlArray) -}}
 {{- end }}
-{{- $envVars = concat $envVars $root.Values.commonEnv $root.Values.smithdb.commonEnv -}}
+{{- $envVars = concat $envVars $envOverrides -}}
 {{- toYaml $envVars }}
 {{- end }}
 
@@ -781,11 +782,19 @@ Args: root, service, displayName.
 - name: {{ $prefix }}__METASTORE__IAM_AUTH_PROVIDER
   value: {{ . | quote }}
 {{- end }}
+{{- $envOverrideKeys := list -}}
+{{- range $envVar := .envOverrides | default (list) -}}
+{{- $envOverrideKeys = append $envOverrideKeys $envVar.name -}}
+{{- end }}
 {{- if and (eq $root.Values.smithdb.config.metastore.iamAuthProvider "aws") $root.Values.smithdb.config.objectStore.s3.region }}
+{{- if not (has "AWS_REGION" $envOverrideKeys) }}
 - name: AWS_REGION
   value: {{ $root.Values.smithdb.config.objectStore.s3.region | quote }}
+{{- end }}
+{{- if not (has "AWS_DEFAULT_REGION" $envOverrideKeys) }}
 - name: AWS_DEFAULT_REGION
   value: {{ $root.Values.smithdb.config.objectStore.s3.region | quote }}
+{{- end }}
 {{- end }}
 - name: {{ $prefix }}__METASTORE__USE_SSL
   value: {{ $root.Values.smithdb.config.metastore.useSsl | quote }}

--- a/charts/langsmith/templates/smithdb/metastore-migration.yaml
+++ b/charts/langsmith/templates/smithdb/metastore-migration.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.smithdb.enabled }}
-{{- $envVars := concat (include "langsmith.smithdb.serviceEnv" (dict "root" . "service" "METASTORE_MIGRATE" "displayName" "smithdb-metastore-migrate") | fromYamlArray) .Values.smithdb.metastoreMigration.job.extraEnv -}}
+{{- $envOverrides := .Values.smithdb.metastoreMigration.job.extraEnv -}}
+{{- $envVars := concat (include "langsmith.smithdb.serviceEnv" (dict "root" . "service" "METASTORE_MIGRATE" "displayName" "smithdb-metastore-migrate" "envOverrides" $envOverrides) | fromYamlArray) $envOverrides -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: batch/v1
 kind: Job

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -97,6 +97,85 @@ tests:
             name: SMITHDB_METASTORE_MIGRATE__METASTORE__USE_SSL
             value: "true"
 
+  - it: skips chart AWS_DEFAULT_REGION when commonEnv already sets it
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      commonEnv:
+        - name: AWS_DEFAULT_REGION
+          value: us-east-2
+        - name: COMMON_CUSTOM_ENV
+          value: keep-me
+      smithdb.config.metastore.iamAuthProvider: aws
+      smithdb.config.metastore.useSsl: true
+      smithdb.config.metastore.passwordSecretKey: ""
+      smithdb.config.objectStore.s3.region: us-west-1
+    template: smithdb/query-deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_DEFAULT_REGION
+            value: us-east-2
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_REGION
+            value: us-west-1
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_DEFAULT_REGION
+            value: us-west-1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: COMMON_CUSTOM_ENV
+            value: keep-me
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_QUERY__METASTORE__IAM_AUTH_PROVIDER
+            value: aws
+
+  - it: skips chart AWS region env when metastore migrate extraEnv already sets it
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.metastoreMigration.job.extraEnv:
+        - name: AWS_DEFAULT_REGION
+          value: us-east-2
+        - name: MIGRATE_CUSTOM_ENV
+          value: keep-me
+      smithdb.config.metastore.iamAuthProvider: aws
+      smithdb.config.metastore.useSsl: true
+      smithdb.config.metastore.passwordSecretKey: ""
+      smithdb.config.objectStore.s3.region: us-west-1
+    template: smithdb/metastore-migration.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_DEFAULT_REGION
+            value: us-east-2
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_REGION
+            value: us-west-1
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_DEFAULT_REGION
+            value: us-west-1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MIGRATE_CUSTOM_ENV
+            value: keep-me
+
   - it: should size the SmithDB query disk cache from its ephemeral storage limit
     values:
       - ./values/smithdb-enabled.yaml


### PR DESCRIPTION
## Summary
- Backport of https://github.com/langchain-ai/helm/pull/938 to `v16-stable`.
- When `metastore.iamAuthProvider=aws`, emit `AWS_REGION` / `AWS_DEFAULT_REGION` from `objectStore.s3.region` only if that key is not already set in `commonEnv` / `smithdb.commonEnv` (or metastore migrate `extraEnv`).
- Chart bump `0.16.5` → `0.16.6`.

## Test plan
- [x] Unittest: commonEnv `AWS_DEFAULT_REGION` kept; chart still emits `AWS_REGION`
- [x] Unittest: migrate `extraEnv` override skips chart `AWS_DEFAULT_REGION`
- [x] `helm unittest charts/langsmith -f tests/langsmith_smithdb_test.yaml`
- [ ] CI lint/unittest