### PR TITLE
fix: increase compaction worker resources

### DIFF
--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -792,7 +792,10 @@ tests:
           path: spec.replicas
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
-          value: "4"
+          value: "8"
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: "16Gi"
       - equal:
           path: spec.template.spec.containers[0].resources.requests.ephemeral-storage
           value: "100Gi"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1717,12 +1717,12 @@ smithdb:
       terminationGracePeriodSeconds: 120
       resources:
         requests:
-          cpu: "4"
-          memory: "8Gi"
+          cpu: "8"
+          memory: "16Gi"
           ephemeral-storage: "100Gi"
         limits:
-          cpu: "4"
-          memory: "8Gi"
+          cpu: "8"
+          memory: "16Gi"
           ephemeral-storage: "100Gi"
       probes:
         startupProbe:


### PR DESCRIPTION
## Description
Backport the compaction-worker sizing update to `v16-stable`, raising default requests and limits from 4 CPU / 8Gi memory to 8 CPU / 16Gi memory while preserving ephemeral storage.

## Test Plan
- [x] `helm lint charts/langsmith`
- [x] Focused SmithDB Helm unittest suite (46 tests)
- [x] Rendered compaction-worker resources as 8 CPU / 16Gi memory

Made by [Open SWE](https://openswe.vercel.app/agents/1c3e4815-8e7f-5508-9e28-770316d98259)