### PR TITLE
fix(langsmith): pass blob S3 region to SmithDB migration

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.17.0-rc.6
+version: 0.17.0-rc.7
 appVersion: "0.17.1rc1"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.17.0-rc.5](https://img.shields.io/badge/Version-0.17.0--rc.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.1rc1](https://img.shields.io/badge/AppVersion-0.17.1rc1-informational?style=flat-square)
+![Version: 0.17.0-rc.7](https://img.shields.io/badge/Version-0.17.0--rc.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.1rc1](https://img.shields.io/badge/AppVersion-0.17.1rc1-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -1339,6 +1339,7 @@ For information on how to use this chart, up-to-date release notes, and other gu
 | config.blobStorage.kmsEncryptionEnabled | bool | `false` |  |
 | config.blobStorage.kmsKeyArn | string | `""` |  |
 | config.blobStorage.minBlobStorageSizeKb | string | `"20"` |  |
+| config.blobStorage.region | string | `""` | AWS region for S3 request signing. |
 | config.blobStorage.s3UsePathStyle | bool | `false` |  |
 | config.customCa.secretKey | string | `""` |  |
 | config.customCa.secretName | string | `""` | Optional. Used to set a file containing trusted CA certificates. Make sure to also include a public CA to access beacon and playground. |

--- a/charts/langsmith/templates/smithdb/migration-job.yaml
+++ b/charts/langsmith/templates/smithdb/migration-job.yaml
@@ -167,6 +167,10 @@ spec:
               value: {{ $blobStorage.apiURL | quote }}
             - name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__S3__ALLOW_HTTP
               value: {{ hasPrefix "http://" $blobStorage.apiURL | quote }}
+            {{- with $blobStorage.region }}
+            - name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__S3__REGION
+              value: {{ . | quote }}
+            {{- end }}
             - name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__S3__ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -709,6 +709,7 @@ tests:
       config.blobStorage.enabled: true
       config.blobStorage.bucketName: langsmith-blob
       config.blobStorage.apiURL: http://blob-store:9000
+      config.blobStorage.region: us-west-2
       smithdb.langsmith.migration.enabled: true
       smithdb.langsmith.query.enabled: false
       smithdb.migration.taskdb.postgres.enabled: true
@@ -799,6 +800,12 @@ tests:
           content:
             name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__S3__BUCKET
             value: langsmith-blob
+      - template: smithdb/migration-job.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__S3__REGION
+            value: us-west-2
       - template: smithdb/migration-job.yaml
         notContains:
           path: spec.template.spec.containers[0].env

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1191,6 +1191,8 @@ config:
     bucketName: ""
     # For GCS, set this to "https://storage.googleapis.com"
     apiURL: "https://s3.us-west-2.amazonaws.com"
+    # -- AWS region for S3 request signing.
+    region: ""
     # Set this to true to use path style addressing for S3. This is required for some S3 compatible storage providers like MinIO.
     # If set to true, endpoint will be s3.<region>.amazonaws.com/bucket-name. If false, endpoint will be bucket-name.s3.<region>.amazonaws.com
     s3UsePathStyle: false


### PR DESCRIPTION
Expose the LangSmith blob-store region and pass it to migration so S3 requests are signed for the bucket's actual region.