### PR TITLE
feat(billing): add support query to re-queue failed trace usage rows

### DIFF
--- a/charts/langsmith/scripts/support_queries/postgres/pg_reset_failed_trace_transactions.sql
+++ b/charts/langsmith/scripts/support_queries/postgres/pg_reset_failed_trace_transactions.sql
@@ -40,6 +40,7 @@ order by status;
 --    so rows that are already sent, already reconciled, or deliberately not
 --    reported are never touched. Rows attached to a backfill_id are skipped
 --    because they are already part of a manual reconciliation.
+with requeued as (
 update trace_count_transactions
 set status = 'pending',
     num_failed_send_attempts = 0
@@ -50,4 +51,7 @@ where status = 'failed'
   and interval_start >= :'window_start'
   and interval_start <  :'window_end'
   and extract(epoch from insertion_time_range_start)::bigint % 3600 = 0
-  and insertion_time_range_end = insertion_time_range_start + interval '1 hour';
+  and insertion_time_range_end = insertion_time_range_start + interval '1 hour'
+  returning 1
+)
+select count(*) as rows_requeued from requeued;

--- a/charts/langsmith/scripts/support_queries/postgres/pg_reset_failed_trace_transactions.sql
+++ b/charts/langsmith/scripts/support_queries/postgres/pg_reset_failed_trace_transactions.sql
@@ -4,8 +4,12 @@
 -- Run once against the deployment's Postgres. Safe to re-run: rows already
 -- re-queued no longer match, so a second run reports 0.
 --
--- The affected window defaults to the values below. Override either bound with
--- -v window_start=2026-07-20T00:00:00Z -v window_end=2026-08-19T00:00:00Z
+-- Usage, from the scripts directory:
+--   sh run_support_query_pg.sh "postgres://USER:PASS@HOST:PORT/DB" \
+--     --input support_queries/postgres/pg_reset_failed_trace_transactions.sql
+--
+-- The affected window defaults to the values below. Override either bound by
+-- appending -v window_start=2026-07-20T00:00:00Z
 --
 -- No restart needed. The reporter picks the rows up on its next scheduled run,
 -- then moves them to 'sent'. Use query 1 afterwards to watch that happen.

--- a/charts/langsmith/scripts/support_queries/postgres/pg_reset_failed_trace_transactions.sql
+++ b/charts/langsmith/scripts/support_queries/postgres/pg_reset_failed_trace_transactions.sql
@@ -1,0 +1,53 @@
+-- Re-queues trace usage rows that were left in the terminal 'failed' state so the
+-- usage reporter sends them again.
+--
+-- Run once against the deployment's Postgres. Safe to re-run: rows already
+-- re-queued no longer match, so a second run reports 0.
+--
+-- The affected window defaults to the values below. Override either bound with
+-- -v window_start=2026-07-20T00:00:00Z -v window_end=2026-08-19T00:00:00Z
+--
+-- No restart needed. The reporter picks the rows up on its next scheduled run,
+-- then moves them to 'sent'. Use query 1 afterwards to watch that happen.
+
+\if :{?window_start}
+\else
+  \set window_start '2026-07-24T00:00:00Z'
+\endif
+\if :{?window_end}
+\else
+  \set window_end '2026-08-19T00:00:00Z'
+\endif
+
+-- 1. Before and after. Run on its own first to see what will change,
+--    and again afterwards to confirm.
+select
+    status,
+    count(*) as rows,
+    sum(trace_count) as traces
+from trace_count_transactions
+where source = 'local'
+  and interval_start >= :'window_start'
+  and interval_start <  :'window_end'
+  and extract(epoch from insertion_time_range_start)::bigint % 3600 = 0
+  and insertion_time_range_end = insertion_time_range_start + interval '1 hour'
+group by status
+order by status;
+
+-- 2. The re-queue itself. Reports how many rows it changed.
+--
+--    status = 'failed' is matched explicitly rather than excluding other states,
+--    so rows that are already sent, already reconciled, or deliberately not
+--    reported are never touched. Rows attached to a backfill_id are skipped
+--    because they are already part of a manual reconciliation.
+update trace_count_transactions
+set status = 'pending',
+    num_failed_send_attempts = 0
+where status = 'failed'
+  and backfill_id is null
+  and source = 'local'
+  and num_failed_send_attempts > 0
+  and interval_start >= :'window_start'
+  and interval_start <  :'window_end'
+  and extract(epoch from insertion_time_range_start)::bigint % 3600 = 0
+  and insertion_time_range_end = insertion_time_range_start + interval '1 hour';

--- a/charts/langsmith/scripts/support_queries/postgres/pg_reset_failed_trace_transactions.sql
+++ b/charts/langsmith/scripts/support_queries/postgres/pg_reset_failed_trace_transactions.sql
@@ -38,24 +38,69 @@ where source = 'local'
 group by status
 order by status;
 
--- 2. The re-queue itself. Reports how many rows it changed.
+-- 2. The re-queue itself, in chunks so it reports progress rather than looking
+--    hung. psql prints each NOTICE as it arrives.
 --
 --    status = 'failed' is matched explicitly rather than excluding other states,
 --    so rows that are already sent, already reconciled, or deliberately not
 --    reported are never touched. Rows attached to a backfill_id are skipped
 --    because they are already part of a manual reconciliation.
-with requeued as (
-update trace_count_transactions
-set status = 'pending',
-    num_failed_send_attempts = 0
-where status = 'failed'
-  and backfill_id is null
-  and source = 'local'
-  and num_failed_send_attempts > 0
-  and interval_start >= :'window_start'
-  and interval_start <  :'window_end'
-  and extract(epoch from insertion_time_range_start)::bigint % 3600 = 0
-  and insertion_time_range_end = insertion_time_range_start + interval '1 hour'
-  returning 1
-)
-select count(*) as rows_requeued from requeued;
+--
+--    statement_timeout is cleared for this session only. A default of a minute or
+--    two will otherwise kill the update part-way and roll all of it back.
+set statement_timeout = 0;
+
+-- psql does not substitute :'vars' inside a $$-quoted body, so pass them through
+-- session settings instead.
+select set_config('requeue.window_start', :'window_start', false),
+       set_config('requeue.window_end',   :'window_end',   false);
+
+do $$
+declare
+    window_start timestamptz := current_setting('requeue.window_start')::timestamptz;
+    window_end   timestamptz := current_setting('requeue.window_end')::timestamptz;
+    batch_size   int := 50000;
+    in_batch     bigint;
+    requeued     bigint := 0;
+    expected     bigint;
+begin
+    select count(*) into expected
+    from trace_count_transactions
+    where status = 'failed'
+      and backfill_id is null
+      and source = 'local'
+      and num_failed_send_attempts > 0
+      and interval_start >= window_start
+      and interval_start <  window_end
+      and extract(epoch from insertion_time_range_start)::bigint % 3600 = 0
+      and insertion_time_range_end = insertion_time_range_start + interval '1 hour';
+
+    raise notice 'rows to re-queue: %', expected;
+
+    loop
+        update trace_count_transactions
+        set status = 'pending',
+            num_failed_send_attempts = 0
+        where id in (
+            select id
+            from trace_count_transactions
+            where status = 'failed'
+              and backfill_id is null
+              and source = 'local'
+              and num_failed_send_attempts > 0
+              and interval_start >= window_start
+              and interval_start <  window_end
+              and extract(epoch from insertion_time_range_start)::bigint % 3600 = 0
+              and insertion_time_range_end = insertion_time_range_start + interval '1 hour'
+            limit batch_size
+        );
+
+        get diagnostics in_batch = row_count;
+        exit when in_batch = 0;
+
+        requeued := requeued + in_batch;
+        raise notice 're-queued % of %', requeued, expected;
+    end loop;
+
+    raise notice 'done. re-queued % rows', requeued;
+end $$;


### PR DESCRIPTION
- Adds pg_reset_failed_trace_transactions.sql. Some hourly trace-usage rows were rejected on receipt and left in the terminal failed state, where nothing re-sends them. This returns them to pending so the usage reporter picks them up on its next run.
- Safe to re-run. Rows already re-queued no longer match, so a second run reports 0. No restart needed.
- Narrowly scoped. Matches status = 'failed' explicitly rather than excluding other states, so sent, sent-backfilled and should_not_report rows can never be touched. Rows carrying a backfill_id are skipped as already part of a manual reconciliation, and the hour-alignment checks limit it to billing V2 rows.

```
➜  scripts git:(ENT-1499-reset-failed-txn-script) ✗ time sh run_support_query_pg.sh "postgres://postgres:postgres@localhost:6432/langsmith_test" \
  --input support_queries/postgres/pg_reset_failed_trace_transactions.sql
status,rows,traces
failed,1000000,10000000
set_config,set_config
2026-07-24T00:00:00Z,2026-08-19T00:00:00Z
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  rows to re-queue: 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 50000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 100000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 150000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 200000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 250000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 300000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 350000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 400000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 450000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 500000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 550000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 600000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 650000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 700000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 750000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 800000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 850000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 900000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 950000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  re-queued 1000000 of 1000000
psql:support_queries/postgres/pg_reset_failed_trace_transactions.sql:106: NOTICE:  done. re-queued 1000000 rows
sh run_support_query_pg.sh  --input   0.01s user 0.02s system 0% cpu 1:04.76 total
```
```
langsmith_test=# select status, count(*) from trace_count_transactions group by status;
 status  |  count
---------+---------
 pending | 1000000
(1 row)
```
