### PR TITLE
feat(langsmith): derive migration workers from CPU limit

### DIFF
--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -518,7 +518,7 @@ Template containing common environment variables that are used by several servic
 {{- if hasSuffix "m" $cpu -}}
 {{- $cores = mulf (float64 (trimSuffix "m" $cpu)) 0.001 -}}
 {{- end -}}
-{{- max 1 (int (floor (mulf $cores 0.75))) -}}
+{{- max 1 (int (floor (mulf $cores 0.5))) -}}
 {{- end }}
 
 {{/*

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -518,7 +518,7 @@ Template containing common environment variables that are used by several servic
 {{- if hasSuffix "m" $cpu -}}
 {{- $cores = mulf (float64 (trimSuffix "m" $cpu)) 0.001 -}}
 {{- end -}}
-{{- max 1 (int (floor (mulf $cores 0.5))) -}}
+{{- max 1 (int (floor (mulf $cores 0.75))) -}}
 {{- end }}
 
 {{/*

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -511,6 +511,16 @@ Template containing common environment variables that are used by several servic
 {{- end }}
 {{- end }}
 
+{{/* Compute NUM_WORKERS from a CPU limit (cores or millicores). */}}
+{{- define "langsmith.smithdb.migrationNumWorkers" -}}
+{{- $cpu := toString . -}}
+{{- $cores := float64 $cpu -}}
+{{- if hasSuffix "m" $cpu -}}
+{{- $cores = mulf (float64 (trimSuffix "m" $cpu)) 0.001 -}}
+{{- end -}}
+{{- max 1 (int (floor (mulf $cores 0.75))) -}}
+{{- end }}
+
 {{/*
 SmithDB resource name prefix.
 */}}

--- a/charts/langsmith/templates/smithdb/migration-job.yaml
+++ b/charts/langsmith/templates/smithdb/migration-job.yaml
@@ -78,7 +78,6 @@ spec:
             - name: SMITHDB_MIGRATION__HTTP_PORT
               value: {{ .Values.smithdb.migration.containerPort | quote }}
             {{- with (index (default (dict) .Values.smithdb.migration.deployment.resources.limits) "cpu") }}
-            {{/* ~80% of CPU limit cores (ceil(limit/1.25)); kubelet emits an integer */}}
             - name: SMITHDB_MIGRATION__WORKER_POOL__NUM_WORKERS
               valueFrom:
                 resourceFieldRef:

--- a/charts/langsmith/templates/smithdb/migration-job.yaml
+++ b/charts/langsmith/templates/smithdb/migration-job.yaml
@@ -77,6 +77,14 @@ spec:
           env:
             - name: SMITHDB_MIGRATION__HTTP_PORT
               value: {{ .Values.smithdb.migration.containerPort | quote }}
+            {{- with (index (default (dict) .Values.smithdb.migration.deployment.resources.limits) "cpu") }}
+            {{/* ~80% of CPU limit cores (ceil(limit/1.25)); kubelet emits an integer */}}
+            - name: SMITHDB_MIGRATION__WORKER_POOL__NUM_WORKERS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+                  divisor: "1.25"
+            {{- end }}
             {{- if .Values.smithdb.migration.taskdb.postgres.enabled }}
             {{- $taskdb := .Values.smithdb.migration.taskdb.postgres }}
             - name: SMITHDB_MIGRATION__TASKDB__MAX_CONNECTIONS

--- a/charts/langsmith/templates/smithdb/migration-job.yaml
+++ b/charts/langsmith/templates/smithdb/migration-job.yaml
@@ -81,6 +81,8 @@ spec:
             - name: SMITHDB_MIGRATION__WORKER_POOL__NUM_WORKERS
               value: {{ include "langsmith.smithdb.migrationNumWorkers" . | quote }}
             {{- end }}
+            - name: SMITHDB_MIGRATION__WORKER_POOL__PAGINATION_LIMIT
+              value: "25000"
             {{- if .Values.smithdb.migration.taskdb.postgres.enabled }}
             {{- $taskdb := .Values.smithdb.migration.taskdb.postgres }}
             - name: SMITHDB_MIGRATION__TASKDB__MAX_CONNECTIONS

--- a/charts/langsmith/templates/smithdb/migration-job.yaml
+++ b/charts/langsmith/templates/smithdb/migration-job.yaml
@@ -79,10 +79,7 @@ spec:
               value: {{ .Values.smithdb.migration.containerPort | quote }}
             {{- with (index (default (dict) .Values.smithdb.migration.deployment.resources.limits) "cpu") }}
             - name: SMITHDB_MIGRATION__WORKER_POOL__NUM_WORKERS
-              valueFrom:
-                resourceFieldRef:
-                  resource: limits.cpu
-                  divisor: "1.25"
+              value: {{ include "langsmith.smithdb.migrationNumWorkers" . | quote }}
             {{- end }}
             {{- if .Values.smithdb.migration.taskdb.postgres.enabled }}
             {{- $taskdb := .Values.smithdb.migration.taskdb.postgres }}

--- a/charts/langsmith/templates/smithdb/migration-job.yaml
+++ b/charts/langsmith/templates/smithdb/migration-job.yaml
@@ -81,8 +81,6 @@ spec:
             - name: SMITHDB_MIGRATION__WORKER_POOL__NUM_WORKERS
               value: {{ include "langsmith.smithdb.migrationNumWorkers" . | quote }}
             {{- end }}
-            - name: SMITHDB_MIGRATION__WORKER_POOL__PAGINATION_LIMIT
-              value: "25000"
             {{- if .Values.smithdb.migration.taskdb.postgres.enabled }}
             {{- $taskdb := .Values.smithdb.migration.taskdb.postgres }}
             - name: SMITHDB_MIGRATION__TASKDB__MAX_CONNECTIONS

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -783,7 +783,13 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: SMITHDB_MIGRATION__WORKER_POOL__NUM_WORKERS
-            value: "6"
+            value: "4"
+      - template: smithdb/migration-job.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_MIGRATION__WORKER_POOL__PAGINATION_LIMIT
+            value: "25000"
       - template: smithdb/migration-job.yaml
         contains:
           path: spec.template.spec.containers[0].env
@@ -943,7 +949,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: SMITHDB_MIGRATION__WORKER_POOL__NUM_WORKERS
-            value: "3"
+            value: "2"
 
   - it: should use native GCS for migration source blobs with workload identity
     values:

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -788,12 +788,6 @@ tests:
         contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: SMITHDB_MIGRATION__WORKER_POOL__PAGINATION_LIMIT
-            value: "25000"
-      - template: smithdb/migration-job.yaml
-        contains:
-          path: spec.template.spec.containers[0].env
-          content:
             name: SMITHDB_MIGRATION__TASKDB__MAX_CONNECTIONS
             value: "10"
       - template: smithdb/migration-job.yaml

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -783,10 +783,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: SMITHDB_MIGRATION__WORKER_POOL__NUM_WORKERS
-            valueFrom:
-              resourceFieldRef:
-                resource: limits.cpu
-                divisor: "1.25"
+            value: "6"
       - template: smithdb/migration-job.yaml
         contains:
           path: spec.template.spec.containers[0].env
@@ -931,6 +928,22 @@ tests:
               secretKeyRef:
                 name: RELEASE-NAME-langsmith-smithdb-taskdb-postgres
                 key: postgres_password
+
+  - it: should derive migration workers from a millicore CPU limit
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.langsmith.migration.enabled: true
+      smithdb.langsmith.query.enabled: false
+      smithdb.migration.deployment.resources.limits.cpu: 4000m
+      smithdb.migration.taskdb.postgres.auth.password: taskdb-password
+    template: smithdb/migration-job.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_MIGRATION__WORKER_POOL__NUM_WORKERS
+            value: "3"
 
   - it: should use native GCS for migration source blobs with workload identity
     values:

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -783,7 +783,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: SMITHDB_MIGRATION__WORKER_POOL__NUM_WORKERS
-            value: "4"
+            value: "6"
       - template: smithdb/migration-job.yaml
         contains:
           path: spec.template.spec.containers[0].env
@@ -949,7 +949,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: SMITHDB_MIGRATION__WORKER_POOL__NUM_WORKERS
-            value: "2"
+            value: "3"
 
   - it: should use native GCS for migration source blobs with workload identity
     values:

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -782,6 +782,15 @@ tests:
         contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: SMITHDB_MIGRATION__WORKER_POOL__NUM_WORKERS
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.cpu
+                divisor: "1.25"
+      - template: smithdb/migration-job.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: SMITHDB_MIGRATION__TASKDB__MAX_CONNECTIONS
             value: "10"
       - template: smithdb/migration-job.yaml

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1970,11 +1970,11 @@ smithdb:
       resources:
         requests:
           cpu: "8"
-          memory: "16Gi"
+          memory: "32Gi"
           ephemeral-storage: "100Gi"
         limits:
           cpu: "8"
-          memory: "16Gi"
+          memory: "32Gi"
           ephemeral-storage: "100Gi"
       # -- Runs taskdb schema migrations, then one-shot self-hosted migrate-all: discover tenants,
       # -- register non-overlapping jobs, drain the global queue, and exit. Override for another migration mode.


### PR DESCRIPTION
## Summary
- Derive `SMITHDB_MIGRATION__WORKER_POOL__NUM_WORKERS` as `max(1, floor(0.75 * CPU limit))` (cores or millicores).
- Default migration resources: 8 CPU / 32Gi (requests and limits).

## Test plan
- [x] `helm unittest` smithdb suite
- [ ] Deploy migration Job and confirm env + resource requests