### PR TITLE
[v16 backport] Add KEDA scaling for SmithDB compaction workers

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1042,8 +1042,8 @@ Two things worth planning for before you enable it:
 | smithdb.compaction.service.annotations | object | `{}` |  |
 | smithdb.compaction.service.labels | object | `{}` |  |
 | smithdb.compaction.service.port | int | `8071` |  |
-| smithdb.compactionWorker.autoscaling.enabled | bool | `true` | Legacy HPA enablement setting. Retained for backwards compatibility; hpa.enabled takes precedence when set. |
-| smithdb.compactionWorker.autoscaling.hpa.enabled | string | `nil` | Enable HPA scaling. Null inherits the legacy autoscaling.enabled value. |
+| smithdb.compactionWorker.autoscaling.enabled | bool | `true` | Enable compaction worker autoscaling. Retained as the master switch for backwards compatibility. |
+| smithdb.compactionWorker.autoscaling.hpa.enabled | bool | `true` | Enable HPA scaling when autoscaling.enabled is true. |
 | smithdb.compactionWorker.autoscaling.keda | object | `{"annotations":{},"cooldownPeriod":300,"enabled":false,"initialCooldownPeriod":0,"labels":{},"pendingJobsThreshold":"60","pollingInterval":30}` | KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster. |
 | smithdb.compactionWorker.autoscaling.keda.pendingJobsThreshold | string | `"60"` | Number of pending compaction jobs per worker. |
 | smithdb.compactionWorker.autoscaling.maxReplicas | int | `10` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1042,7 +1042,10 @@ Two things worth planning for before you enable it:
 | smithdb.compaction.service.annotations | object | `{}` |  |
 | smithdb.compaction.service.labels | object | `{}` |  |
 | smithdb.compaction.service.port | int | `8071` |  |
-| smithdb.compactionWorker.autoscaling.enabled | bool | `true` |  |
+| smithdb.compactionWorker.autoscaling.enabled | bool | `true` | Legacy HPA enablement setting. Retained for backwards compatibility; hpa.enabled takes precedence when set. |
+| smithdb.compactionWorker.autoscaling.hpa.enabled | string | `nil` | Enable HPA scaling. Null inherits the legacy autoscaling.enabled value. |
+| smithdb.compactionWorker.autoscaling.keda | object | `{"annotations":{},"cooldownPeriod":300,"enabled":false,"initialCooldownPeriod":0,"labels":{},"pendingJobsThreshold":"60","pollingInterval":30}` | KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster. |
+| smithdb.compactionWorker.autoscaling.keda.pendingJobsThreshold | string | `"60"` | Number of pending compaction jobs per worker. |
 | smithdb.compactionWorker.autoscaling.maxReplicas | int | `10` |  |
 | smithdb.compactionWorker.autoscaling.minReplicas | int | `1` |  |
 | smithdb.compactionWorker.autoscaling.scaleDownStabilizationWindowSeconds | int | `300` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1043,14 +1043,14 @@ Two things worth planning for before you enable it:
 | smithdb.compaction.service.labels | object | `{}` |  |
 | smithdb.compaction.service.port | int | `8071` |  |
 | smithdb.compactionWorker.autoscaling.hpa.enabled | bool | `true` | Enable HPA scaling. |
-| smithdb.compactionWorker.autoscaling.keda | object | `{"annotations":{},"cooldownPeriod":300,"enabled":false,"initialCooldownPeriod":0,"labels":{},"pendingJobsThreshold":"60","pollingInterval":30}` | KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster. |
+| smithdb.compactionWorker.autoscaling.hpa.maxReplicas | int | `10` |  |
+| smithdb.compactionWorker.autoscaling.hpa.minReplicas | int | `1` |  |
+| smithdb.compactionWorker.autoscaling.hpa.scaleDownStabilizationWindowSeconds | int | `300` |  |
+| smithdb.compactionWorker.autoscaling.hpa.scalePodCount | int | `1` |  |
+| smithdb.compactionWorker.autoscaling.hpa.scaleUpStabilizationWindowSeconds | int | `120` |  |
+| smithdb.compactionWorker.autoscaling.hpa.targetCPUUtilizationPercentage | int | `60` |  |
+| smithdb.compactionWorker.autoscaling.keda | object | `{"annotations":{},"cooldownPeriod":300,"enabled":false,"initialCooldownPeriod":0,"labels":{},"maxReplicaCount":10,"minReplicaCount":1,"pendingJobsThreshold":"60","pollingInterval":30,"scaleDownStabilizationWindowSeconds":300,"scalePodCount":1,"scaleUpStabilizationWindowSeconds":120,"targetCPUUtilizationPercentage":60}` | KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster. |
 | smithdb.compactionWorker.autoscaling.keda.pendingJobsThreshold | string | `"60"` | Number of pending compaction jobs per worker. |
-| smithdb.compactionWorker.autoscaling.maxReplicas | int | `10` |  |
-| smithdb.compactionWorker.autoscaling.minReplicas | int | `1` |  |
-| smithdb.compactionWorker.autoscaling.scaleDownStabilizationWindowSeconds | int | `300` |  |
-| smithdb.compactionWorker.autoscaling.scalePodCount | int | `1` |  |
-| smithdb.compactionWorker.autoscaling.scaleUpStabilizationWindowSeconds | int | `120` |  |
-| smithdb.compactionWorker.autoscaling.targetCPUUtilizationPercentage | int | `60` |  |
 | smithdb.compactionWorker.containerPort | int | `9000` |  |
 | smithdb.compactionWorker.deployment.affinity | object | `{}` |  |
 | smithdb.compactionWorker.deployment.annotations | object | `{}` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1042,8 +1042,7 @@ Two things worth planning for before you enable it:
 | smithdb.compaction.service.annotations | object | `{}` |  |
 | smithdb.compaction.service.labels | object | `{}` |  |
 | smithdb.compaction.service.port | int | `8071` |  |
-| smithdb.compactionWorker.autoscaling.enabled | bool | `true` | Enable compaction worker autoscaling. Retained as the master switch for backwards compatibility. |
-| smithdb.compactionWorker.autoscaling.hpa.enabled | bool | `true` | Enable HPA scaling when autoscaling.enabled is true. |
+| smithdb.compactionWorker.autoscaling.hpa.enabled | bool | `true` | Enable HPA scaling. |
 | smithdb.compactionWorker.autoscaling.keda | object | `{"annotations":{},"cooldownPeriod":300,"enabled":false,"initialCooldownPeriod":0,"labels":{},"pendingJobsThreshold":"60","pollingInterval":30}` | KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster. |
 | smithdb.compactionWorker.autoscaling.keda.pendingJobsThreshold | string | `"60"` | Number of pending compaction jobs per worker. |
 | smithdb.compactionWorker.autoscaling.maxReplicas | int | `10` |  |

--- a/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.smithdb.enabled }}
 {{- $envVars := concat (include "langsmith.smithdb.componentEnv" (dict "root" . "service" "COMPACTION_WORKER" "displayName" "smithdb-compaction-worker") | fromYamlArray) .Values.smithdb.compactionWorker.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
+{{- $hpaEnabled := dig "autoscaling" "enabled" false .Values.smithdb.compactionWorker -}}
+{{- if kindIs "bool" .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
+{{- $hpaEnabled = .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -18,7 +22,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if not (dig "autoscaling" "enabled" false .Values.smithdb.compactionWorker) }}
+  {{- if not (or $hpaEnabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled) }}
   replicas: {{ .Values.smithdb.compactionWorker.deployment.replicas }}
   {{- end }}
   selector:

--- a/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
@@ -18,7 +18,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if not (and .Values.smithdb.compactionWorker.autoscaling.enabled (or .Values.smithdb.compactionWorker.autoscaling.hpa.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled)) }}
+  {{- if not (or .Values.smithdb.compactionWorker.autoscaling.hpa.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled) }}
   replicas: {{ .Values.smithdb.compactionWorker.deployment.replicas }}
   {{- end }}
   selector:

--- a/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
@@ -1,10 +1,6 @@
 {{- if .Values.smithdb.enabled }}
 {{- $envVars := concat (include "langsmith.smithdb.componentEnv" (dict "root" . "service" "COMPACTION_WORKER" "displayName" "smithdb-compaction-worker") | fromYamlArray) .Values.smithdb.compactionWorker.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
-{{- $hpaEnabled := dig "autoscaling" "enabled" false .Values.smithdb.compactionWorker -}}
-{{- if kindIs "bool" .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
-{{- $hpaEnabled = .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
-{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,7 +18,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if not (or $hpaEnabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled) }}
+  {{- if not (and .Values.smithdb.compactionWorker.autoscaling.enabled (or .Values.smithdb.compactionWorker.autoscaling.hpa.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled)) }}
   replicas: {{ .Values.smithdb.compactionWorker.deployment.replicas }}
   {{- end }}
   selector:

--- a/charts/langsmith/templates/smithdb/compaction-worker-hpa.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-hpa.yaml
@@ -1,8 +1,4 @@
-{{- $hpaEnabled := dig "autoscaling" "enabled" false .Values.smithdb.compactionWorker -}}
-{{- if kindIs "bool" .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
-{{- $hpaEnabled = .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
-{{- end -}}
-{{- if and .Values.smithdb.enabled $hpaEnabled }}
+{{- if and .Values.smithdb.enabled .Values.smithdb.compactionWorker.autoscaling.enabled .Values.smithdb.compactionWorker.autoscaling.hpa.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/langsmith/templates/smithdb/compaction-worker-hpa.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-hpa.yaml
@@ -12,26 +12,26 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compactionWorker") }}
-  minReplicas: {{ .Values.smithdb.compactionWorker.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.smithdb.compactionWorker.autoscaling.maxReplicas }}
+  minReplicas: {{ .Values.smithdb.compactionWorker.autoscaling.hpa.minReplicas }}
+  maxReplicas: {{ .Values.smithdb.compactionWorker.autoscaling.hpa.maxReplicas }}
   behavior:
     scaleUp:
-      stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleUpStabilizationWindowSeconds }}
+      stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.hpa.scaleUpStabilizationWindowSeconds }}
       policies:
         - type: Pods
-          value: {{ .Values.smithdb.compactionWorker.autoscaling.scalePodCount }}
-          periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleUpStabilizationWindowSeconds }}
+          value: {{ .Values.smithdb.compactionWorker.autoscaling.hpa.scalePodCount }}
+          periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.hpa.scaleUpStabilizationWindowSeconds }}
     scaleDown:
-      stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleDownStabilizationWindowSeconds }}
+      stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.hpa.scaleDownStabilizationWindowSeconds }}
       policies:
         - type: Pods
-          value: {{ .Values.smithdb.compactionWorker.autoscaling.scalePodCount }}
-          periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleDownStabilizationWindowSeconds }}
+          value: {{ .Values.smithdb.compactionWorker.autoscaling.hpa.scalePodCount }}
+          periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.hpa.scaleDownStabilizationWindowSeconds }}
   metrics:
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.smithdb.compactionWorker.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ .Values.smithdb.compactionWorker.autoscaling.hpa.targetCPUUtilizationPercentage }}
 {{- end }}

--- a/charts/langsmith/templates/smithdb/compaction-worker-hpa.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-hpa.yaml
@@ -1,4 +1,8 @@
-{{- if and .Values.smithdb.enabled (dig "autoscaling" "enabled" false .Values.smithdb.compactionWorker) }}
+{{- $hpaEnabled := dig "autoscaling" "enabled" false .Values.smithdb.compactionWorker -}}
+{{- if kindIs "bool" .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
+{{- $hpaEnabled = .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
+{{- end -}}
+{{- if and .Values.smithdb.enabled $hpaEnabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/langsmith/templates/smithdb/compaction-worker-hpa.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.smithdb.enabled .Values.smithdb.compactionWorker.autoscaling.enabled .Values.smithdb.compactionWorker.autoscaling.hpa.enabled }}
+{{- if and .Values.smithdb.enabled .Values.smithdb.compactionWorker.autoscaling.hpa.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/langsmith/templates/smithdb/compaction-worker-scaled-object.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-scaled-object.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.smithdb.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled }}
+{{- if and .Values.smithdb.enabled .Values.smithdb.compactionWorker.autoscaling.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/charts/langsmith/templates/smithdb/compaction-worker-scaled-object.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-scaled-object.yaml
@@ -1,0 +1,55 @@
+{{- if and .Values.smithdb.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compactionWorker") }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "langsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compactionWorker") }}
+    {{- with .Values.smithdb.compactionWorker.autoscaling.keda.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    scaledobject.keda.sh/transfer-hpa-ownership: "true"
+    {{- with .Values.smithdb.compactionWorker.autoscaling.keda.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compactionWorker") }}
+  pollingInterval: {{ .Values.smithdb.compactionWorker.autoscaling.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.smithdb.compactionWorker.autoscaling.keda.cooldownPeriod }}
+  initialCooldownPeriod: {{ .Values.smithdb.compactionWorker.autoscaling.keda.initialCooldownPeriod }}
+  minReplicaCount: {{ .Values.smithdb.compactionWorker.autoscaling.minReplicas }}
+  maxReplicaCount: {{ .Values.smithdb.compactionWorker.autoscaling.maxReplicas }}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      name: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compactionWorker") }}
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleUpStabilizationWindowSeconds }}
+          policies:
+            - type: Pods
+              value: {{ .Values.smithdb.compactionWorker.autoscaling.scalePodCount }}
+              periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleUpStabilizationWindowSeconds }}
+        scaleDown:
+          stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleDownStabilizationWindowSeconds }}
+          policies:
+            - type: Pods
+              value: {{ .Values.smithdb.compactionWorker.autoscaling.scalePodCount }}
+              periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleDownStabilizationWindowSeconds }}
+  triggers:
+    - type: metrics-api
+      metadata:
+        targetValue: {{ .Values.smithdb.compactionWorker.autoscaling.keda.pendingJobsThreshold | quote }}
+        url: "http://{{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compaction") }}.{{ .Values.namespace | default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.smithdb.compaction.containerPort }}/metrics/jobs"
+        valueLocation: "pending"
+        format: "json"
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: {{ .Values.smithdb.compactionWorker.autoscaling.targetCPUUtilizationPercentage | quote }}
+{{- end }}

--- a/charts/langsmith/templates/smithdb/compaction-worker-scaled-object.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-scaled-object.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.smithdb.enabled .Values.smithdb.compactionWorker.autoscaling.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled }}
+{{- if and .Values.smithdb.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/charts/langsmith/templates/smithdb/compaction-worker-scaled-object.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-scaled-object.yaml
@@ -23,24 +23,24 @@ spec:
   pollingInterval: {{ .Values.smithdb.compactionWorker.autoscaling.keda.pollingInterval }}
   cooldownPeriod: {{ .Values.smithdb.compactionWorker.autoscaling.keda.cooldownPeriod }}
   initialCooldownPeriod: {{ .Values.smithdb.compactionWorker.autoscaling.keda.initialCooldownPeriod }}
-  minReplicaCount: {{ .Values.smithdb.compactionWorker.autoscaling.minReplicas }}
-  maxReplicaCount: {{ .Values.smithdb.compactionWorker.autoscaling.maxReplicas }}
+  minReplicaCount: {{ .Values.smithdb.compactionWorker.autoscaling.keda.minReplicaCount }}
+  maxReplicaCount: {{ .Values.smithdb.compactionWorker.autoscaling.keda.maxReplicaCount }}
   advanced:
     horizontalPodAutoscalerConfig:
       name: {{ include "langsmith.smithdb.componentName" (dict "root" . "component" "compactionWorker") }}
       behavior:
         scaleUp:
-          stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleUpStabilizationWindowSeconds }}
+          stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.keda.scaleUpStabilizationWindowSeconds }}
           policies:
             - type: Pods
-              value: {{ .Values.smithdb.compactionWorker.autoscaling.scalePodCount }}
-              periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleUpStabilizationWindowSeconds }}
+              value: {{ .Values.smithdb.compactionWorker.autoscaling.keda.scalePodCount }}
+              periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.keda.scaleUpStabilizationWindowSeconds }}
         scaleDown:
-          stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleDownStabilizationWindowSeconds }}
+          stabilizationWindowSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.keda.scaleDownStabilizationWindowSeconds }}
           policies:
             - type: Pods
-              value: {{ .Values.smithdb.compactionWorker.autoscaling.scalePodCount }}
-              periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.scaleDownStabilizationWindowSeconds }}
+              value: {{ .Values.smithdb.compactionWorker.autoscaling.keda.scalePodCount }}
+              periodSeconds: {{ .Values.smithdb.compactionWorker.autoscaling.keda.scaleDownStabilizationWindowSeconds }}
   triggers:
     - type: metrics-api
       metadata:
@@ -51,5 +51,5 @@ spec:
     - type: cpu
       metricType: Utilization
       metadata:
-        value: {{ .Values.smithdb.compactionWorker.autoscaling.targetCPUUtilizationPercentage | quote }}
+        value: {{ .Values.smithdb.compactionWorker.autoscaling.keda.targetCPUUtilizationPercentage | quote }}
 {{- end }}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -552,12 +552,7 @@ AWS Marketplace Helm template verification).
 {{- end -}}
 {{- end -}}
 
-{{- /* The SmithDB compaction worker retains autoscaling.enabled as a legacy HPA alias. */ -}}
-{{- $compactionWorkerHpaEnabled := .Values.smithdb.compactionWorker.autoscaling.enabled -}}
-{{- if kindIs "bool" .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
-{{- $compactionWorkerHpaEnabled = .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
-{{- end -}}
-{{- if and $compactionWorkerHpaEnabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled -}}
+{{- if and .Values.smithdb.compactionWorker.autoscaling.hpa.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled -}}
 {{- fail "Only one of smithdb.compactionWorker.autoscaling.hpa.enabled or smithdb.compactionWorker.autoscaling.keda.enabled can be enabled at the same time. Set hpa.enabled to false when enabling KEDA." -}}
 {{- end -}}
 

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -552,6 +552,15 @@ AWS Marketplace Helm template verification).
 {{- end -}}
 {{- end -}}
 
+{{- /* The SmithDB compaction worker retains autoscaling.enabled as a legacy HPA alias. */ -}}
+{{- $compactionWorkerHpaEnabled := .Values.smithdb.compactionWorker.autoscaling.enabled -}}
+{{- if kindIs "bool" .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
+{{- $compactionWorkerHpaEnabled = .Values.smithdb.compactionWorker.autoscaling.hpa.enabled -}}
+{{- end -}}
+{{- if and $compactionWorkerHpaEnabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled -}}
+{{- fail "Only one of smithdb.compactionWorker.autoscaling.hpa.enabled or smithdb.compactionWorker.autoscaling.keda.enabled can be enabled at the same time. Set hpa.enabled to false when enabling KEDA." -}}
+{{- end -}}
+
 {{- end -}}{{- /* end skipValidation */ -}}
 
 {{- /* Engine (co-hosted Insights+Engine) requires config when enabled. */ -}}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -534,6 +534,7 @@ AWS Marketplace Helm template verification).
   "playground" .Values.playground.autoscaling
   "queue" .Values.queue.autoscaling
   "ingestQueue" .Values.ingestQueue.autoscaling
+  "smithdb.compactionWorker" .Values.smithdb.compactionWorker.autoscaling
 -}}
 {{- range $serviceName, $autoscaling := $autoscalingServices -}}
 {{- /* Validate that both HPA and KEDA are not enabled at the same time */ -}}
@@ -550,10 +551,6 @@ AWS Marketplace Helm template verification).
 {{- if hasKey $autoscaling "enabled" -}}
 {{- fail (printf "%s.autoscaling.enabled is deprecated. Please use %s.autoscaling.hpa.enabled and/or %s.autoscaling.keda.enabled instead." $serviceName $serviceName $serviceName) -}}
 {{- end -}}
-{{- end -}}
-
-{{- if and .Values.smithdb.compactionWorker.autoscaling.hpa.enabled .Values.smithdb.compactionWorker.autoscaling.keda.enabled -}}
-{{- fail "Only one of smithdb.compactionWorker.autoscaling.hpa.enabled or smithdb.compactionWorker.autoscaling.keda.enabled can be enabled at the same time. Set hpa.enabled to false when enabling KEDA." -}}
 {{- end -}}
 
 {{- end -}}{{- /* end skipValidation */ -}}

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -844,11 +844,11 @@ tests:
       - notExists:
           path: spec.replicas
 
-  - it: should honor the legacy compaction-worker autoscaling master switch
+  - it: should render compaction-worker replicas when autoscaling is disabled
     values:
       - ./values/smithdb-enabled.yaml
     set:
-      smithdb.compactionWorker.autoscaling.enabled: false
+      smithdb.compactionWorker.autoscaling.hpa.enabled: false
     template: smithdb/compaction-worker-deployment.yaml
     asserts:
       - equal:

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -15,6 +15,7 @@ templates:
   - smithdb/compaction-deployment.yaml
   - smithdb/compaction-worker-deployment.yaml
   - smithdb/compaction-worker-hpa.yaml
+  - smithdb/compaction-worker-scaled-object.yaml
   - smithdb/cluster-manager-deployment.yaml
   - smithdb/migration-job.yaml
   - smithdb/taskdb-postgres-secret.yaml
@@ -799,6 +800,60 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.ephemeral-storage
           value: "100Gi"
+
+  - it: should enable compaction-worker KEDA scaling from pending jobs and CPU
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.compactionWorker.autoscaling.hpa.enabled: false
+      smithdb.compactionWorker.autoscaling.keda.enabled: true
+    template: smithdb/compaction-worker-scaled-object.yaml
+    asserts:
+      - isKind:
+          of: ScaledObject
+      - equal:
+          path: spec.minReplicaCount
+          value: 1
+      - equal:
+          path: spec.maxReplicaCount
+          value: 10
+      - equal:
+          path: spec.triggers[0].type
+          value: metrics-api
+      - equal:
+          path: spec.triggers[0].metadata.url
+          value: http://RELEASE-NAME-langsmith-smithdb-compaction.NAMESPACE.svc.cluster.local:8070/metrics/jobs
+      - equal:
+          path: spec.triggers[0].metadata.valueLocation
+          value: pending
+      - equal:
+          path: spec.triggers[0].metadata.targetValue
+          value: "60"
+      - equal:
+          path: spec.triggers[1].type
+          value: cpu
+
+  - it: should omit compaction-worker deployment replicas when KEDA is enabled
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.compactionWorker.autoscaling.hpa.enabled: false
+      smithdb.compactionWorker.autoscaling.keda.enabled: true
+    template: smithdb/compaction-worker-deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.replicas
+
+  - it: should honor explicit compaction-worker HPA disablement over the legacy setting
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.compactionWorker.autoscaling.hpa.enabled: false
+    template: smithdb/compaction-worker-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
 
   - it: should expose compaction worker concurrency as a value
     values:

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -844,11 +844,11 @@ tests:
       - notExists:
           path: spec.replicas
 
-  - it: should honor explicit compaction-worker HPA disablement over the legacy setting
+  - it: should honor the legacy compaction-worker autoscaling master switch
     values:
       - ./values/smithdb-enabled.yaml
     set:
-      smithdb.compactionWorker.autoscaling.hpa.enabled: false
+      smithdb.compactionWorker.autoscaling.enabled: false
     template: smithdb/compaction-worker-deployment.yaml
     asserts:
       - equal:

--- a/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
@@ -2,6 +2,17 @@ suite: test smithdb phase validation
 templates:
   - validate.yaml
 tests:
+  - it: should reject compaction-worker HPA and KEDA being enabled together
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      config.existingSecretName: langsmith-secret
+      smithdb.compactionWorker.autoscaling.hpa.enabled: true
+      smithdb.compactionWorker.autoscaling.keda.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Only one of smithdb.compactionWorker.autoscaling.hpa.enabled or smithdb.compactionWorker.autoscaling.keda.enabled can be enabled at the same time. Set hpa.enabled to false when enabling KEDA."
+
   - it: should reject smithdb without query replicas
     values:
       - ./values/smithdb-enabled.yaml
@@ -203,4 +214,3 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "smithdb.commonInitContainers[0] must be a container object."
-

--- a/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
@@ -11,7 +11,7 @@ tests:
       smithdb.compactionWorker.autoscaling.keda.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: "Only one of smithdb.compactionWorker.autoscaling.hpa.enabled or smithdb.compactionWorker.autoscaling.keda.enabled can be enabled at the same time. Set hpa.enabled to false when enabling KEDA."
+          errorMessage: "Only one of smithdb.compactionWorker.autoscaling.hpa.enabled or smithdb.compactionWorker.autoscaling.keda.enabled can be enabled at the same time."
 
   - it: should reject smithdb without query replicas
     values:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1771,8 +1771,6 @@ smithdb:
       labels: {}
       annotations: {}
     autoscaling:
-      # -- Enable compaction worker autoscaling. Retained as the master switch for backwards compatibility.
-      enabled: true
       minReplicas: 1
       maxReplicas: 10
       targetCPUUtilizationPercentage: 60
@@ -1780,7 +1778,7 @@ smithdb:
       scaleDownStabilizationWindowSeconds: 300
       scalePodCount: 1
       hpa:
-        # -- Enable HPA scaling when autoscaling.enabled is true.
+        # -- Enable HPA scaling.
         enabled: true
       # -- KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster.
       keda:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1771,7 +1771,7 @@ smithdb:
       labels: {}
       annotations: {}
     autoscaling:
-      # -- Legacy HPA enablement setting. Retained for backwards compatibility; hpa.enabled takes precedence when set.
+      # -- Enable compaction worker autoscaling. Retained as the master switch for backwards compatibility.
       enabled: true
       minReplicas: 1
       maxReplicas: 10
@@ -1780,8 +1780,8 @@ smithdb:
       scaleDownStabilizationWindowSeconds: 300
       scalePodCount: 1
       hpa:
-        # -- Enable HPA scaling. Null inherits the legacy autoscaling.enabled value.
-        enabled: null
+        # -- Enable HPA scaling when autoscaling.enabled is true.
+        enabled: true
       # -- KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster.
       keda:
         enabled: false

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1771,6 +1771,7 @@ smithdb:
       labels: {}
       annotations: {}
     autoscaling:
+      # -- Legacy HPA enablement setting. Retained for backwards compatibility; hpa.enabled takes precedence when set.
       enabled: true
       minReplicas: 1
       maxReplicas: 10
@@ -1778,6 +1779,19 @@ smithdb:
       scaleUpStabilizationWindowSeconds: 120
       scaleDownStabilizationWindowSeconds: 300
       scalePodCount: 1
+      hpa:
+        # -- Enable HPA scaling. Null inherits the legacy autoscaling.enabled value.
+        enabled: null
+      # -- KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster.
+      keda:
+        enabled: false
+        labels: {}
+        annotations: {}
+        pollingInterval: 30
+        cooldownPeriod: 300
+        initialCooldownPeriod: 0
+        # -- Number of pending compaction jobs per worker.
+        pendingJobsThreshold: "60"
 
   clusterManager:
     name: "cluster-manager"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1771,15 +1771,15 @@ smithdb:
       labels: {}
       annotations: {}
     autoscaling:
-      minReplicas: 1
-      maxReplicas: 10
-      targetCPUUtilizationPercentage: 60
-      scaleUpStabilizationWindowSeconds: 120
-      scaleDownStabilizationWindowSeconds: 300
-      scalePodCount: 1
       hpa:
         # -- Enable HPA scaling.
         enabled: true
+        minReplicas: 1
+        maxReplicas: 10
+        targetCPUUtilizationPercentage: 60
+        scaleUpStabilizationWindowSeconds: 120
+        scaleDownStabilizationWindowSeconds: 300
+        scalePodCount: 1
       # -- KEDA scaling based on pending compaction jobs and CPU. Requires KEDA to be installed in the cluster.
       keda:
         enabled: false
@@ -1788,6 +1788,12 @@ smithdb:
         pollingInterval: 30
         cooldownPeriod: 300
         initialCooldownPeriod: 0
+        minReplicaCount: 1
+        maxReplicaCount: 10
+        targetCPUUtilizationPercentage: 60
+        scaleUpStabilizationWindowSeconds: 120
+        scaleDownStabilizationWindowSeconds: 300
+        scalePodCount: 1
         # -- Number of pending compaction jobs per worker.
         pendingJobsThreshold: "60"
 


### PR DESCRIPTION
## Summary
Backport of #990 to `v16-stable`.

- add HPA/KEDA selection for the SmithDB compaction worker
- scale from pending compaction jobs and CPU using the SaaS metrics endpoint pattern
- validate mutually exclusive scalers and document the new values

## Testing
- `helm lint charts/langsmith`
- SmithDB suites: 75 tests passed
- full suite: 318 passed, with 2 pre-existing JuiceFS annotation failures reproduced on the unmodified `v16-stable` baseline