### PR TITLE
fix(langsmith): SmithDB Beacon env compatible with BYOC commonEnv

### DIFF
--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -631,7 +631,22 @@ Args: root, service, displayName.
 {{- if $root.Values.smithdb.enabled }}
 {{- $envVars = concat $envVars (include "langsmith.smithdb.clusterManagerClientEnv" (dict "root" $root "service" $service) | fromYamlArray) -}}
 {{- end }}
-{{- $envVars = concat $envVars $root.Values.commonEnv $root.Values.smithdb.commonEnv -}}
+{{- $seen := dict -}}
+{{- range $envVars }}
+{{- $_ := set $seen .name true -}}
+{{- end }}
+{{- range $root.Values.commonEnv }}
+{{- if not (hasKey $seen .name) }}
+{{- $envVars = append $envVars . -}}
+{{- $_ := set $seen .name true -}}
+{{- end }}
+{{- end }}
+{{- range $root.Values.smithdb.commonEnv }}
+{{- if not (hasKey $seen .name) }}
+{{- $envVars = append $envVars . -}}
+{{- $_ := set $seen .name true -}}
+{{- end }}
+{{- end }}
 {{- toYaml $envVars }}
 {{- end }}
 
@@ -667,7 +682,9 @@ SmithDB Beacon log export environment.
     secretKeyRef:
       name: {{ include "langsmith.secretsName" . }}
       key: langsmith_license_key
-      optional: {{ .Values.config.disableSecretCreation }}
+      # BYOC existing secrets authenticate Beacon with DATA_PLANE_JWT_SECRET
+      # and do not store langsmith_license_key.
+      optional: {{ or .Values.config.disableSecretCreation (ne (default "" .Values.config.existingSecretName) "") }}
 {{- end }}
 
 {{/*

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -119,7 +119,7 @@ tests:
               secretKeyRef:
                 name: langsmith-runtime
                 key: langsmith_license_key
-                optional: false
+                optional: true
 
   - it: should use SmithDB's default Beacon endpoint when no override is configured
     values:
@@ -149,6 +149,43 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: BEACON_ENDPOINT
+
+  - it: should skip duplicate commonEnv keys already set by SmithDB Beacon env
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      commonEnv:
+        - name: PHONE_HOME_ENABLED
+          value: "true"
+        - name: BEACON_ENDPOINT
+          value: https://beacon.langchain.com
+      smithdb.commonEnv:
+        - name: BEACON_LOGGING_ENABLED
+          value: "true"
+        - name: AWS_REGION
+          value: us-west-2
+    template: smithdb/query-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PHONE_HOME_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BEACON_LOGGING_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_REGION
+            value: us-west-2
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BEACON_ENDPOINT
+            value: https://beacon.langchain.com
 
   - it: should enable Beacon phone-home when traces are enabled without logs
     values:


### PR DESCRIPTION
## Summary
Backport of the main-branch SmithDB Beacon BYOC env fix to `v16-stable`.

- Skip duplicate `commonEnv` keys so BYOC `PHONE_HOME_ENABLED` does not fail Helm.
- Treat `langsmith_license_key` as optional when using an existing secret.

## Test plan
- [x] `helm unittest charts/langsmith -f charts/langsmith/tests/langsmith_smithdb_test.yaml`

Made with [Cursor](https://cursor.com)