### PR TITLE
fix: size TaskDB max_connections from migration parallelism

### DIFF
--- a/charts/langsmith/templates/smithdb/migration-job.yaml
+++ b/charts/langsmith/templates/smithdb/migration-job.yaml
@@ -79,6 +79,8 @@ spec:
               value: {{ .Values.smithdb.migration.containerPort | quote }}
             {{- if .Values.smithdb.migration.taskdb.postgres.enabled }}
             {{- $taskdb := .Values.smithdb.migration.taskdb.postgres }}
+            - name: SMITHDB_MIGRATION__TASKDB__MAX_CONNECTIONS
+              value: {{ $taskdb.maxConnectionsPerMigrationPod | quote }}
             {{- if $taskdb.external.enabled }}
             - name: SMITHDB_MIGRATION__TASKDB__HOST
               valueFrom:

--- a/charts/langsmith/templates/smithdb/taskdb-postgres-statefulset.yaml
+++ b/charts/langsmith/templates/smithdb/taskdb-postgres-statefulset.yaml
@@ -1,4 +1,5 @@
 {{- $taskdb := .Values.smithdb.migration.taskdb.postgres -}}
+{{- $maxConnections := mul (add (int .Values.smithdb.migration.job.parallelism) 1) (int $taskdb.maxConnectionsPerMigrationPod) -}}
 {{- if and .Values.smithdb.enabled .Values.smithdb.langsmith.migration.enabled $taskdb.enabled (not $taskdb.external.enabled) }}
 {{- $envVars := concat .Values.commonEnv $taskdb.statefulSet.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
@@ -66,6 +67,9 @@ spec:
           command:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          args:
+            - "-c"
+            - "max_connections={{ $maxConnections }}"
           env:
             - name: POSTGRES_DB
               value: {{ $taskdb.auth.database | quote }}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -425,6 +425,9 @@ AWS Marketplace Helm template verification).
 {{- if lt (int .Values.smithdb.migration.job.parallelism) 1 -}}
 {{- fail "smithdb.migration.job.parallelism must be greater than 0 when smithdb migration is enabled." -}}
 {{- end -}}
+{{- if gt (int .Values.smithdb.migration.job.parallelism) 20 -}}
+{{- fail "smithdb.migration.job.parallelism must be at most 20. Beyond that, scale TaskDB vertically (CPU/memory) rather than increasing migration Job parallelism further." -}}
+{{- end -}}
 {{- if lt (int $taskdb.maxConnectionsPerMigrationPod) 1 -}}
 {{- fail "smithdb.migration.taskdb.postgres.maxConnectionsPerMigrationPod must be greater than 0." -}}
 {{- end -}}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -422,6 +422,12 @@ AWS Marketplace Helm template verification).
 {{- end -}}
 {{- $taskdb := .Values.smithdb.migration.taskdb.postgres -}}
 {{- if and .Values.smithdb.langsmith.migration.enabled $taskdb.enabled -}}
+{{- if lt (int .Values.smithdb.migration.job.parallelism) 1 -}}
+{{- fail "smithdb.migration.job.parallelism must be greater than 0 when smithdb migration is enabled." -}}
+{{- end -}}
+{{- if lt (int $taskdb.maxConnectionsPerMigrationPod) 1 -}}
+{{- fail "smithdb.migration.taskdb.postgres.maxConnectionsPerMigrationPod must be greater than 0." -}}
+{{- end -}}
 {{- if $taskdb.external.enabled -}}
 {{- if not $taskdb.external.port -}}
 {{- fail "smithdb.migration.taskdb.postgres.external.port is required when smithdb.migration.taskdb.postgres.external.enabled is true." -}}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -425,9 +425,6 @@ AWS Marketplace Helm template verification).
 {{- if lt (int .Values.smithdb.migration.job.parallelism) 1 -}}
 {{- fail "smithdb.migration.job.parallelism must be greater than 0 when smithdb migration is enabled." -}}
 {{- end -}}
-{{- if gt (int .Values.smithdb.migration.job.parallelism) 20 -}}
-{{- fail "smithdb.migration.job.parallelism must be at most 20. Beyond that, scale TaskDB vertically (CPU/memory) rather than increasing migration Job parallelism further." -}}
-{{- end -}}
 {{- if lt (int $taskdb.maxConnectionsPerMigrationPod) 1 -}}
 {{- fail "smithdb.migration.taskdb.postgres.maxConnectionsPerMigrationPod must be greater than 0." -}}
 {{- end -}}

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -783,7 +783,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: SMITHDB_MIGRATION__TASKDB__MAX_CONNECTIONS
-            value: "20"
+            value: "25"
       - template: smithdb/migration-job.yaml
         contains:
           path: spec.template.spec.containers[0].env
@@ -886,7 +886,7 @@ tests:
           path: spec.template.spec.containers[0].args
           value:
             - "-c"
-            - "max_connections=40"
+            - "max_connections=50"
       - template: smithdb/taskdb-postgres-statefulset.yaml
         equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
@@ -981,7 +981,7 @@ tests:
           path: spec.template.spec.containers[0].args
           value:
             - "-c"
-            - "max_connections=120"
+            - "max_connections=150"
 
   - it: should allow retaining the taskdb PVC when the StatefulSet is deleted
     values:

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -783,7 +783,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: SMITHDB_MIGRATION__TASKDB__MAX_CONNECTIONS
-            value: "25"
+            value: "10"
       - template: smithdb/migration-job.yaml
         contains:
           path: spec.template.spec.containers[0].env
@@ -886,7 +886,7 @@ tests:
           path: spec.template.spec.containers[0].args
           value:
             - "-c"
-            - "max_connections=50"
+            - "max_connections=20"
       - template: smithdb/taskdb-postgres-statefulset.yaml
         equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
@@ -981,7 +981,7 @@ tests:
           path: spec.template.spec.containers[0].args
           value:
             - "-c"
-            - "max_connections=150"
+            - "max_connections=60"
 
   - it: should allow retaining the taskdb PVC when the StatefulSet is deleted
     values:

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -782,6 +782,12 @@ tests:
         contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: SMITHDB_MIGRATION__TASKDB__MAX_CONNECTIONS
+            value: "20"
+      - template: smithdb/migration-job.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: SMITHDB_MIGRATION__TASKDB__PORT
             value: "5433"
       - template: smithdb/migration-job.yaml
@@ -877,6 +883,12 @@ tests:
           value: 50Gi
       - template: smithdb/taskdb-postgres-statefulset.yaml
         equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - "-c"
+            - "max_connections=40"
+      - template: smithdb/taskdb-postgres-statefulset.yaml
+        equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 5433
       - template: smithdb/taskdb-postgres-statefulset.yaml
@@ -956,11 +968,20 @@ tests:
       smithdb.langsmith.query.enabled: false
       smithdb.migration.job.parallelism: 5
       smithdb.migration.taskdb.postgres.auth.password: taskdb-password
-    template: smithdb/migration-job.yaml
+    templates:
+      - smithdb/migration-job.yaml
+      - smithdb/taskdb-postgres-statefulset.yaml
     asserts:
-      - equal:
+      - template: smithdb/migration-job.yaml
+        equal:
           path: spec.parallelism
           value: 5
+      - template: smithdb/taskdb-postgres-statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - "-c"
+            - "max_connections=120"
 
   - it: should allow retaining the taskdb PVC when the StatefulSet is deleted
     values:

--- a/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
@@ -49,18 +49,6 @@ tests:
       - failedTemplate:
           errorMessage: "smithdb.migration.job.parallelism must be greater than 0 when smithdb migration is enabled."
 
-  - it: should reject migration parallelism above 20
-    values:
-      - ./values/smithdb-enabled.yaml
-    set:
-      config.existingSecretName: langsmith-secret
-      smithdb.langsmith.query.enabled: false
-      smithdb.langsmith.migration.enabled: true
-      smithdb.migration.job.parallelism: 21
-    asserts:
-      - failedTemplate:
-          errorMessage: "smithdb.migration.job.parallelism must be at most 20. Beyond that, scale TaskDB vertically (CPU/memory) rather than increasing migration Job parallelism further."
-
   - it: should reject non-positive taskdb connections per migration pod
     values:
       - ./values/smithdb-enabled.yaml

--- a/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
@@ -37,6 +37,30 @@ tests:
       - failedTemplate:
           errorMessage: "smithdb.migration.taskdb.postgres.auth.password is required when smithdb.migration.taskdb.postgres.enabled is true and auth.existingSecretName is not set."
 
+  - it: should reject non-positive migration parallelism
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      config.existingSecretName: langsmith-secret
+      smithdb.langsmith.query.enabled: false
+      smithdb.langsmith.migration.enabled: true
+      smithdb.migration.job.parallelism: 0
+    asserts:
+      - failedTemplate:
+          errorMessage: "smithdb.migration.job.parallelism must be greater than 0 when smithdb migration is enabled."
+
+  - it: should reject non-positive taskdb connections per migration pod
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      config.existingSecretName: langsmith-secret
+      smithdb.langsmith.query.enabled: false
+      smithdb.langsmith.migration.enabled: true
+      smithdb.migration.taskdb.postgres.maxConnectionsPerMigrationPod: 0
+    asserts:
+      - failedTemplate:
+          errorMessage: "smithdb.migration.taskdb.postgres.maxConnectionsPerMigrationPod must be greater than 0."
+
   - it: should reject external taskdb postgres without a password
     values:
       - ./values/smithdb-enabled.yaml

--- a/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
@@ -49,6 +49,18 @@ tests:
       - failedTemplate:
           errorMessage: "smithdb.migration.job.parallelism must be greater than 0 when smithdb migration is enabled."
 
+  - it: should reject migration parallelism above 20
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      config.existingSecretName: langsmith-secret
+      smithdb.langsmith.query.enabled: false
+      smithdb.langsmith.migration.enabled: true
+      smithdb.migration.job.parallelism: 21
+    asserts:
+      - failedTemplate:
+          errorMessage: "smithdb.migration.job.parallelism must be at most 20. Beyond that, scale TaskDB vertically (CPU/memory) rather than increasing migration Job parallelism further."
+
   - it: should reject non-positive taskdb connections per migration pod
     values:
       - ./values/smithdb-enabled.yaml

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1849,6 +1849,8 @@ smithdb:
       # -- Keep finished migrate-all Jobs around for seven days so operators can inspect status/logs.
       ttlSecondsAfterFinished: 604800
       # -- Maximum number of migration pods that run concurrently.
+      # -- Capped at 20 by chart validation. Beyond that, scale TaskDB vertically (CPU/memory)
+      # -- rather than adding more migration pods.
       parallelism: 1
       # -- Retry failed migrate-all pods up to this many times before marking the Job failed.
       backoffLimit: 3
@@ -1860,9 +1862,10 @@ smithdb:
         # -- Enable Postgres for SmithDB migration task state. This is a separate database from
         # -- both the main LangSmith Postgres and the SmithDB metastore.
         enabled: true
-        # -- Maximum TaskDB connections opened by each migration pod. The chart-managed Postgres
-        # -- server allows this many connections for every parallel pod plus one pod of headroom.
-        maxConnectionsPerMigrationPod: 25
+        # -- Maximum TaskDB connections opened by each migration pod. Sized for concurrent short
+        # -- Postgres ops, not worker count. The chart-managed Postgres server allows this many
+        # -- connections for every parallel pod plus one pod of headroom.
+        maxConnectionsPerMigrationPod: 10
         name: "taskdb-postgres"
         containerPort: 5433
         # -- Credentials for the in-chart taskdb Postgres instance. Used only when external.enabled is false.

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1860,6 +1860,9 @@ smithdb:
         # -- Enable Postgres for SmithDB migration task state. This is a separate database from
         # -- both the main LangSmith Postgres and the SmithDB metastore.
         enabled: true
+        # -- Maximum TaskDB connections opened by each migration pod. The chart-managed Postgres
+        # -- server allows this many connections for every parallel pod plus one pod of headroom.
+        maxConnectionsPerMigrationPod: 20
         name: "taskdb-postgres"
         containerPort: 5433
         # -- Credentials for the in-chart taskdb Postgres instance. Used only when external.enabled is false.

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1862,7 +1862,7 @@ smithdb:
         enabled: true
         # -- Maximum TaskDB connections opened by each migration pod. The chart-managed Postgres
         # -- server allows this many connections for every parallel pod plus one pod of headroom.
-        maxConnectionsPerMigrationPod: 20
+        maxConnectionsPerMigrationPod: 25
         name: "taskdb-postgres"
         containerPort: 5433
         # -- Credentials for the in-chart taskdb Postgres instance. Used only when external.enabled is false.

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1849,8 +1849,8 @@ smithdb:
       # -- Keep finished migrate-all Jobs around for seven days so operators can inspect status/logs.
       ttlSecondsAfterFinished: 604800
       # -- Maximum number of migration pods that run concurrently.
-      # -- Capped at 20 by chart validation. Beyond that, scale TaskDB vertically (CPU/memory)
-      # -- rather than adding more migration pods.
+      # -- Above ~20, prefer scaling TaskDB vertically (CPU/memory) rather than adding more
+      # -- migration pods.
       parallelism: 1
       # -- Retry failed migrate-all pods up to this many times before marking the Job failed.
       backoffLimit: 3


### PR DESCRIPTION
## Description

Apply the TaskDB connection sizing fix to v16-stable so chart-managed PostgreSQL `max_connections` scales with migration parallelism and per-pod pool size.

Follow-up adjustments (mirrors https://github.com/langchain-ai/helm/pull/956):
- Default `maxConnectionsPerMigrationPod` is **10** (short concurrent TaskDB ops, not worker count).
- Above ~20 Job parallelism, prefer scaling TaskDB vertically (CPU/memory). Guidance only; not a hard fail.

## Release Note

Chart-managed TaskDB PostgreSQL now sizes `max_connections` for migration parallelism and defaults the per-pod pool to 10.

## Test plan

- [x] `helm template` with parallelism=5 renders `max_connections=60`
- [x] Parallelism above 20 no longer fails chart validation
- [ ] `helm lint charts/langsmith`
- [ ] `helm unittest --color=false charts/langsmith`