### PR TITLE
fix: validate v17 sandbox JuiceFS values

### DIFF
--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -65,6 +65,14 @@ AWS Marketplace Helm template verification).
 {{- fail (printf "images.%s is deprecated: this workload now runs on the consolidated backend image. Configure images.backendImage instead (and mirror only that image)." $key) -}}
 {{- end -}}
 {{- end -}}
+{{- range $key := list "juicefsCSIImage" "juicefsCSINodeDriverRegistrarImage" "juicefsMountImage" -}}
+{{- if hasKey $.Values.images $key -}}
+{{- fail (printf "images.%s was removed in v17 with the bundled JuiceFS CSI driver. Remove it; sandbox-host now owns the JuiceFS mount and uses images.sandboxHostImage." $key) -}}
+{{- end -}}
+{{- end -}}
+{{- if hasKey .Values.sandboxes.juicefs "csi" -}}
+{{- fail "sandboxes.juicefs.csi was removed in v17 because sandbox-host now owns the JuiceFS mount. Move csi.existingSecretName to sandboxes.juicefs.existingSecretName, replace csi.mountPodPatch with sandboxes.juicefs.hostMount.cacheDirs and mountOptions, move csi.node.serviceAccount.annotations to sandboxes.sandboxHost.serviceAccount.annotations, then remove sandboxes.juicefs.csi." -}}
+{{- end -}}
 {{- if hasKey .Values.smithdb.langsmith "dualIngest" -}}
 {{- $legacySmithdbDualIngest := get .Values.smithdb.langsmith "dualIngest" -}}
 {{- if eq (lower (toString (get $legacySmithdbDualIngest "enabled"))) "true" -}}
@@ -237,12 +245,15 @@ AWS Marketplace Helm template verification).
 {{- fail "sandboxes.juicefs.bucket must use an HTTP(S) S3 endpoint URL when sandboxes.juicefs.storage is s3." -}}
 {{- end -}}
 {{- end -}}
-{{- $hostMount := .Values.sandboxes.juicefs.hostMount -}}
-{{- if not $hostMount.cacheDirs -}}
+{{- $hostMount := get $juicefs "hostMount" -}}
+{{- if not (kindIs "map" $hostMount) -}}
+{{- fail "sandboxes.juicefs.hostMount is required when sandboxes.enabled is true. Configure hostMount.cacheDirs and hostMount.mountOptions for the v17 sandbox-host-owned JuiceFS mount." -}}
+{{- end -}}
+{{- if not (get $hostMount "cacheDirs") -}}
 {{- fail "sandboxes.juicefs.hostMount.cacheDirs must contain at least one node host path when sandboxes.enabled is true." -}}
 {{- end -}}
 {{- $cacheDirsSeen := dict -}}
-{{- range $cacheDir := $hostMount.cacheDirs -}}
+{{- range $cacheDir := get $hostMount "cacheDirs" -}}
 {{- if not (kindIs "string" $cacheDir) -}}
 {{- fail "sandboxes.juicefs.hostMount.cacheDirs entries must be strings." -}}
 {{- end -}}
@@ -260,7 +271,7 @@ AWS Marketplace Helm template verification).
 {{- end -}}
 {{- $_ := set $cacheDirsSeen $cacheDir true -}}
 {{- end -}}
-{{- range $mountOption := $hostMount.mountOptions -}}
+{{- range $mountOption := get $hostMount "mountOptions" -}}
 {{- if regexMatch "^--cache-dir($|=)" $mountOption -}}
 {{- fail "sandboxes.juicefs.hostMount.mountOptions must not set --cache-dir; configure sandboxes.juicefs.hostMount.cacheDirs instead." -}}
 {{- end -}}

--- a/charts/langsmith/tests/sandbox_juicefs_test.yaml
+++ b/charts/langsmith/tests/sandbox_juicefs_test.yaml
@@ -175,6 +175,38 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: should reject the removed v16 JuiceFS CSI settings even when sandboxes are disabled
+    set:
+      sandboxes.juicefs.csi.existingSecretName: external-juicefs-config
+    template: validate.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "sandboxes.juicefs.csi was removed in v17 because sandbox-host now owns the JuiceFS mount. Move csi.existingSecretName to sandboxes.juicefs.existingSecretName, replace csi.mountPodPatch with sandboxes.juicefs.hostMount.cacheDirs and mountOptions, move csi.node.serviceAccount.annotations to sandboxes.sandboxHost.serviceAccount.annotations, then remove sandboxes.juicefs.csi."
+
+  - it: should reject the removed JuiceFS CSI driver image setting
+    set:
+      images.juicefsCSIImage.repository: example.com/juicefs-csi-driver
+    template: validate.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "images.juicefsCSIImage was removed in v17 with the bundled JuiceFS CSI driver. Remove it; sandbox-host now owns the JuiceFS mount and uses images.sandboxHostImage."
+
+  - it: should reject the removed JuiceFS CSI registrar image setting
+    set:
+      images.juicefsCSINodeDriverRegistrarImage.repository: example.com/csi-node-driver-registrar
+    template: validate.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "images.juicefsCSINodeDriverRegistrarImage was removed in v17 with the bundled JuiceFS CSI driver. Remove it; sandbox-host now owns the JuiceFS mount and uses images.sandboxHostImage."
+
+  - it: should reject the removed JuiceFS mount image setting
+    set:
+      images.juicefsMountImage.repository: example.com/juicefs-mount
+    template: validate.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "images.juicefsMountImage was removed in v17 with the bundled JuiceFS CSI driver. Remove it; sandbox-host now owns the JuiceFS mount and uses images.sandboxHostImage."
+
   - it: should configure multiple node-local cache directories
     values:
       - ./values/sandboxes-enabled.yaml


### PR DESCRIPTION
## Description
Rejects values from the bundled JuiceFS CSI setup removed in v17 and directs operators to the sandbox-host-owned replacements. It also gives reused values a clear failure when the required host mount map is absent.

## Test Plan
- [x] Focused sandbox JuiceFS Helm unit tests (14 passed)
- [x] LangSmith chart lint with sandbox-enabled values

Made by [Open SWE](https://openswe.vercel.app/agents/8562f570-2c3a-563b-b4e9-ddd50c95b0ba)