### PR TITLE
fix(langsmith): bound ClickHouse system log growth (cherry-pick #974)

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.9
+version: 0.16.10
 appVersion: "0.16.43"

--- a/charts/langsmith/templates/clickhouse/config-map.yaml
+++ b/charts/langsmith/templates/clickhouse/config-map.yaml
@@ -67,4 +67,34 @@ data:
         <errors>true</errors>
       </prometheus>
     </clickhouse>
+
+  telemetry_config.xml: |
+    <clickhouse>
+      <!-- Disable high-churn introspection logs that can consume significant CPU and disk while idle. -->
+      <trace_log remove="1"/>
+      <metric_log remove="1"/>
+      <asynchronous_metric_log remove="1"/>
+      <query_metric_log remove="1"/>
+      <background_schedule_pool_log remove="1"/>
+
+      <!-- Retain useful operational logs while preventing unbounded growth on the ClickHouse PVC. -->
+      <query_log>
+        <ttl>event_date + INTERVAL 3 DAY</ttl>
+      </query_log>
+      <part_log>
+        <ttl>event_date + INTERVAL 3 DAY</ttl>
+      </part_log>
+      <text_log>
+        <ttl>event_date + INTERVAL 3 DAY</ttl>
+      </text_log>
+      <error_log>
+        <ttl>event_date + INTERVAL 3 DAY</ttl>
+      </error_log>
+      <processors_profile_log>
+        <ttl>event_date + INTERVAL 3 DAY</ttl>
+      </processors_profile_log>
+      <query_views_log>
+        <ttl>event_date + INTERVAL 3 DAY</ttl>
+      </query_views_log>
+    </clickhouse>
 {{- end }}

--- a/charts/langsmith/templates/clickhouse/stateful-set.yaml
+++ b/charts/langsmith/templates/clickhouse/stateful-set.yaml
@@ -140,6 +140,9 @@ spec:
             - mountPath: /etc/clickhouse-server/config.d/metrics_config.xml
               name: clickhouse-conf
               subPath: metrics_config.xml
+            - mountPath: /etc/clickhouse-server/config.d/telemetry_config.xml
+              name: clickhouse-conf
+              subPath: telemetry_config.xml
           {{- with .Values.clickhouse.statefulSet.extraContainerConfig }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
@@ -173,6 +176,8 @@ spec:
                 path: logging_config.xml
               - key: metrics_config.xml
                 path: metrics_config.xml
+              - key: telemetry_config.xml
+                path: telemetry_config.xml
       {{- with $volumes }}
           {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/langsmith/tests/clickhouse_statefulset_test.yaml
+++ b/charts/langsmith/tests/clickhouse_statefulset_test.yaml
@@ -4,6 +4,53 @@ templates:
   # config-map.yaml is loaded so the StatefulSet's checksum/config `include` resolves.
   - clickhouse/config-map.yaml
 tests:
+  - it: configures bounded ClickHouse system log retention
+    template: clickhouse/config-map.yaml
+    asserts:
+      - matchRegex:
+          path: data["telemetry_config.xml"]
+          pattern: '<trace_log remove="1"/>'
+      - matchRegex:
+          path: data["telemetry_config.xml"]
+          pattern: '<metric_log remove="1"/>'
+      - matchRegex:
+          path: data["telemetry_config.xml"]
+          pattern: '<asynchronous_metric_log remove="1"/>'
+      - matchRegex:
+          path: data["telemetry_config.xml"]
+          pattern: '<query_metric_log remove="1"/>'
+      - matchRegex:
+          path: data["telemetry_config.xml"]
+          pattern: '<background_schedule_pool_log remove="1"/>'
+      - matchRegex:
+          path: data["telemetry_config.xml"]
+          pattern: '<query_log>[[:space:]]*<ttl>event_date \+ INTERVAL 3 DAY</ttl>[[:space:]]*</query_log>'
+      - matchRegex:
+          path: data["telemetry_config.xml"]
+          pattern: '<part_log>[[:space:]]*<ttl>event_date \+ INTERVAL 3 DAY</ttl>[[:space:]]*</part_log>'
+      - matchRegex:
+          path: data["telemetry_config.xml"]
+          pattern: '<text_log>[[:space:]]*<ttl>event_date \+ INTERVAL 3 DAY</ttl>[[:space:]]*</text_log>'
+      - matchRegex:
+          path: data["telemetry_config.xml"]
+          pattern: '<error_log>[[:space:]]*<ttl>event_date \+ INTERVAL 3 DAY</ttl>[[:space:]]*</error_log>'
+      - matchRegex:
+          path: data["telemetry_config.xml"]
+          pattern: '<processors_profile_log>[[:space:]]*<ttl>event_date \+ INTERVAL 3 DAY</ttl>[[:space:]]*</processors_profile_log>'
+      - matchRegex:
+          path: data["telemetry_config.xml"]
+          pattern: '<query_views_log>[[:space:]]*<ttl>event_date \+ INTERVAL 3 DAY</ttl>[[:space:]]*</query_views_log>'
+
+  - it: mounts the ClickHouse telemetry configuration
+    template: clickhouse/stateful-set.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /etc/clickhouse-server/config.d/telemetry_config.xml
+            name: clickhouse-conf
+            subPath: telemetry_config.xml
+
   - it: does not render updateStrategy by default
     template: clickhouse/stateful-set.yaml
     asserts:


### PR DESCRIPTION
Backports #974 to the v16 stable train to prevent bundled ClickHouse introspection logs from consuming unbounded CPU, disk I/O, and PVC capacity.

- Applies the same five disabled high-churn logs and six three-day TTLs merged on `main`.
- Mounts the policy only for the bundled ClickHouse instance; external and disabled ClickHouse deployments remain unaffected.
- Bumps the v16 chart from `0.16.9` to `0.16.10`; `appVersion` remains `0.16.43`.

This is a targeted adaptation of main commit `0ca690e` because the stable chart-version line intentionally differs.

## Test Plan

- [x] Confirmed the telemetry policy, mount, and regression tests are byte-identical to #974.
- [x] Rendered the bundled ClickHouse ConfigMap and validated `telemetry_config.xml` with `xmllint`.