### PR TITLE
chore(mission-control): sync ingress support (ingressClassName/annotations/tls), bump to 1.2.6

### DIFF
--- a/charts/mission-control/Chart.yaml
+++ b/charts/mission-control/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: mission-control
 description: Mission Control to deploy and manage Langsmith in EKS
-version: 1.2.4
-appVersion: "1.2.5"
+version: 1.2.6
+appVersion: "1.2.6"

--- a/charts/mission-control/README.md
+++ b/charts/mission-control/README.md
@@ -1,6 +1,6 @@
 # mission-control
 
-![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![AppVersion: 1.2.4](https://img.shields.io/badge/AppVersion-1.2.4-informational?style=flat-square)
+![Version: 1.2.6](https://img.shields.io/badge/Version-1.2.6-informational?style=flat-square) ![AppVersion: 1.2.6](https://img.shields.io/badge/AppVersion-1.2.6-informational?style=flat-square)
 
 Mission Control to deploy and manage Langsmith in EKS
 
@@ -153,8 +153,11 @@ helm install mission-control langchain/mission-control \
 | images.frontendImage.tag | string | `"latest"` | Frontend image tag. Defaults to `latest`; pin to a specific release like `1.2.2` for reproducible deploys. Versioned tags are published alongside `latest` on every release. |
 | images.imagePullSecrets | list | `[{"name":"regcred"}]` | Image pull secrets used by all components. |
 | images.registry | string | `""` | If supplied, all child <image>.repository values will be prepended with this registry name + `/` |
-| ingress.enabled | bool | `false` |  |
-| ingress.host | string | `""` |  |
+| ingress.annotations | object | `{}` | Controller-specific annotations (e.g. ALB/AGIC/nginx annotations, cert ARNs). Merged with commonAnnotations; these take precedence on key conflicts. |
+| ingress.enabled | bool | `false` | Expose Mission Control through an ingress controller instead of port-forwarding. |
+| ingress.host | string | `""` | Hostname for the Ingress rule, e.g. mission-control.example.com. Point a DNS CNAME/A record at your ingress controller's address once enabled. |
+| ingress.ingressClassName | string | `""` | IngressClass to use (e.g. `nginx`, `alb`, `azure/application-gateway`). Leave empty to use the cluster's default IngressClass. |
+| ingress.tls | list | `[]` | Optional TLS configuration, e.g.: tls:   - hosts: ["mission-control.example.com"]     secretName: mission-control-tls |
 | nameOverride | string | `""` | Provide a name in place of `mission-control` |
 | namespace | string | `""` | Namespace to install the chart into. If not set, will use the namespace of the current context. |
 

--- a/charts/mission-control/examples/ingress.yaml
+++ b/charts/mission-control/examples/ingress.yaml
@@ -7,3 +7,22 @@
 ingress:
   enabled: true
   host: mission-control.example.com
+
+  # Uncomment and adjust for your ingress controller:
+
+  # AKS with Application Gateway Ingress Controller (AGIC):
+  # ingressClassName: azure/application-gateway
+  # annotations:
+  #   appgw.ingress.kubernetes.io/ssl-redirect: "true"
+
+  # EKS with the AWS Load Balancer Controller (ALB):
+  # ingressClassName: alb
+  # annotations:
+  #   alb.ingress.kubernetes.io/scheme: internal
+  #   alb.ingress.kubernetes.io/target-type: ip
+
+  # ingress-nginx (any cluster):
+  # ingressClassName: nginx
+  # tls:
+  #   - hosts: ["mission-control.example.com"]
+  #     secretName: mission-control-tls

--- a/charts/mission-control/install-script.sh
+++ b/charts/mission-control/install-script.sh
@@ -285,6 +285,9 @@ frontend:
 ingress:
   enabled: false
   host: ""
+  ingressClassName: ""
+  annotations: {}
+  tls: []
 
 config:
   auth:

--- a/charts/mission-control/templates/ingress.yaml
+++ b/charts/mission-control/templates/ingress.yaml
@@ -6,11 +6,19 @@ metadata:
   namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "missionControl.labels" . | nindent 4 }}
-  {{- with (include "missionControl.annotations" .) }}
+  {{- $ingressAnnotations := merge (.Values.ingress.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- if $ingressAnnotations }}
   annotations:
-    {{- . | nindent 4 }}
+    {{- toYaml $ingressAnnotations | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.host | quote }}
       http:

--- a/charts/mission-control/values.yaml
+++ b/charts/mission-control/values.yaml
@@ -204,10 +204,25 @@ frontend:
     type: ClusterIP
     port: 3000
 
-# Optional ingress; disabled by default.
+# Optional ingress; disabled by default. Alternative to kubectl port-forward
+# for reaching the Mission Control console - see docs/installation.md.
 ingress:
+  # -- Expose Mission Control through an ingress controller instead of port-forwarding.
   enabled: false
+  # -- Hostname for the Ingress rule, e.g. mission-control.example.com. Point a DNS
+  # CNAME/A record at your ingress controller's address once enabled.
   host: ""
+  # -- IngressClass to use (e.g. `nginx`, `alb`, `azure/application-gateway`). Leave
+  # empty to use the cluster's default IngressClass.
+  ingressClassName: ""
+  # -- Controller-specific annotations (e.g. ALB/AGIC/nginx annotations, cert ARNs).
+  # Merged with commonAnnotations; these take precedence on key conflicts.
+  annotations: {}
+  # -- Optional TLS configuration, e.g.:
+  # tls:
+  #   - hosts: ["mission-control.example.com"]
+  #     secretName: mission-control-tls
+  tls: []
 
 # Diagnostic-bundle storage. The backend always writes bundles to /tmp/mc_diagnostics.
 # The backend runs as a StatefulSet so persistence can be toggled by including or


### PR DESCRIPTION
## Summary
Manually syncs `charts/mission-control` with [langchain-ai/langchain-mission-control#153](https://github.com/langchain-ai/langchain-mission-control/pull/153), adding `ingressClassName`, TLS, and annotation support to the chart's ingress, and bumps to 1.2.6.

## Test plan
- [x] `helm lint charts/mission-control`
- [x] `helm template` with ingress disabled (default)
- [x] `helm template` with `--set ingress.enabled=true --set ingress.host=x.example.com`, plus ingressClassName/annotations/tls set, confirming `ingress.annotations` takes precedence over `commonAnnotations` on conflict