### PR TITLE
fix(langsmith): backport configurable ServiceAccount token automount to v16

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.13
+version: 0.16.14
 appVersion: "0.16.47"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.16.13](https://img.shields.io/badge/Version-0.16.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.47](https://img.shields.io/badge/AppVersion-0.16.47-informational?style=flat-square)
+![Version: 0.16.14](https://img.shields.io/badge/Version-0.16.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.47](https://img.shields.io/badge/AppVersion-0.16.47-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 

--- a/charts/langsmith/templates/agent-features/fleet/api-server/serviceaccount.yaml
+++ b/charts/langsmith/templates/agent-features/fleet/api-server/serviceaccount.yaml
@@ -15,6 +15,6 @@ metadata:
     {{- with .Values.fleet.apiServer.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-automountServiceAccountToken: true
+automountServiceAccountToken: {{ .Values.fleet.apiServer.serviceAccount.automountServiceAccountToken }}
 {{- end }}
 {{- end }}

--- a/charts/langsmith/templates/agent-features/fleet/postgres/serviceaccount.yaml
+++ b/charts/langsmith/templates/agent-features/fleet/postgres/serviceaccount.yaml
@@ -16,6 +16,6 @@ metadata:
     {{- with .Values.fleet.postgres.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-automountServiceAccountToken: true
+automountServiceAccountToken: {{ .Values.fleet.postgres.serviceAccount.automountServiceAccountToken }}
 {{- end }}
 {{- end }}

--- a/charts/langsmith/templates/agent-features/fleet/queue/serviceaccount.yaml
+++ b/charts/langsmith/templates/agent-features/fleet/queue/serviceaccount.yaml
@@ -15,6 +15,6 @@ metadata:
     {{- with .Values.fleet.queue.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-automountServiceAccountToken: true
+automountServiceAccountToken: {{ .Values.fleet.queue.serviceAccount.automountServiceAccountToken }}
 {{- end }}
 {{- end }}

--- a/charts/langsmith/templates/agent-features/fleet/redis/serviceaccount.yaml
+++ b/charts/langsmith/templates/agent-features/fleet/redis/serviceaccount.yaml
@@ -16,6 +16,6 @@ metadata:
     {{- with .Values.fleet.redis.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-automountServiceAccountToken: true
+automountServiceAccountToken: {{ .Values.fleet.redis.serviceAccount.automountServiceAccountToken }}
 {{- end }}
 {{- end }}

--- a/charts/langsmith/templates/agent-features/insights/api-server/serviceaccount.yaml
+++ b/charts/langsmith/templates/agent-features/insights/api-server/serviceaccount.yaml
@@ -15,6 +15,6 @@ metadata:
     {{- with .Values.engineInsightsAgent.apiServer.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-automountServiceAccountToken: true
+automountServiceAccountToken: {{ .Values.engineInsightsAgent.apiServer.serviceAccount.automountServiceAccountToken }}
 {{- end }}
 {{- end }}

--- a/charts/langsmith/templates/agent-features/insights/postgres/serviceaccount.yaml
+++ b/charts/langsmith/templates/agent-features/insights/postgres/serviceaccount.yaml
@@ -16,6 +16,6 @@ metadata:
     {{- with .Values.engineInsightsAgent.postgres.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-automountServiceAccountToken: true
+automountServiceAccountToken: {{ .Values.engineInsightsAgent.postgres.serviceAccount.automountServiceAccountToken }}
 {{- end }}
 {{- end }}

--- a/charts/langsmith/templates/agent-features/insights/queue/serviceaccount.yaml
+++ b/charts/langsmith/templates/agent-features/insights/queue/serviceaccount.yaml
@@ -15,6 +15,6 @@ metadata:
     {{- with .Values.engineInsightsAgent.queue.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-automountServiceAccountToken: true
+automountServiceAccountToken: {{ .Values.engineInsightsAgent.queue.serviceAccount.automountServiceAccountToken }}
 {{- end }}
 {{- end }}

--- a/charts/langsmith/templates/agent-features/insights/redis/serviceaccount.yaml
+++ b/charts/langsmith/templates/agent-features/insights/redis/serviceaccount.yaml
@@ -16,6 +16,6 @@ metadata:
     {{- with .Values.engineInsightsAgent.redis.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-automountServiceAccountToken: true
+automountServiceAccountToken: {{ .Values.engineInsightsAgent.redis.serviceAccount.automountServiceAccountToken }}
 {{- end }}
 {{- end }}

--- a/charts/langsmith/templates/agent-features/polly/api-server/serviceaccount.yaml
+++ b/charts/langsmith/templates/agent-features/polly/api-server/serviceaccount.yaml
@@ -15,6 +15,6 @@ metadata:
     {{- with .Values.polly.apiServer.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-automountServiceAccountToken: true
+automountServiceAccountToken: {{ .Values.polly.apiServer.serviceAccount.automountServiceAccountToken }}
 {{- end }}
 {{- end }}

--- a/charts/langsmith/templates/agent-features/polly/postgres/serviceaccount.yaml
+++ b/charts/langsmith/templates/agent-features/polly/postgres/serviceaccount.yaml
@@ -16,6 +16,6 @@ metadata:
     {{- with .Values.polly.postgres.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-automountServiceAccountToken: true
+automountServiceAccountToken: {{ .Values.polly.postgres.serviceAccount.automountServiceAccountToken }}
 {{- end }}
 {{- end }}

--- a/charts/langsmith/templates/agent-features/polly/queue/serviceaccount.yaml
+++ b/charts/langsmith/templates/agent-features/polly/queue/serviceaccount.yaml
@@ -15,6 +15,6 @@ metadata:
     {{- with .Values.polly.queue.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-automountServiceAccountToken: true
+automountServiceAccountToken: {{ .Values.polly.queue.serviceAccount.automountServiceAccountToken }}
 {{- end }}
 {{- end }}

--- a/charts/langsmith/templates/agent-features/polly/redis/serviceaccount.yaml
+++ b/charts/langsmith/templates/agent-features/polly/redis/serviceaccount.yaml
@@ -16,6 +16,6 @@ metadata:
     {{- with .Values.polly.redis.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-automountServiceAccountToken: true
+automountServiceAccountToken: {{ .Values.polly.redis.serviceAccount.automountServiceAccountToken }}
 {{- end }}
 {{- end }}

--- a/charts/langsmith/tests/service_account_test.yaml
+++ b/charts/langsmith/tests/service_account_test.yaml
@@ -1,0 +1,89 @@
+suite: ServiceAccount token automount configuration
+templates:
+  - agent-features/fleet/api-server/serviceaccount.yaml
+  - agent-features/fleet/postgres/serviceaccount.yaml
+  - agent-features/fleet/queue/serviceaccount.yaml
+  - agent-features/fleet/redis/serviceaccount.yaml
+  - agent-features/insights/api-server/serviceaccount.yaml
+  - agent-features/insights/postgres/serviceaccount.yaml
+  - agent-features/insights/queue/serviceaccount.yaml
+  - agent-features/insights/redis/serviceaccount.yaml
+  - agent-features/polly/api-server/serviceaccount.yaml
+  - agent-features/polly/postgres/serviceaccount.yaml
+  - agent-features/polly/queue/serviceaccount.yaml
+  - agent-features/polly/redis/serviceaccount.yaml
+tests:
+  - it: configures Fleet ServiceAccounts
+    set:
+      fleet.enabled: true
+      fleet.apiServer.serviceAccount.automountServiceAccountToken: false
+      fleet.postgres.serviceAccount.automountServiceAccountToken: false
+      fleet.queue.serviceAccount.automountServiceAccountToken: false
+      fleet.redis.serviceAccount.automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+        template: agent-features/fleet/api-server/serviceaccount.yaml
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+        template: agent-features/fleet/postgres/serviceaccount.yaml
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+        template: agent-features/fleet/queue/serviceaccount.yaml
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+        template: agent-features/fleet/redis/serviceaccount.yaml
+
+  - it: configures Engine and Insights ServiceAccounts
+    set:
+      insights.enabled: true
+      engineInsightsAgent.apiServer.serviceAccount.automountServiceAccountToken: false
+      engineInsightsAgent.postgres.serviceAccount.automountServiceAccountToken: false
+      engineInsightsAgent.queue.serviceAccount.automountServiceAccountToken: false
+      engineInsightsAgent.redis.serviceAccount.automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+        template: agent-features/insights/api-server/serviceaccount.yaml
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+        template: agent-features/insights/postgres/serviceaccount.yaml
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+        template: agent-features/insights/queue/serviceaccount.yaml
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+        template: agent-features/insights/redis/serviceaccount.yaml
+
+  - it: configures Polly ServiceAccounts
+    set:
+      polly.enabled: true
+      polly.apiServer.serviceAccount.automountServiceAccountToken: false
+      polly.postgres.serviceAccount.automountServiceAccountToken: false
+      polly.queue.serviceAccount.automountServiceAccountToken: false
+      polly.redis.serviceAccount.automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+        template: agent-features/polly/api-server/serviceaccount.yaml
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+        template: agent-features/polly/postgres/serviceaccount.yaml
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+        template: agent-features/polly/queue/serviceaccount.yaml
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+        template: agent-features/polly/redis/serviceaccount.yaml


### PR DESCRIPTION
### Summary

- backport the LangSmith portion of #993 to `v16-stable`
- wire Fleet, Engine/Insights, and Polly ServiceAccounts to their existing `automountServiceAccountToken` values
- preserve the backward-compatible `true` defaults and bump the v16 LangSmith chart to `0.16.14`

### Test Plan

- [x] confirmed the new Helm unit test fails before the template changes
- [x] `helm unittest charts/langsmith` (319 tests)
- [x] `helm lint charts/langsmith`
- [x] static audit confirms no hardcoded token automount remains in the backported agent-feature ServiceAccounts
