### PR TITLE
chore(smithdb): Support KEDA scaling for SmithDB compaction workers 

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.17.0-rc.17
+version: 0.17.0-rc.18
 appVersion: "0.17.17rc1"

--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.17.0-rc.18
+version: 0.17.0-rc.19
 appVersion: "0.17.17rc1"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,10 +1,6 @@
 # langsmith
 
-<<<<<<< HEAD
-![Version: 0.17.0-rc.17](https://img.shields.io/badge/Version-0.17.0--rc.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.17rc1](https://img.shields.io/badge/AppVersion-0.17.17rc1-informational?style=flat-square)
-=======
-![Version: 0.17.0-rc.18](https://img.shields.io/badge/Version-0.17.0--rc.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.14rc1](https://img.shields.io/badge/AppVersion-0.17.14rc1-informational?style=flat-square)
->>>>>>> 73edff69 (Normalize SmithDB query and ingestion autoscaling to hpa nested layout.)
+![Version: 0.17.0-rc.19](https://img.shields.io/badge/Version-0.17.0--rc.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.17rc1](https://img.shields.io/badge/AppVersion-0.17.17rc1-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -1023,15 +1019,26 @@ Replica counts and autoscaling remain controlled by each component's `deployment
 | smithdb.compaction.service.annotations | object | `{}` |  |
 | smithdb.compaction.service.labels | object | `{}` |  |
 | smithdb.compaction.service.port | int | `8071` |  |
-| smithdb.compactionWorker.autoscaling.hpa.enabled | bool | `true` | Enable HPA scaling. |
+| smithdb.compactionWorker.autoscaling.hpa.enabled | bool | `true` |  |
 | smithdb.compactionWorker.autoscaling.hpa.maxReplicas | int | `10` |  |
 | smithdb.compactionWorker.autoscaling.hpa.minReplicas | int | `1` |  |
 | smithdb.compactionWorker.autoscaling.hpa.scaleDownStabilizationWindowSeconds | int | `300` |  |
 | smithdb.compactionWorker.autoscaling.hpa.scalePodCount | int | `1` |  |
 | smithdb.compactionWorker.autoscaling.hpa.scaleUpStabilizationWindowSeconds | int | `120` |  |
 | smithdb.compactionWorker.autoscaling.hpa.targetCPUUtilizationPercentage | int | `60` |  |
-| smithdb.compactionWorker.autoscaling.keda | object | `{"annotations":{},"cooldownPeriod":300,"enabled":false,"initialCooldownPeriod":0,"labels":{},"maxReplicaCount":10,"minReplicaCount":1,"pendingJobsThreshold":"60","pollingInterval":30,"scaleDownStabilizationWindowSeconds":300,"scalePodCount":1,"scaleUpStabilizationWindowSeconds":120,"targetCPUUtilizationPercentage":60}` | KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster. |
+| smithdb.compactionWorker.autoscaling.keda.annotations | object | `{}` |  |
+| smithdb.compactionWorker.autoscaling.keda.cooldownPeriod | int | `300` |  |
+| smithdb.compactionWorker.autoscaling.keda.enabled | bool | `false` |  |
+| smithdb.compactionWorker.autoscaling.keda.initialCooldownPeriod | int | `0` |  |
+| smithdb.compactionWorker.autoscaling.keda.labels | object | `{}` |  |
+| smithdb.compactionWorker.autoscaling.keda.maxReplicaCount | int | `10` |  |
+| smithdb.compactionWorker.autoscaling.keda.minReplicaCount | int | `1` |  |
 | smithdb.compactionWorker.autoscaling.keda.pendingJobsThreshold | string | `"60"` | Number of pending compaction jobs per worker. |
+| smithdb.compactionWorker.autoscaling.keda.pollingInterval | int | `30` |  |
+| smithdb.compactionWorker.autoscaling.keda.scaleDownStabilizationWindowSeconds | int | `300` |  |
+| smithdb.compactionWorker.autoscaling.keda.scalePodCount | int | `1` |  |
+| smithdb.compactionWorker.autoscaling.keda.scaleUpStabilizationWindowSeconds | int | `120` |  |
+| smithdb.compactionWorker.autoscaling.keda.targetCPUUtilizationPercentage | int | `60` |  |
 | smithdb.compactionWorker.containerPort | int | `9000` |  |
 | smithdb.compactionWorker.deployment.affinity | object | `{}` |  |
 | smithdb.compactionWorker.deployment.annotations | object | `{}` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1019,7 +1019,10 @@ Replica counts and autoscaling remain controlled by each component's `deployment
 | smithdb.compaction.service.annotations | object | `{}` |  |
 | smithdb.compaction.service.labels | object | `{}` |  |
 | smithdb.compaction.service.port | int | `8071` |  |
-| smithdb.compactionWorker.autoscaling.enabled | bool | `true` |  |
+| smithdb.compactionWorker.autoscaling.enabled | bool | `true` | Legacy HPA enablement setting. Retained for backwards compatibility; hpa.enabled takes precedence when set. |
+| smithdb.compactionWorker.autoscaling.hpa.enabled | string | `nil` | Enable HPA scaling. Null inherits the legacy autoscaling.enabled value. |
+| smithdb.compactionWorker.autoscaling.keda | object | `{"annotations":{},"cooldownPeriod":300,"enabled":false,"initialCooldownPeriod":0,"labels":{},"pendingJobsThreshold":"60","pollingInterval":30}` | KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster. |
+| smithdb.compactionWorker.autoscaling.keda.pendingJobsThreshold | string | `"60"` | Number of pending compaction jobs per worker. |
 | smithdb.compactionWorker.autoscaling.maxReplicas | int | `10` |  |
 | smithdb.compactionWorker.autoscaling.minReplicas | int | `1` |  |
 | smithdb.compactionWorker.autoscaling.scaleDownStabilizationWindowSeconds | int | `300` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1019,8 +1019,8 @@ Replica counts and autoscaling remain controlled by each component's `deployment
 | smithdb.compaction.service.annotations | object | `{}` |  |
 | smithdb.compaction.service.labels | object | `{}` |  |
 | smithdb.compaction.service.port | int | `8071` |  |
-| smithdb.compactionWorker.autoscaling.enabled | bool | `true` | Legacy HPA enablement setting. Retained for backwards compatibility; hpa.enabled takes precedence when set. |
-| smithdb.compactionWorker.autoscaling.hpa.enabled | string | `nil` | Enable HPA scaling. Null inherits the legacy autoscaling.enabled value. |
+| smithdb.compactionWorker.autoscaling.enabled | bool | `true` | Enable compaction worker autoscaling. Retained as the master switch for backwards compatibility. |
+| smithdb.compactionWorker.autoscaling.hpa.enabled | bool | `true` | Enable HPA scaling when autoscaling.enabled is true. |
 | smithdb.compactionWorker.autoscaling.keda | object | `{"annotations":{},"cooldownPeriod":300,"enabled":false,"initialCooldownPeriod":0,"labels":{},"pendingJobsThreshold":"60","pollingInterval":30}` | KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster. |
 | smithdb.compactionWorker.autoscaling.keda.pendingJobsThreshold | string | `"60"` | Number of pending compaction jobs per worker. |
 | smithdb.compactionWorker.autoscaling.maxReplicas | int | `10` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1020,14 +1020,14 @@ Replica counts and autoscaling remain controlled by each component's `deployment
 | smithdb.compaction.service.labels | object | `{}` |  |
 | smithdb.compaction.service.port | int | `8071` |  |
 | smithdb.compactionWorker.autoscaling.hpa.enabled | bool | `true` | Enable HPA scaling. |
-| smithdb.compactionWorker.autoscaling.keda | object | `{"annotations":{},"cooldownPeriod":300,"enabled":false,"initialCooldownPeriod":0,"labels":{},"pendingJobsThreshold":"60","pollingInterval":30}` | KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster. |
+| smithdb.compactionWorker.autoscaling.hpa.maxReplicas | int | `10` |  |
+| smithdb.compactionWorker.autoscaling.hpa.minReplicas | int | `1` |  |
+| smithdb.compactionWorker.autoscaling.hpa.scaleDownStabilizationWindowSeconds | int | `300` |  |
+| smithdb.compactionWorker.autoscaling.hpa.scalePodCount | int | `1` |  |
+| smithdb.compactionWorker.autoscaling.hpa.scaleUpStabilizationWindowSeconds | int | `120` |  |
+| smithdb.compactionWorker.autoscaling.hpa.targetCPUUtilizationPercentage | int | `60` |  |
+| smithdb.compactionWorker.autoscaling.keda | object | `{"annotations":{},"cooldownPeriod":300,"enabled":false,"initialCooldownPeriod":0,"labels":{},"maxReplicaCount":10,"minReplicaCount":1,"pendingJobsThreshold":"60","pollingInterval":30,"scaleDownStabilizationWindowSeconds":300,"scalePodCount":1,"scaleUpStabilizationWindowSeconds":120,"targetCPUUtilizationPercentage":60}` | KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster. |
 | smithdb.compactionWorker.autoscaling.keda.pendingJobsThreshold | string | `"60"` | Number of pending compaction jobs per worker. |
-| smithdb.compactionWorker.autoscaling.maxReplicas | int | `10` |  |
-| smithdb.compactionWorker.autoscaling.minReplicas | int | `1` |  |
-| smithdb.compactionWorker.autoscaling.scaleDownStabilizationWindowSeconds | int | `300` |  |
-| smithdb.compactionWorker.autoscaling.scalePodCount | int | `1` |  |
-| smithdb.compactionWorker.autoscaling.scaleUpStabilizationWindowSeconds | int | `120` |  |
-| smithdb.compactionWorker.autoscaling.targetCPUUtilizationPercentage | int | `60` |  |
 | smithdb.compactionWorker.containerPort | int | `9000` |  |
 | smithdb.compactionWorker.deployment.affinity | object | `{}` |  |
 | smithdb.compactionWorker.deployment.annotations | object | `{}` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,10 @@
 # langsmith
 
+<<<<<<< HEAD
 ![Version: 0.17.0-rc.17](https://img.shields.io/badge/Version-0.17.0--rc.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.17rc1](https://img.shields.io/badge/AppVersion-0.17.17rc1-informational?style=flat-square)
+=======
+![Version: 0.17.0-rc.18](https://img.shields.io/badge/Version-0.17.0--rc.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.14rc1](https://img.shields.io/badge/AppVersion-0.17.14rc1-informational?style=flat-square)
+>>>>>>> 73edff69 (Normalize SmithDB query and ingestion autoscaling to hpa nested layout.)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -1086,13 +1090,13 @@ Replica counts and autoscaling remain controlled by each component's `deployment
 | smithdb.config.objectStore.s3.secretAccessKeySecretKey | string | `""` |  |
 | smithdb.config.objectStore.type | string | `"s3"` | Supported values: s3, gcs. |
 | smithdb.enabled | bool | `false` | Please express interest (https://www.langchain.com/smithdb-early-access-waitlist) and we will reach out promptly to ensure we can set you up for success with SmithDB. |
-| smithdb.ingestion.autoscaling.enabled | bool | `true` |  |
-| smithdb.ingestion.autoscaling.maxReplicas | int | `10` |  |
-| smithdb.ingestion.autoscaling.minReplicas | int | `1` |  |
-| smithdb.ingestion.autoscaling.scaleDownStabilizationWindowSeconds | int | `900` |  |
-| smithdb.ingestion.autoscaling.scalePodCount | int | `1` |  |
-| smithdb.ingestion.autoscaling.scaleUpStabilizationWindowSeconds | int | `300` |  |
-| smithdb.ingestion.autoscaling.targetCPUUtilizationPercentage | int | `45` |  |
+| smithdb.ingestion.autoscaling.hpa.enabled | bool | `true` |  |
+| smithdb.ingestion.autoscaling.hpa.maxReplicas | int | `10` |  |
+| smithdb.ingestion.autoscaling.hpa.minReplicas | int | `1` |  |
+| smithdb.ingestion.autoscaling.hpa.scaleDownStabilizationWindowSeconds | int | `900` |  |
+| smithdb.ingestion.autoscaling.hpa.scalePodCount | int | `1` |  |
+| smithdb.ingestion.autoscaling.hpa.scaleUpStabilizationWindowSeconds | int | `300` |  |
+| smithdb.ingestion.autoscaling.hpa.targetCPUUtilizationPercentage | int | `45` |  |
 | smithdb.ingestion.containerGrpcPort | int | `8082` |  |
 | smithdb.ingestion.containerPort | int | `8050` |  |
 | smithdb.ingestion.deployment.affinity | object | `{}` |  |
@@ -1252,13 +1256,13 @@ Replica counts and autoscaling remain controlled by each component's `deployment
 | smithdb.migration.taskdb.postgres.statefulSet.volumeMounts | list | `[]` |  |
 | smithdb.migration.taskdb.postgres.statefulSet.volumes | list | `[]` |  |
 | smithdb.name | string | `"smithdb"` | Name segment used for SmithDB resources. |
-| smithdb.query.autoscaling.enabled | bool | `true` |  |
-| smithdb.query.autoscaling.maxReplicas | int | `10` |  |
-| smithdb.query.autoscaling.minReplicas | int | `1` |  |
-| smithdb.query.autoscaling.scaleDownStabilizationWindowSeconds | int | `900` |  |
-| smithdb.query.autoscaling.scalePodCount | int | `1` |  |
-| smithdb.query.autoscaling.scaleUpStabilizationWindowSeconds | int | `300` |  |
-| smithdb.query.autoscaling.targetCPUUtilizationPercentage | int | `40` |  |
+| smithdb.query.autoscaling.hpa.enabled | bool | `true` |  |
+| smithdb.query.autoscaling.hpa.maxReplicas | int | `10` |  |
+| smithdb.query.autoscaling.hpa.minReplicas | int | `1` |  |
+| smithdb.query.autoscaling.hpa.scaleDownStabilizationWindowSeconds | int | `900` |  |
+| smithdb.query.autoscaling.hpa.scalePodCount | int | `1` |  |
+| smithdb.query.autoscaling.hpa.scaleUpStabilizationWindowSeconds | int | `300` |  |
+| smithdb.query.autoscaling.hpa.targetCPUUtilizationPercentage | int | `40` |  |
 | smithdb.query.containerGrpcPort | int | `8080` |  |
 | smithdb.query.containerPort | int | `8060` |  |
 | smithdb.query.deployment.affinity | object | `{}` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1019,8 +1019,7 @@ Replica counts and autoscaling remain controlled by each component's `deployment
 | smithdb.compaction.service.annotations | object | `{}` |  |
 | smithdb.compaction.service.labels | object | `{}` |  |
 | smithdb.compaction.service.port | int | `8071` |  |
-| smithdb.compactionWorker.autoscaling.enabled | bool | `true` | Enable compaction worker autoscaling. Retained as the master switch for backwards compatibility. |
-| smithdb.compactionWorker.autoscaling.hpa.enabled | bool | `true` | Enable HPA scaling when autoscaling.enabled is true. |
+| smithdb.compactionWorker.autoscaling.hpa.enabled | bool | `true` | Enable HPA scaling. |
 | smithdb.compactionWorker.autoscaling.keda | object | `{"annotations":{},"cooldownPeriod":300,"enabled":false,"initialCooldownPeriod":0,"labels":{},"pendingJobsThreshold":"60","pollingInterval":30}` | KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster. |
 | smithdb.compactionWorker.autoscaling.keda.pendingJobsThreshold | string | `"60"` | Number of pending compaction jobs per worker. |
 | smithdb.compactionWorker.autoscaling.maxReplicas | int | `10` |  |

--- a/charts/langsmith/templates/smithdb/cluster-manager-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/cluster-manager-deployment.yaml
@@ -75,8 +75,8 @@ spec:
             */}}
             {{- range $svc := list (dict "env" "QUERY" "component" "query") (dict "env" "INGESTION" "component" "ingestion") }}
             {{- $component := index $.Values.smithdb $svc.component }}
-            {{- $hpaEnabled := dig "autoscaling" "enabled" false $component }}
-            {{- $maxReplicas := ternary (dig "autoscaling" "maxReplicas" $component.deployment.replicas $component) $component.deployment.replicas $hpaEnabled }}
+            {{- $hpaEnabled := dig "autoscaling" "hpa" "enabled" false $component }}
+            {{- $maxReplicas := ternary (dig "autoscaling" "hpa" "maxReplicas" $component.deployment.replicas $component) $component.deployment.replicas $hpaEnabled }}
             {{- $prefix := printf "SMITHDB_CLUSTERMANAGER__SERVICES__%s" $svc.env }}
             - name: {{ $prefix }}__MIN_REPLICAS
               value: "1"

--- a/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
@@ -19,7 +19,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if not (and .Values.smithdb.compactionWorker.autoscaling.enabled (or .Values.smithdb.compactionWorker.autoscaling.hpa.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled)) }}
+  {{- if not (or .Values.smithdb.compactionWorker.autoscaling.hpa.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled) }}
   replicas: {{ .Values.smithdb.compactionWorker.deployment.replicas }}
   {{- end }}
   selector:

--- a/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
@@ -2,6 +2,10 @@
 {{- $resources := include "langsmith.smithdb.resources" (dict "root" . "component" "compactionWorker") | fromYaml -}}
 {{- $envVars := concat (include "langsmith.smithdb.componentEnv" (dict "root" . "service" "COMPACTION_WORKER" "displayName" "smithdb-compaction-worker") | fromYamlArray) .Values.smithdb.compactionWorker.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
+{{- $hpaEnabled := dig "autoscaling" "enabled" false .Values.smithdb.compactionWorker -}}
+{{- if kindIs "bool" .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
+{{- $hpaEnabled = .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,7 +23,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if not (dig "autoscaling" "enabled" false .Values.smithdb.compactionWorker) }}
+  {{- if not (or $hpaEnabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled) }}
   replicas: {{ .Values.smithdb.compactionWorker.deployment.replicas }}
   {{- end }}
   selector:

--- a/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
@@ -19,7 +19,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if not (or .Values.smithdb.compactionWorker.autoscaling.hpa.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled) }}
+  {{- if not (or .Values.smithdb.compactionWorker.autoscaling.hpa.enabled (dig "keda" "enabled" false .Values.smithdb.compactionWorker.autoscaling)) }}
   replicas: {{ .Values.smithdb.compactionWorker.deployment.replicas }}
   {{- end }}
   selector:

--- a/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
@@ -2,10 +2,6 @@
 {{- $resources := include "langsmith.smithdb.resources" (dict "root" . "component" "compactionWorker") | fromYaml -}}
 {{- $envVars := concat (include "langsmith.smithdb.componentEnv" (dict "root" . "service" "COMPACTION_WORKER" "displayName" "smithdb-compaction-worker") | fromYamlArray) .Values.smithdb.compactionWorker.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
-{{- $hpaEnabled := dig "autoscaling" "enabled" false .Values.smithdb.compactionWorker -}}
-{{- if kindIs "bool" .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
-{{- $hpaEnabled = .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
-{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -23,7 +19,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if not (or $hpaEnabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled) }}
+  {{- if not (and .Values.smithdb.compactionWorker.autoscaling.enabled (or .Values.smithdb.compactionWorker.autoscaling.hpa.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled)) }}
   replicas: {{ .Values.smithdb.compactionWorker.deployment.replicas }}
   {{- end }}
   selector:

--- a/charts/langsmith/templates/smithdb/compaction-worker-hpa.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-hpa.yaml
@@ -1,8 +1,4 @@
-{{- $hpaEnabled := dig "autoscaling" "enabled" false .Values.smithdb.compactionWorker -}}
-{{- if kindIs "bool" .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
-{{- $hpaEnabled = .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
-{{- end -}}
-{{- if and .Values.smithdb.enabled $hpaEnabled }}
+{{- if and .Values.smithdb.enabled .Values.smithdb.compactionWorker.autoscaling.enabled .Values.smithdb.compactionWorker.autoscaling.hpa.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/langsmith/templates/smithdb/compaction-worker-hpa.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-hpa.yaml
@@ -12,26 +12,26 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compactionWorker") }}
-  minReplicas: {{ .Values.smithdb.compactionWorker.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.smithdb.compactionWorker.autoscaling.maxReplicas }}
+  minReplicas: {{ .Values.smithdb.compactionWorker.autoscaling.hpa.minReplicas }}
+  maxReplicas: {{ .Values.smithdb.compactionWorker.autoscaling.hpa.maxReplicas }}
   behavior:
     scaleUp:
-      stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleUpStabilizationWindowSeconds }}
+      stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.hpa.scaleUpStabilizationWindowSeconds }}
       policies:
         - type: Pods
-          value: {{ .Values.smithdb.compactionWorker.autoscaling.scalePodCount }}
-          periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleUpStabilizationWindowSeconds }}
+          value: {{ .Values.smithdb.compactionWorker.autoscaling.hpa.scalePodCount }}
+          periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.hpa.scaleUpStabilizationWindowSeconds }}
     scaleDown:
-      stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleDownStabilizationWindowSeconds }}
+      stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.hpa.scaleDownStabilizationWindowSeconds }}
       policies:
         - type: Pods
-          value: {{ .Values.smithdb.compactionWorker.autoscaling.scalePodCount }}
-          periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleDownStabilizationWindowSeconds }}
+          value: {{ .Values.smithdb.compactionWorker.autoscaling.hpa.scalePodCount }}
+          periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.hpa.scaleDownStabilizationWindowSeconds }}
   metrics:
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.smithdb.compactionWorker.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ .Values.smithdb.compactionWorker.autoscaling.hpa.targetCPUUtilizationPercentage }}
 {{- end }}

--- a/charts/langsmith/templates/smithdb/compaction-worker-hpa.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-hpa.yaml
@@ -1,4 +1,8 @@
-{{- if and .Values.smithdb.enabled (dig "autoscaling" "enabled" false .Values.smithdb.compactionWorker) }}
+{{- $hpaEnabled := dig "autoscaling" "enabled" false .Values.smithdb.compactionWorker -}}
+{{- if kindIs "bool" .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
+{{- $hpaEnabled = .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
+{{- end -}}
+{{- if and .Values.smithdb.enabled $hpaEnabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/langsmith/templates/smithdb/compaction-worker-hpa.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.smithdb.enabled .Values.smithdb.compactionWorker.autoscaling.enabled .Values.smithdb.compactionWorker.autoscaling.hpa.enabled }}
+{{- if and .Values.smithdb.enabled .Values.smithdb.compactionWorker.autoscaling.hpa.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/langsmith/templates/smithdb/compaction-worker-scaled-object.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-scaled-object.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.smithdb.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled }}
+{{- if and .Values.smithdb.enabled .Values.smithdb.compactionWorker.autoscaling.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/charts/langsmith/templates/smithdb/compaction-worker-scaled-object.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-scaled-object.yaml
@@ -1,0 +1,55 @@
+{{- if and .Values.smithdb.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compactionWorker") }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "langsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compactionWorker") }}
+    {{- with .Values.smithdb.compactionWorker.autoscaling.keda.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    scaledobject.keda.sh/transfer-hpa-ownership: "true"
+    {{- with .Values.smithdb.compactionWorker.autoscaling.keda.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compactionWorker") }}
+  pollingInterval: {{ .Values.smithdb.compactionWorker.autoscaling.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.smithdb.compactionWorker.autoscaling.keda.cooldownPeriod }}
+  initialCooldownPeriod: {{ .Values.smithdb.compactionWorker.autoscaling.keda.initialCooldownPeriod }}
+  minReplicaCount: {{ .Values.smithdb.compactionWorker.autoscaling.minReplicas }}
+  maxReplicaCount: {{ .Values.smithdb.compactionWorker.autoscaling.maxReplicas }}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      name: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compactionWorker") }}
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleUpStabilizationWindowSeconds }}
+          policies:
+            - type: Pods
+              value: {{ .Values.smithdb.compactionWorker.autoscaling.scalePodCount }}
+              periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleUpStabilizationWindowSeconds }}
+        scaleDown:
+          stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleDownStabilizationWindowSeconds }}
+          policies:
+            - type: Pods
+              value: {{ .Values.smithdb.compactionWorker.autoscaling.scalePodCount }}
+              periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleDownStabilizationWindowSeconds }}
+  triggers:
+    - type: metrics-api
+      metadata:
+        targetValue: {{ .Values.smithdb.compactionWorker.autoscaling.keda.pendingJobsThreshold | quote }}
+        url: "http://{{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compaction") }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.smithdb.compaction.containerPort }}/metrics/jobs"
+        valueLocation: "pending"
+        format: "json"
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: {{ .Values.smithdb.compactionWorker.autoscaling.targetCPUUtilizationPercentage | quote }}
+{{- end }}

--- a/charts/langsmith/templates/smithdb/compaction-worker-scaled-object.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-scaled-object.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.smithdb.enabled .Values.smithdb.compactionWorker.autoscaling.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled }}
+{{- if and .Values.smithdb.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/charts/langsmith/templates/smithdb/compaction-worker-scaled-object.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-scaled-object.yaml
@@ -23,24 +23,24 @@ spec:
   pollingInterval: {{ .Values.smithdb.compactionWorker.autoscaling.keda.pollingInterval }}
   cooldownPeriod: {{ .Values.smithdb.compactionWorker.autoscaling.keda.cooldownPeriod }}
   initialCooldownPeriod: {{ .Values.smithdb.compactionWorker.autoscaling.keda.initialCooldownPeriod }}
-  minReplicaCount: {{ .Values.smithdb.compactionWorker.autoscaling.minReplicas }}
-  maxReplicaCount: {{ .Values.smithdb.compactionWorker.autoscaling.maxReplicas }}
+  minReplicaCount: {{ .Values.smithdb.compactionWorker.autoscaling.keda.minReplicaCount }}
+  maxReplicaCount: {{ .Values.smithdb.compactionWorker.autoscaling.keda.maxReplicaCount }}
   advanced:
     horizontalPodAutoscalerConfig:
       name: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compactionWorker") }}
       behavior:
         scaleUp:
-          stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleUpStabilizationWindowSeconds }}
+          stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.keda.scaleUpStabilizationWindowSeconds }}
           policies:
             - type: Pods
-              value: {{ .Values.smithdb.compactionWorker.autoscaling.scalePodCount }}
-              periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleUpStabilizationWindowSeconds }}
+              value: {{ .Values.smithdb.compactionWorker.autoscaling.keda.scalePodCount }}
+              periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.keda.scaleUpStabilizationWindowSeconds }}
         scaleDown:
-          stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleDownStabilizationWindowSeconds }}
+          stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.keda.scaleDownStabilizationWindowSeconds }}
           policies:
             - type: Pods
-              value: {{ .Values.smithdb.compactionWorker.autoscaling.scalePodCount }}
-              periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleDownStabilizationWindowSeconds }}
+              value: {{ .Values.smithdb.compactionWorker.autoscaling.keda.scalePodCount }}
+              periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.keda.scaleDownStabilizationWindowSeconds }}
   triggers:
     - type: metrics-api
       metadata:
@@ -51,5 +51,5 @@ spec:
     - type: cpu
       metricType: Utilization
       metadata:
-        value: {{ .Values.smithdb.compactionWorker.autoscaling.targetCPUUtilizationPercentage | quote }}
+        value: {{ .Values.smithdb.compactionWorker.autoscaling.keda.targetCPUUtilizationPercentage | quote }}
 {{- end }}

--- a/charts/langsmith/templates/smithdb/ingestion-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/ingestion-deployment.yaml
@@ -19,7 +19,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if not (dig "autoscaling" "enabled" false .Values.smithdb.ingestion) }}
+  {{- if not .Values.smithdb.ingestion.autoscaling.hpa.enabled }}
   replicas: {{ .Values.smithdb.ingestion.deployment.replicas }}
   {{- end }}
   strategy:

--- a/charts/langsmith/templates/smithdb/ingestion-hpa.yaml
+++ b/charts/langsmith/templates/smithdb/ingestion-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.smithdb.enabled (dig "autoscaling" "enabled" false .Values.smithdb.ingestion) }}
+{{- if and .Values.smithdb.enabled .Values.smithdb.ingestion.autoscaling.hpa.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -12,26 +12,26 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "ingestion") }}
-  minReplicas: {{ .Values.smithdb.ingestion.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.smithdb.ingestion.autoscaling.maxReplicas }}
+  minReplicas: {{ .Values.smithdb.ingestion.autoscaling.hpa.minReplicas }}
+  maxReplicas: {{ .Values.smithdb.ingestion.autoscaling.hpa.maxReplicas }}
   behavior:
     scaleUp:
-      stabilizationWindowSeconds: {{ .Values.smithdb.ingestion.autoscaling.scaleUpStabilizationWindowSeconds }}
+      stabilizationWindowSeconds: {{ .Values.smithdb.ingestion.autoscaling.hpa.scaleUpStabilizationWindowSeconds }}
       policies:
         - type: Pods
-          value: {{ .Values.smithdb.ingestion.autoscaling.scalePodCount }}
-          periodSeconds: {{ .Values.smithdb.ingestion.autoscaling.scaleUpStabilizationWindowSeconds }}
+          value: {{ .Values.smithdb.ingestion.autoscaling.hpa.scalePodCount }}
+          periodSeconds: {{ .Values.smithdb.ingestion.autoscaling.hpa.scaleUpStabilizationWindowSeconds }}
     scaleDown:
-      stabilizationWindowSeconds: {{ .Values.smithdb.ingestion.autoscaling.scaleDownStabilizationWindowSeconds }}
+      stabilizationWindowSeconds: {{ .Values.smithdb.ingestion.autoscaling.hpa.scaleDownStabilizationWindowSeconds }}
       policies:
         - type: Pods
-          value: {{ .Values.smithdb.ingestion.autoscaling.scalePodCount }}
-          periodSeconds: {{ .Values.smithdb.ingestion.autoscaling.scaleDownStabilizationWindowSeconds }}
+          value: {{ .Values.smithdb.ingestion.autoscaling.hpa.scalePodCount }}
+          periodSeconds: {{ .Values.smithdb.ingestion.autoscaling.hpa.scaleDownStabilizationWindowSeconds }}
   metrics:
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.smithdb.ingestion.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ .Values.smithdb.ingestion.autoscaling.hpa.targetCPUUtilizationPercentage }}
 {{- end }}

--- a/charts/langsmith/templates/smithdb/query-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/query-deployment.yaml
@@ -19,7 +19,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if not (dig "autoscaling" "enabled" false .Values.smithdb.query) }}
+  {{- if not .Values.smithdb.query.autoscaling.hpa.enabled }}
   replicas: {{ .Values.smithdb.query.deployment.replicas }}
   {{- end }}
   strategy:

--- a/charts/langsmith/templates/smithdb/query-hpa.yaml
+++ b/charts/langsmith/templates/smithdb/query-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.smithdb.enabled (dig "autoscaling" "enabled" false .Values.smithdb.query) }}
+{{- if and .Values.smithdb.enabled .Values.smithdb.query.autoscaling.hpa.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -12,26 +12,26 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "query") }}
-  minReplicas: {{ .Values.smithdb.query.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.smithdb.query.autoscaling.maxReplicas }}
+  minReplicas: {{ .Values.smithdb.query.autoscaling.hpa.minReplicas }}
+  maxReplicas: {{ .Values.smithdb.query.autoscaling.hpa.maxReplicas }}
   behavior:
     scaleUp:
-      stabilizationWindowSeconds: {{ .Values.smithdb.query.autoscaling.scaleUpStabilizationWindowSeconds }}
+      stabilizationWindowSeconds: {{ .Values.smithdb.query.autoscaling.hpa.scaleUpStabilizationWindowSeconds }}
       policies:
         - type: Pods
-          value: {{ .Values.smithdb.query.autoscaling.scalePodCount }}
-          periodSeconds: {{ .Values.smithdb.query.autoscaling.scaleUpStabilizationWindowSeconds }}
+          value: {{ .Values.smithdb.query.autoscaling.hpa.scalePodCount }}
+          periodSeconds: {{ .Values.smithdb.query.autoscaling.hpa.scaleUpStabilizationWindowSeconds }}
     scaleDown:
-      stabilizationWindowSeconds: {{ .Values.smithdb.query.autoscaling.scaleDownStabilizationWindowSeconds }}
+      stabilizationWindowSeconds: {{ .Values.smithdb.query.autoscaling.hpa.scaleDownStabilizationWindowSeconds }}
       policies:
         - type: Pods
-          value: {{ .Values.smithdb.query.autoscaling.scalePodCount }}
-          periodSeconds: {{ .Values.smithdb.query.autoscaling.scaleDownStabilizationWindowSeconds }}
+          value: {{ .Values.smithdb.query.autoscaling.hpa.scalePodCount }}
+          periodSeconds: {{ .Values.smithdb.query.autoscaling.hpa.scaleDownStabilizationWindowSeconds }}
   metrics:
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.smithdb.query.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ .Values.smithdb.query.autoscaling.hpa.targetCPUUtilizationPercentage }}
 {{- end }}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -492,21 +492,28 @@ AWS Marketplace Helm template verification).
 {{- fail (printf "smithdb.compactionWorker.autoscaling.%s is no longer supported. Compaction-worker autoscaling now uses nested blocks: set autoscaling.hpa.enabled with hpa.minReplicas, hpa.maxReplicas, and related hpa.* fields for chart-managed HPA, or autoscaling.keda.enabled with keda.minReplicaCount, keda.maxReplicaCount, keda.pendingJobsThreshold, and related keda.* fields for KEDA scaling on pending compaction jobs and CPU. Only one scaler can be enabled at a time." .) -}}
 {{- end -}}
 {{- end -}}
-{{- if and .Values.smithdb.enabled $cwAutoscaling.hpa.enabled $cwAutoscaling.keda.enabled -}}
+{{- if and .Values.smithdb.enabled $cwAutoscaling.hpa.enabled (dig "keda" "enabled" false $cwAutoscaling) -}}
 {{- fail "Only one of smithdb.compactionWorker.autoscaling.hpa.enabled or smithdb.compactionWorker.autoscaling.keda.enabled can be enabled at the same time." -}}
 {{- end -}}
-{{- $smithdbAutoscalingWorkloads := dict
+{{- $legacySmithdbHpaAutoscalingKeys := list "enabled" "minReplicas" "maxReplicas" "targetCPUUtilizationPercentage" "scaleUpStabilizationWindowSeconds" "scaleDownStabilizationWindowSeconds" "scalePodCount" "createHpa" "type" -}}
+{{- $smithdbHpaAutoscalingWorkloads := dict
   "query" .Values.smithdb.query
   "ingestion" .Values.smithdb.ingestion
 -}}
-{{- range $workloadName, $workload := $smithdbAutoscalingWorkloads -}}
+{{- range $workloadName, $workload := $smithdbHpaAutoscalingWorkloads -}}
 {{- $autoscaling := dig "autoscaling" (dict) $workload -}}
-{{- if and $.Values.smithdb.enabled (dig "enabled" false $autoscaling) -}}
-{{- if lt (int $autoscaling.minReplicas) 1 -}}
-{{- fail (printf "smithdb.%s.autoscaling.minReplicas must be greater than 0 when autoscaling is enabled." $workloadName) -}}
+{{- range $legacySmithdbHpaAutoscalingKeys -}}
+{{- if and $.Values.smithdb.enabled (hasKey $autoscaling .) -}}
+{{- fail (printf "smithdb.%s.autoscaling.%s is no longer supported. Use autoscaling.hpa.enabled with hpa.minReplicas, hpa.maxReplicas, and related hpa.* fields." $workloadName .) -}}
 {{- end -}}
-{{- if lt (int $autoscaling.maxReplicas) (int $autoscaling.minReplicas) -}}
-{{- fail (printf "smithdb.%s.autoscaling.maxReplicas must be >= minReplicas when autoscaling is enabled." $workloadName) -}}
+{{- end -}}
+{{- $hpa := dig "hpa" (dict) $autoscaling -}}
+{{- if and $.Values.smithdb.enabled (dig "enabled" false $hpa) -}}
+{{- if lt (int $hpa.minReplicas) 1 -}}
+{{- fail (printf "smithdb.%s.autoscaling.hpa.minReplicas must be greater than 0 when autoscaling.hpa.enabled is true." $workloadName) -}}
+{{- end -}}
+{{- if lt (int $hpa.maxReplicas) (int $hpa.minReplicas) -}}
+{{- fail (printf "smithdb.%s.autoscaling.hpa.maxReplicas must be >= hpa.minReplicas when autoscaling.hpa.enabled is true." $workloadName) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -549,6 +549,7 @@ AWS Marketplace Helm template verification).
   "playground" .Values.playground.autoscaling
   "queue" .Values.queue.autoscaling
   "ingestQueue" .Values.ingestQueue.autoscaling
+  "smithdb.compactionWorker" .Values.smithdb.compactionWorker.autoscaling
 -}}
 {{- range $serviceName, $autoscaling := $autoscalingServices -}}
 {{- /* Validate that both HPA and KEDA are not enabled at the same time */ -}}
@@ -565,10 +566,6 @@ AWS Marketplace Helm template verification).
 {{- if hasKey $autoscaling "enabled" -}}
 {{- fail (printf "%s.autoscaling.enabled is deprecated. Please use %s.autoscaling.hpa.enabled and/or %s.autoscaling.keda.enabled instead." $serviceName $serviceName $serviceName) -}}
 {{- end -}}
-{{- end -}}
-
-{{- if and .Values.smithdb.compactionWorker.autoscaling.hpa.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled -}}
-{{- fail "Only one of smithdb.compactionWorker.autoscaling.hpa.enabled or smithdb.compactionWorker.autoscaling.keda.enabled can be enabled at the same time. Set hpa.enabled to false when enabling KEDA." -}}
 {{- end -}}
 
 {{- end -}}{{- /* end skipValidation */ -}}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -489,7 +489,7 @@ AWS Marketplace Helm template verification).
 {{- $legacyCompactionWorkerAutoscalingKeys := list "enabled" "minReplicas" "maxReplicas" "targetCPUUtilizationPercentage" "scaleUpStabilizationWindowSeconds" "scaleDownStabilizationWindowSeconds" "scalePodCount" "createHpa" "type" -}}
 {{- range $legacyCompactionWorkerAutoscalingKeys -}}
 {{- if and $.Values.smithdb.enabled (hasKey $cwAutoscaling .) -}}
-{{- fail (printf "smithdb.compactionWorker.autoscaling.%s is no longer supported. Compaction-worker autoscaling now uses nested blocks: set autoscaling.hpa.enabled with hpa.minReplicas, hpa.maxReplicas, and related hpa.* fields for chart-managed HPA, or autoscaling.keda.enabled with keda.minReplicaCount, keda.maxReplicaCount, keda.pendingJobsThreshold, and related keda.* fields for KEDA scaling on pending compaction jobs and CPU. Only one scaler can be enabled at a time." .) -}}
+{{- fail (printf "smithdb.compactionWorker.autoscaling.%s is no longer supported. Use autoscaling.hpa.* for chart-managed HPA or autoscaling.keda.* for KEDA; only one scaler can be enabled at a time." .) -}}
 {{- end -}}
 {{- end -}}
 {{- if and .Values.smithdb.enabled $cwAutoscaling.hpa.enabled (dig "keda" "enabled" false $cwAutoscaling) -}}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -567,12 +567,7 @@ AWS Marketplace Helm template verification).
 {{- end -}}
 {{- end -}}
 
-{{- /* The SmithDB compaction worker retains autoscaling.enabled as a legacy HPA alias. */ -}}
-{{- $compactionWorkerHpaEnabled := .Values.smithdb.compactionWorker.autoscaling.enabled -}}
-{{- if kindIs "bool" .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
-{{- $compactionWorkerHpaEnabled = .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
-{{- end -}}
-{{- if and $compactionWorkerHpaEnabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled -}}
+{{- if and .Values.smithdb.compactionWorker.autoscaling.hpa.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled -}}
 {{- fail "Only one of smithdb.compactionWorker.autoscaling.hpa.enabled or smithdb.compactionWorker.autoscaling.keda.enabled can be enabled at the same time. Set hpa.enabled to false when enabling KEDA." -}}
 {{- end -}}
 

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -485,10 +485,19 @@ AWS Marketplace Helm template verification).
 {{- if and .Values.smithdb.enabled (ne (toString .Values.smithdb.compactionWorker.maxConcurrentJobs) "") (lt (int .Values.smithdb.compactionWorker.maxConcurrentJobs) 1) -}}
 {{- fail "smithdb.compactionWorker.maxConcurrentJobs must be greater than 0 when set." -}}
 {{- end -}}
+{{- $cwAutoscaling := .Values.smithdb.compactionWorker.autoscaling -}}
+{{- $legacyCompactionWorkerAutoscalingKeys := list "enabled" "minReplicas" "maxReplicas" "targetCPUUtilizationPercentage" "scaleUpStabilizationWindowSeconds" "scaleDownStabilizationWindowSeconds" "scalePodCount" "createHpa" "type" -}}
+{{- range $legacyCompactionWorkerAutoscalingKeys -}}
+{{- if and $.Values.smithdb.enabled (hasKey $cwAutoscaling .) -}}
+{{- fail (printf "smithdb.compactionWorker.autoscaling.%s is no longer supported. Compaction-worker autoscaling now uses nested blocks: set autoscaling.hpa.enabled with hpa.minReplicas, hpa.maxReplicas, and related hpa.* fields for chart-managed HPA, or autoscaling.keda.enabled with keda.minReplicaCount, keda.maxReplicaCount, keda.pendingJobsThreshold, and related keda.* fields for KEDA scaling on pending compaction jobs and CPU. Only one scaler can be enabled at a time." .) -}}
+{{- end -}}
+{{- end -}}
+{{- if and .Values.smithdb.enabled $cwAutoscaling.hpa.enabled $cwAutoscaling.keda.enabled -}}
+{{- fail "Only one of smithdb.compactionWorker.autoscaling.hpa.enabled or smithdb.compactionWorker.autoscaling.keda.enabled can be enabled at the same time." -}}
+{{- end -}}
 {{- $smithdbAutoscalingWorkloads := dict
   "query" .Values.smithdb.query
   "ingestion" .Values.smithdb.ingestion
-  "compactionWorker" .Values.smithdb.compactionWorker
 -}}
 {{- range $workloadName, $workload := $smithdbAutoscalingWorkloads -}}
 {{- $autoscaling := dig "autoscaling" (dict) $workload -}}
@@ -549,7 +558,6 @@ AWS Marketplace Helm template verification).
   "playground" .Values.playground.autoscaling
   "queue" .Values.queue.autoscaling
   "ingestQueue" .Values.ingestQueue.autoscaling
-  "smithdb.compactionWorker" .Values.smithdb.compactionWorker.autoscaling
 -}}
 {{- range $serviceName, $autoscaling := $autoscalingServices -}}
 {{- /* Validate that both HPA and KEDA are not enabled at the same time */ -}}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -567,6 +567,15 @@ AWS Marketplace Helm template verification).
 {{- end -}}
 {{- end -}}
 
+{{- /* The SmithDB compaction worker retains autoscaling.enabled as a legacy HPA alias. */ -}}
+{{- $compactionWorkerHpaEnabled := .Values.smithdb.compactionWorker.autoscaling.enabled -}}
+{{- if kindIs "bool" .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
+{{- $compactionWorkerHpaEnabled = .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
+{{- end -}}
+{{- if and $compactionWorkerHpaEnabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled -}}
+{{- fail "Only one of smithdb.compactionWorker.autoscaling.hpa.enabled or smithdb.compactionWorker.autoscaling.keda.enabled can be enabled at the same time. Set hpa.enabled to false when enabling KEDA." -}}
+{{- end -}}
+
 {{- end -}}{{- /* end skipValidation */ -}}
 
 {{- /* Engine (co-hosted Insights+Engine) requires config when enabled. */ -}}

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -908,11 +908,11 @@ tests:
       - notExists:
           path: spec.replicas
 
-  - it: should honor the legacy compaction-worker autoscaling master switch
+  - it: should render compaction-worker replicas when autoscaling is disabled
     values:
       - ./values/smithdb-enabled.yaml
     set:
-      smithdb.compactionWorker.autoscaling.enabled: false
+      smithdb.compactionWorker.autoscaling.hpa.enabled: false
     template: smithdb/compaction-worker-deployment.yaml
     asserts:
       - equal:

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -908,11 +908,11 @@ tests:
       - notExists:
           path: spec.replicas
 
-  - it: should honor explicit compaction-worker HPA disablement over the legacy setting
+  - it: should honor the legacy compaction-worker autoscaling master switch
     values:
       - ./values/smithdb-enabled.yaml
     set:
-      smithdb.compactionWorker.autoscaling.hpa.enabled: false
+      smithdb.compactionWorker.autoscaling.enabled: false
     template: smithdb/compaction-worker-deployment.yaml
     asserts:
       - equal:

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -15,6 +15,7 @@ templates:
   - smithdb/compaction-deployment.yaml
   - smithdb/compaction-worker-deployment.yaml
   - smithdb/compaction-worker-hpa.yaml
+  - smithdb/compaction-worker-scaled-object.yaml
   - smithdb/cluster-manager-deployment.yaml
   - smithdb/migration-job.yaml
   - smithdb/taskdb-postgres-secret.yaml
@@ -863,6 +864,60 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.ephemeral-storage
           value: "100Gi"
+
+  - it: should enable compaction-worker KEDA scaling from pending jobs and CPU
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.compactionWorker.autoscaling.hpa.enabled: false
+      smithdb.compactionWorker.autoscaling.keda.enabled: true
+    template: smithdb/compaction-worker-scaled-object.yaml
+    asserts:
+      - isKind:
+          of: ScaledObject
+      - equal:
+          path: spec.minReplicaCount
+          value: 1
+      - equal:
+          path: spec.maxReplicaCount
+          value: 10
+      - equal:
+          path: spec.triggers[0].type
+          value: metrics-api
+      - equal:
+          path: spec.triggers[0].metadata.url
+          value: http://RELEASE-NAME-langsmith-smithdb-compaction.NAMESPACE.svc.cluster.local:8070/metrics/jobs
+      - equal:
+          path: spec.triggers[0].metadata.valueLocation
+          value: pending
+      - equal:
+          path: spec.triggers[0].metadata.targetValue
+          value: "60"
+      - equal:
+          path: spec.triggers[1].type
+          value: cpu
+
+  - it: should omit compaction-worker deployment replicas when KEDA is enabled
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.compactionWorker.autoscaling.hpa.enabled: false
+      smithdb.compactionWorker.autoscaling.keda.enabled: true
+    template: smithdb/compaction-worker-deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.replicas
+
+  - it: should honor explicit compaction-worker HPA disablement over the legacy setting
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.compactionWorker.autoscaling.hpa.enabled: false
+    template: smithdb/compaction-worker-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
 
   - it: should expose compaction worker concurrency as a value
     values:

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -724,8 +724,8 @@ tests:
     values:
       - ./values/smithdb-enabled.yaml
     set:
-      smithdb.query.autoscaling.enabled: false
-      smithdb.ingestion.autoscaling.enabled: false
+      smithdb.query.autoscaling.hpa.enabled: false
+      smithdb.ingestion.autoscaling.hpa.enabled: false
       smithdb.query.deployment.replicas: 4
       smithdb.ingestion.deployment.replicas: 2
     template: smithdb/cluster-manager-deployment.yaml
@@ -771,9 +771,9 @@ tests:
       - ./values/smithdb-enabled.yaml
     set:
       smithdb.query.deployment.replicas: 1
-      smithdb.query.autoscaling.enabled: true
-      smithdb.query.autoscaling.minReplicas: 2
-      smithdb.query.autoscaling.maxReplicas: 6
+      smithdb.query.autoscaling.hpa.enabled: true
+      smithdb.query.autoscaling.hpa.minReplicas: 2
+      smithdb.query.autoscaling.hpa.maxReplicas: 6
     template: smithdb/cluster-manager-deployment.yaml
     asserts:
       - contains:

--- a/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
@@ -28,7 +28,7 @@ tests:
       smithdb.compactionWorker.autoscaling.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: "smithdb.compactionWorker.autoscaling.enabled is no longer supported. Compaction-worker autoscaling now uses nested blocks: set autoscaling.hpa.enabled with hpa.minReplicas, hpa.maxReplicas, and related hpa.* fields for chart-managed HPA, or autoscaling.keda.enabled with keda.minReplicaCount, keda.maxReplicaCount, keda.pendingJobsThreshold, and related keda.* fields for KEDA scaling on pending compaction jobs and CPU. Only one scaler can be enabled at a time."
+          errorMessage: "smithdb.compactionWorker.autoscaling.enabled is no longer supported. Use autoscaling.hpa.* for chart-managed HPA or autoscaling.keda.* for KEDA; only one scaler can be enabled at a time."
 
   - it: should reject legacy flat compaction-worker autoscaling minReplicas
     values:
@@ -38,7 +38,7 @@ tests:
       smithdb.compactionWorker.autoscaling.minReplicas: 2
     asserts:
       - failedTemplate:
-          errorMessage: "smithdb.compactionWorker.autoscaling.minReplicas is no longer supported. Compaction-worker autoscaling now uses nested blocks: set autoscaling.hpa.enabled with hpa.minReplicas, hpa.maxReplicas, and related hpa.* fields for chart-managed HPA, or autoscaling.keda.enabled with keda.minReplicaCount, keda.maxReplicaCount, keda.pendingJobsThreshold, and related keda.* fields for KEDA scaling on pending compaction jobs and CPU. Only one scaler can be enabled at a time."
+          errorMessage: "smithdb.compactionWorker.autoscaling.minReplicas is no longer supported. Use autoscaling.hpa.* for chart-managed HPA or autoscaling.keda.* for KEDA; only one scaler can be enabled at a time."
 
   - it: should reject legacy flat query autoscaling.enabled
     values:

--- a/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
@@ -40,6 +40,26 @@ tests:
       - failedTemplate:
           errorMessage: "smithdb.compactionWorker.autoscaling.minReplicas is no longer supported. Compaction-worker autoscaling now uses nested blocks: set autoscaling.hpa.enabled with hpa.minReplicas, hpa.maxReplicas, and related hpa.* fields for chart-managed HPA, or autoscaling.keda.enabled with keda.minReplicaCount, keda.maxReplicaCount, keda.pendingJobsThreshold, and related keda.* fields for KEDA scaling on pending compaction jobs and CPU. Only one scaler can be enabled at a time."
 
+  - it: should reject legacy flat query autoscaling.enabled
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      config.existingSecretName: langsmith-secret
+      smithdb.query.autoscaling.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "smithdb.query.autoscaling.enabled is no longer supported. Use autoscaling.hpa.enabled with hpa.minReplicas, hpa.maxReplicas, and related hpa.* fields."
+
+  - it: should reject legacy flat ingestion autoscaling minReplicas
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      config.existingSecretName: langsmith-secret
+      smithdb.ingestion.autoscaling.minReplicas: 2
+    asserts:
+      - failedTemplate:
+          errorMessage: "smithdb.ingestion.autoscaling.minReplicas is no longer supported. Use autoscaling.hpa.enabled with hpa.minReplicas, hpa.maxReplicas, and related hpa.* fields."
+
   - it: should reject smithdb without query replicas
     values:
       - ./values/smithdb-enabled.yaml

--- a/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
@@ -9,6 +9,17 @@ tests:
       - failedTemplate:
           errorMessage: "smithdb.resourceTier must be one of: small, medium, large."
 
+  - it: should reject compaction-worker HPA and KEDA being enabled together
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      config.existingSecretName: langsmith-secret
+      smithdb.compactionWorker.autoscaling.hpa.enabled: true
+      smithdb.compactionWorker.autoscaling.keda.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Only one of smithdb.compactionWorker.autoscaling.hpa.enabled or smithdb.compactionWorker.autoscaling.keda.enabled can be enabled at the same time. Set hpa.enabled to false when enabling KEDA."
+
   - it: should reject smithdb without query replicas
     values:
       - ./values/smithdb-enabled.yaml

--- a/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
@@ -20,6 +20,26 @@ tests:
       - failedTemplate:
           errorMessage: "Only one of smithdb.compactionWorker.autoscaling.hpa.enabled or smithdb.compactionWorker.autoscaling.keda.enabled can be enabled at the same time."
 
+  - it: should reject legacy flat compaction-worker autoscaling.enabled
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      config.existingSecretName: langsmith-secret
+      smithdb.compactionWorker.autoscaling.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "smithdb.compactionWorker.autoscaling.enabled is no longer supported. Compaction-worker autoscaling now uses nested blocks: set autoscaling.hpa.enabled with hpa.minReplicas, hpa.maxReplicas, and related hpa.* fields for chart-managed HPA, or autoscaling.keda.enabled with keda.minReplicaCount, keda.maxReplicaCount, keda.pendingJobsThreshold, and related keda.* fields for KEDA scaling on pending compaction jobs and CPU. Only one scaler can be enabled at a time."
+
+  - it: should reject legacy flat compaction-worker autoscaling minReplicas
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      config.existingSecretName: langsmith-secret
+      smithdb.compactionWorker.autoscaling.minReplicas: 2
+    asserts:
+      - failedTemplate:
+          errorMessage: "smithdb.compactionWorker.autoscaling.minReplicas is no longer supported. Compaction-worker autoscaling now uses nested blocks: set autoscaling.hpa.enabled with hpa.minReplicas, hpa.maxReplicas, and related hpa.* fields for chart-managed HPA, or autoscaling.keda.enabled with keda.minReplicaCount, keda.maxReplicaCount, keda.pendingJobsThreshold, and related keda.* fields for KEDA scaling on pending compaction jobs and CPU. Only one scaler can be enabled at a time."
+
   - it: should reject smithdb without query replicas
     values:
       - ./values/smithdb-enabled.yaml

--- a/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
@@ -18,7 +18,7 @@ tests:
       smithdb.compactionWorker.autoscaling.keda.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: "Only one of smithdb.compactionWorker.autoscaling.hpa.enabled or smithdb.compactionWorker.autoscaling.keda.enabled can be enabled at the same time. Set hpa.enabled to false when enabling KEDA."
+          errorMessage: "Only one of smithdb.compactionWorker.autoscaling.hpa.enabled or smithdb.compactionWorker.autoscaling.keda.enabled can be enabled at the same time."
 
   - it: should reject smithdb without query replicas
     values:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1694,15 +1694,15 @@ smithdb:
       labels: {}
       annotations: {}
     autoscaling:
-      minReplicas: 1
-      maxReplicas: 10
-      targetCPUUtilizationPercentage: 60
-      scaleUpStabilizationWindowSeconds: 120
-      scaleDownStabilizationWindowSeconds: 300
-      scalePodCount: 1
       hpa:
         # -- Enable HPA scaling.
         enabled: true
+        minReplicas: 1
+        maxReplicas: 10
+        targetCPUUtilizationPercentage: 60
+        scaleUpStabilizationWindowSeconds: 120
+        scaleDownStabilizationWindowSeconds: 300
+        scalePodCount: 1
       # -- KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster.
       keda:
         enabled: false
@@ -1711,6 +1711,12 @@ smithdb:
         pollingInterval: 30
         cooldownPeriod: 300
         initialCooldownPeriod: 0
+        minReplicaCount: 1
+        maxReplicaCount: 10
+        targetCPUUtilizationPercentage: 60
+        scaleUpStabilizationWindowSeconds: 120
+        scaleDownStabilizationWindowSeconds: 300
+        scalePodCount: 1
         # -- Number of pending compaction jobs per worker.
         pendingJobsThreshold: "60"
 

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1694,8 +1694,6 @@ smithdb:
       labels: {}
       annotations: {}
     autoscaling:
-      # -- Enable compaction worker autoscaling. Retained as the master switch for backwards compatibility.
-      enabled: true
       minReplicas: 1
       maxReplicas: 10
       targetCPUUtilizationPercentage: 60
@@ -1703,7 +1701,7 @@ smithdb:
       scaleDownStabilizationWindowSeconds: 300
       scalePodCount: 1
       hpa:
-        # -- Enable HPA scaling when autoscaling.enabled is true.
+        # -- Enable HPA scaling.
         enabled: true
       # -- KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster.
       keda:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1498,13 +1498,14 @@ smithdb:
       labels: {}
       annotations: {}
     autoscaling:
-      enabled: true
-      minReplicas: 1
-      maxReplicas: 10
-      targetCPUUtilizationPercentage: 40
-      scaleUpStabilizationWindowSeconds: 300
-      scaleDownStabilizationWindowSeconds: 900
-      scalePodCount: 1
+      hpa:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 10
+        targetCPUUtilizationPercentage: 40
+        scaleUpStabilizationWindowSeconds: 300
+        scaleDownStabilizationWindowSeconds: 900
+        scalePodCount: 1
 
   ingestion:
     name: "ingestion"
@@ -1573,13 +1574,14 @@ smithdb:
       labels: {}
       annotations: {}
     autoscaling:
-      enabled: true
-      minReplicas: 1
-      maxReplicas: 10
-      targetCPUUtilizationPercentage: 45
-      scaleUpStabilizationWindowSeconds: 300
-      scaleDownStabilizationWindowSeconds: 900
-      scalePodCount: 1
+      hpa:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 10
+        targetCPUUtilizationPercentage: 45
+        scaleUpStabilizationWindowSeconds: 300
+        scaleDownStabilizationWindowSeconds: 900
+        scalePodCount: 1
 
   compaction:
     name: "compaction"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1693,9 +1693,10 @@ smithdb:
       minAvailable: 1
       labels: {}
       annotations: {}
+    # Autoscaling configuration. Either HPA or KEDA can be enabled, not both.
     autoscaling:
+      # HPA-specific configuration
       hpa:
-        # -- Enable HPA scaling.
         enabled: true
         minReplicas: 1
         maxReplicas: 10
@@ -1703,7 +1704,8 @@ smithdb:
         scaleUpStabilizationWindowSeconds: 120
         scaleDownStabilizationWindowSeconds: 300
         scalePodCount: 1
-      # -- KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster.
+      # KEDA ScaledObject configuration. See https://keda.sh/docs/2.18/reference/scaledobject-spec
+      # These are some recommended default values. You can tweak them to your needs, using the docs above.
       keda:
         enabled: false
         labels: {}

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1694,6 +1694,7 @@ smithdb:
       labels: {}
       annotations: {}
     autoscaling:
+      # -- Legacy HPA enablement setting. Retained for backwards compatibility; hpa.enabled takes precedence when set.
       enabled: true
       minReplicas: 1
       maxReplicas: 10
@@ -1701,6 +1702,19 @@ smithdb:
       scaleUpStabilizationWindowSeconds: 120
       scaleDownStabilizationWindowSeconds: 300
       scalePodCount: 1
+      hpa:
+        # -- Enable HPA scaling. Null inherits the legacy autoscaling.enabled value.
+        enabled: null
+      # -- KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster.
+      keda:
+        enabled: false
+        labels: {}
+        annotations: {}
+        pollingInterval: 30
+        cooldownPeriod: 300
+        initialCooldownPeriod: 0
+        # -- Number of pending compaction jobs per worker.
+        pendingJobsThreshold: "60"
 
   clusterManager:
     name: "cluster-manager"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1694,7 +1694,7 @@ smithdb:
       labels: {}
       annotations: {}
     autoscaling:
-      # -- Legacy HPA enablement setting. Retained for backwards compatibility; hpa.enabled takes precedence when set.
+      # -- Enable compaction worker autoscaling. Retained as the master switch for backwards compatibility.
       enabled: true
       minReplicas: 1
       maxReplicas: 10
@@ -1703,8 +1703,8 @@ smithdb:
       scaleDownStabilizationWindowSeconds: 300
       scalePodCount: 1
       hpa:
-        # -- Enable HPA scaling. Null inherits the legacy autoscaling.enabled value.
-        enabled: null
+        # -- Enable HPA scaling when autoscaling.enabled is true.
+        enabled: true
       # -- KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster.
       keda:
         enabled: false


### PR DESCRIPTION
## Summary
- add backwards-compatible HPA and KEDA selection for the SmithDB compaction worker
- scale from pending compaction jobs and CPU using the metrics endpoint pattern
- validate mutually exclusive scalers and document the new values

## Testing
- `helm lint charts/langsmith`
- `helm unittest charts/langsmith` (297 tests passed)