### PR TITLE
fix(langsmith): omit empty SmithDB migration blob access keys

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.17.0-rc.13
+version: 0.17.0-rc.14
 appVersion: "0.17.14rc1"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.17.0-rc.13](https://img.shields.io/badge/Version-0.17.0--rc.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.14rc1](https://img.shields.io/badge/AppVersion-0.17.14rc1-informational?style=flat-square)
+![Version: 0.17.0-rc.14](https://img.shields.io/badge/Version-0.17.0--rc.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.14rc1](https://img.shields.io/badge/AppVersion-0.17.14rc1-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 

--- a/charts/langsmith/templates/smithdb/migration-job.yaml
+++ b/charts/langsmith/templates/smithdb/migration-job.yaml
@@ -173,6 +173,8 @@ spec:
               value: {{ $blobStorage.apiURL | quote }}
             - name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__S3__ALLOW_HTTP
               value: {{ hasPrefix "http://" $blobStorage.apiURL | quote }}
+            {{- /* Empty keys become static "" credentials in SmithDB and break IRSA/Pod Identity. */}}
+            {{- if or $blobStorage.accessKey $blobStorage.accessKeySecret }}
             - name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__S3__ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -185,6 +187,7 @@ spec:
                   name: {{ include "langsmith.secretsName" . }}
                   key: blob_storage_access_key_secret
                   optional: true
+            {{- end }}
             {{- else if and $blobStorage.enabled (eq (lower $blobStorage.engine) "gcs") }}
             - name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__TYPE
               value: "gcs"

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -913,6 +913,16 @@ tests:
         notContains:
           path: spec.template.spec.containers[0].env
           content:
+            name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__S3__ACCESS_KEY_ID
+      - template: smithdb/migration-job.yaml
+        notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__S3__SECRET_ACCESS_KEY
+      - template: smithdb/migration-job.yaml
+        notContains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: SMITHDB_MIGRATION__BLOB_STORE_PREFIXED__TYPE
       - template: smithdb/migration-job.yaml
         contains:
@@ -1000,6 +1010,41 @@ tests:
               secretKeyRef:
                 name: RELEASE-NAME-langsmith-smithdb-taskdb-postgres
                 key: postgres_password
+
+  - it: should mount smithdb migration blob store access keys when configured
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      images.smithdbImage.tag: test-tag
+      config.blobStorage.enabled: true
+      config.blobStorage.bucketName: langsmith-blob
+      config.blobStorage.apiURL: http://blob-store:9000
+      config.blobStorage.accessKey: blob-access-key
+      config.blobStorage.accessKeySecret: blob-secret-key
+      smithdb.langsmith.migration.enabled: true
+      smithdb.langsmith.query.enabled: false
+      smithdb.migration.taskdb.postgres.enabled: true
+      smithdb.migration.taskdb.postgres.auth.password: taskdb-password
+    template: smithdb/migration-job.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__S3__ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-langsmith-secrets
+                key: blob_storage_access_key
+                optional: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__S3__SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-langsmith-secrets
+                key: blob_storage_access_key_secret
+                optional: true
 
   - it: should derive migration workers from a millicore CPU limit
     values:


### PR DESCRIPTION
## Summary
- Do not mount `SMITHDB_MIGRATION__BLOB_STORE_DEFAULT__S3__ACCESS_KEY_ID` / `SECRET_ACCESS_KEY` when `config.blobStorage.accessKey` and `accessKeySecret` are empty.

Companions:
- [smithdb#2621](https://github.com/langchain-ai/smithdb/pull/2621) — treat leftover `""` keys as unset so [#2584](https://github.com/langchain-ai/smithdb/pull/2584) can use the AWS SDK region/credential chain
- [deployments#36429](https://github.com/langchain-ai/deployments/pull/36429) — LangSmith blob-bucket IAM (region extraEnv no longer required)

Keep this Helm omit even after SmithDB lands: the Job should not advertise dummy HMAC secrets.

## Test Plan
- [x] `helm unittest charts/langsmith -f charts/langsmith/tests/langsmith_smithdb_test.yaml`
- [ ] After chart pickup on a BYOC dataplane, confirm the migration Job has no empty `ACCESS_KEY_ID` env vars