### PR TITLE
fix(langsmith): use native GCS for migration source reads

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.5
+version: 0.16.6
 appVersion: "0.16.37"

--- a/charts/langsmith/templates/smithdb/migration-job.yaml
+++ b/charts/langsmith/templates/smithdb/migration-job.yaml
@@ -2,7 +2,6 @@
 {{- $envVars := concat (include "langsmith.smithdb.componentEnv" (dict "root" . "service" "MIGRATION" "displayName" "smithdb-migration") | fromYamlArray) .Values.smithdb.migration.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
 {{- $blobStorage := .Values.config.blobStorage -}}
-{{- $blobStorageEngine := lower $blobStorage.engine -}}
 {{- $smithdbObjectStore := .Values.smithdb.config.objectStore -}}
 {{- $smithdbObjectStoreType := lower (default "s3" $smithdbObjectStore.type) -}}
 apiVersion: batch/v1
@@ -157,7 +156,7 @@ spec:
                   optional: {{ .Values.config.disableSecretCreation }}
             - name: SMITHDB_MIGRATION__BLOB_PREFIX_PATTERN
               value: "__none__"
-            {{- if and $blobStorage.enabled (eq $blobStorageEngine "s3") }}
+            {{- if and $blobStorage.enabled (eq (lower $blobStorage.engine) "s3") }}
             - name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__TYPE
               value: "s3"
             - name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__S3__BUCKET
@@ -180,7 +179,7 @@ spec:
                   name: {{ include "langsmith.secretsName" . }}
                   key: blob_storage_access_key_secret
                   optional: true
-            {{- else if and $blobStorage.enabled (eq $blobStorageEngine "gcs") }}
+            {{- else if and $blobStorage.enabled (eq (lower $blobStorage.engine) "gcs") }}
             - name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__TYPE
               value: "gcs"
             - name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__GCS__BUCKET

--- a/charts/langsmith/templates/smithdb/migration-job.yaml
+++ b/charts/langsmith/templates/smithdb/migration-job.yaml
@@ -2,6 +2,7 @@
 {{- $envVars := concat (include "langsmith.smithdb.componentEnv" (dict "root" . "service" "MIGRATION" "displayName" "smithdb-migration") | fromYamlArray) .Values.smithdb.migration.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
 {{- $blobStorage := .Values.config.blobStorage -}}
+{{- $blobStorageEngine := lower $blobStorage.engine -}}
 {{- $smithdbObjectStore := .Values.smithdb.config.objectStore -}}
 {{- $smithdbObjectStoreType := lower (default "s3" $smithdbObjectStore.type) -}}
 apiVersion: batch/v1
@@ -156,7 +157,7 @@ spec:
                   optional: {{ .Values.config.disableSecretCreation }}
             - name: SMITHDB_MIGRATION__BLOB_PREFIX_PATTERN
               value: "__none__"
-            {{- if and $blobStorage.enabled (or (eq (lower $blobStorage.engine) "s3") (eq (lower $blobStorage.engine) "gcs")) }}
+            {{- if and $blobStorage.enabled (eq $blobStorageEngine "s3") }}
             - name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__TYPE
               value: "s3"
             - name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__S3__BUCKET
@@ -179,6 +180,13 @@ spec:
                   name: {{ include "langsmith.secretsName" . }}
                   key: blob_storage_access_key_secret
                   optional: true
+            {{- else if and $blobStorage.enabled (eq $blobStorageEngine "gcs") }}
+            - name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__TYPE
+              value: "gcs"
+            - name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__GCS__BUCKET
+              value: {{ $blobStorage.bucketName | quote }}
+            - name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__GCS__ROOT_FOLDER
+              value: "/"
             {{- end }}
             - name: SMITHDB_MIGRATION__OUTPUT__OBJECT_STORE__TYPE
               value: {{ $smithdbObjectStoreType | quote }}

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -911,6 +911,43 @@ tests:
                 name: RELEASE-NAME-langsmith-smithdb-taskdb-postgres
                 key: postgres_password
 
+  - it: should use native GCS for migration source blobs with workload identity
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      config.blobStorage.enabled: true
+      config.blobStorage.engine: GCS
+      config.blobStorage.bucketName: langsmith-gcs-blob
+      config.blobStorage.apiURL: https://storage.googleapis.com
+      smithdb.langsmith.migration.enabled: true
+      smithdb.langsmith.query.enabled: false
+      smithdb.migration.taskdb.postgres.auth.password: taskdb-password
+    template: smithdb/migration-job.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__TYPE
+            value: gcs
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__GCS__BUCKET
+            value: langsmith-gcs-blob
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__GCS__ROOT_FOLDER
+            value: /
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__S3__BUCKET
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__S3__ACCESS_KEY_ID
+
   - it: should configure smithdb migration parallelism
     values:
       - ./values/smithdb-enabled.yaml


### PR DESCRIPTION
## Summary
- configure migration source reads from the selected LangSmith blob-storage provider
- use SmithDB's native GCS client so ADC and Workload Identity can authenticate reads
- preserve the existing S3 source configuration

## Test Plan
- [x] Verify GCS migration rendering uses native GCS variables and omits S3 credentials
- [x] Run the SmithDB Helm unit-test suite and chart lint

Made with [Cursor](https://cursor.com)