### PR TITLE
feat: derive SmithDB migration sizing from limits

### DIFF
--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -505,6 +505,28 @@ Template containing common environment variables that are used by several servic
 {{- end }}
 {{- end }}
 
+{{/* Scale a Kubernetes memory quantity to 75% and format it for SmithDB. */}}
+{{- define "langsmith.smithdb.memoryQuota" -}}
+{{- $limit := toString . -}}
+{{- $numberPattern := `(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)` -}}
+{{- $quantityPattern := printf "^%s(?:Ki|Mi|Gi|Ti|Pi|Ei|[kKMGTPE])?$" $numberPattern -}}
+{{- if regexMatch $quantityPattern $limit -}}
+{{- $amountText := regexFind (printf "^%s" $numberPattern) $limit -}}
+{{- $unit := trimPrefix $amountText $limit -}}
+{{- $amount := mulf (float64 $amountText) 0.75 -}}
+{{- if eq $unit "" -}}
+{{- printf "%.0f" (ceil $amount) -}}
+{{- else -}}
+{{- $byteSizeUnits := dict "k" "kB" "K" "KB" "M" "MB" "G" "GB" "T" "TB" "P" "PB" "E" "EB" "Ki" "KiB" "Mi" "MiB" "Gi" "GiB" "Ti" "TiB" "Pi" "PiB" "Ei" "EiB" -}}
+{{- printf "%g%s" $amount (index $byteSizeUnits $unit) -}}
+{{- end -}}
+{{- else if regexMatch (printf "^%s[eE][+-]?[0-9]+$" $numberPattern) $limit -}}
+{{- printf "%.0f" (ceil (mulf (float64 $limit) 0.75)) -}}
+{{- else -}}
+{{- fail (printf "smithdb.migration.deployment.resources.limits.memory must be a Kubernetes memory quantity, got %q" $limit) -}}
+{{- end -}}
+{{- end }}
+
 {{/*
 SmithDB resource name prefix.
 */}}

--- a/charts/langsmith/templates/smithdb/migration-job.yaml
+++ b/charts/langsmith/templates/smithdb/migration-job.yaml
@@ -77,6 +77,17 @@ spec:
           env:
             - name: SMITHDB_MIGRATION__HTTP_PORT
               value: {{ .Values.smithdb.migration.containerPort | quote }}
+            {{- if (index (default (dict) .Values.smithdb.migration.deployment.resources.limits) "cpu") }}
+            - name: SMITHDB_MIGRATION__WORKER_POOL__NUM_WORKERS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+                  divisor: 1334m
+            {{- end }}
+            {{- if (index (default (dict) .Values.smithdb.migration.deployment.resources.limits) "memory") }}
+            - name: SMITHDB_MIGRATION__WORKER_POOL__MEMORY_QUOTA
+              value: {{ include "langsmith.smithdb.memoryQuota" (index .Values.smithdb.migration.deployment.resources.limits "memory") | quote }}
+            {{- end }}
             {{- if .Values.smithdb.migration.taskdb.postgres.enabled }}
             {{- $taskdb := .Values.smithdb.migration.taskdb.postgres }}
             - name: SMITHDB_MIGRATION__TASKDB__MAX_CONNECTIONS

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -756,6 +756,21 @@ tests:
         contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: SMITHDB_MIGRATION__WORKER_POOL__NUM_WORKERS
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.cpu
+                divisor: 1334m
+      - template: smithdb/migration-job.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_MIGRATION__WORKER_POOL__MEMORY_QUOTA
+            value: 12GiB
+      - template: smithdb/migration-job.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: SMITHDB_MIGRATION__TASKDB__MAX_CONNECTIONS
             value: "10"
       - template: smithdb/migration-job.yaml
@@ -896,6 +911,22 @@ tests:
               secretKeyRef:
                 name: RELEASE-NAME-langsmith-smithdb-taskdb-postgres
                 key: postgres_password
+
+  - it: should derive the migration memory quota from a MiB limit
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.langsmith.migration.enabled: true
+      smithdb.langsmith.query.enabled: false
+      smithdb.migration.deployment.resources.limits.memory: 1024Mi
+      smithdb.migration.taskdb.postgres.auth.password: taskdb-password
+    template: smithdb/migration-job.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_MIGRATION__WORKER_POOL__MEMORY_QUOTA
+            value: 768MiB
 
   - it: should use native GCS for migration source blobs with workload identity
     values:


### PR DESCRIPTION
## Description
Derive SmithDB migration workers and memory quota at roughly 75% of the container CPU and memory limits. CPU uses the Downward API; memory is scaled during rendering because Kubernetes memory divisors cannot represent a 3/4 multiplier.

## Test Plan
- [x] `helm unittest --color=false -f 'tests/langsmith_smithdb_test.yaml' charts/langsmith`
- [x] `helm lint charts/langsmith`

Made by [Open SWE](https://openswe.vercel.app/agents/f926cc42-3b37-c0b5-558b-885e26efc7e4)