### PR TITLE
fix(langsmith): use JSON logs for SmithDB in Kubernetes

### DIFF
--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -663,7 +663,7 @@ Args: root, service, displayName.
 {{- $tracing := $root.Values.config.observability.tracing -}}
 {{- $tracingEnabled := and $tracing.enabled (eq $tracing.exporter "grpc") -}}
 - name: {{ $prefix }}__LOGGING__FORMAT
-  value: {{ ternary "opentelemetry" "console" $tracingEnabled | quote }}
+  value: {{ ternary "opentelemetry" "json" $tracingEnabled | quote }}
 - name: {{ $prefix }}__LOGGING__TRACING_ENABLED
   value: {{ $tracingEnabled | quote }}
 - name: {{ $prefix }}__LOGGING__SERVICE_NAME

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -262,7 +262,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: SMITHDB_QUERY__LOGGING__FORMAT
-            value: console
+            value: json
       - notContains:
           path: spec.template.spec.containers[0].env
           content:
@@ -532,7 +532,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: SMITHDB_CLUSTERMANAGER__LOGGING__FORMAT
-            value: console
+            value: json
 
   - it: should default cluster-manager service max replicas to deployment replicas
     values:


### PR DESCRIPTION
## Summary

- default SmithDB stdout logging to JSON when OTLP gRPC export is disabled
- preserve OpenTelemetry logging when OTLP gRPC export is enabled
- update SmithDB Helm unit-test expectations

## Testing

- helm unittest -f tests/langsmith_smithdb_test.yaml charts/langsmith
- helm lint charts/langsmith

The full chart unit-test run also passes the SmithDB suite but currently reports two unrelated, pre-existing JuiceFS CSI ServiceAccount annotation failures.