### PR TITLE
feat(langsmith): backport SmithDB resource tiers to v16

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.13
+version: 0.16.14
 appVersion: "0.16.47"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.16.13](https://img.shields.io/badge/Version-0.16.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.47](https://img.shields.io/badge/AppVersion-0.16.47-informational?style=flat-square)
+![Version: 0.16.14](https://img.shields.io/badge/Version-0.16.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.47](https://img.shields.io/badge/AppVersion-0.16.47-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -29,6 +29,20 @@ Two things worth planning for before you enable it:
 **Sandbox nodes.** Sandboxes are Firecracker microVMs, so `sandboxes.sandboxHost.deployment.nodeSelector` must place host pods on KVM-capable nodes — bare-metal instances, or instance types with nested virtualization explicitly enabled. Sandbox images are published for `linux/amd64` only. A dedicated, tainted node pool is the usual arrangement, since rolling a sandbox-host pod suspends every microVM on it.
 
 **Which workspace owns the sandboxes.** By default smith-go resolves the install's workspace, which works when there is exactly one non-personal organization. With more than one it declines rather than guess, and you must set `engine.sandboxTenantId` explicitly. Prefer a workspace reserved for the Engine: its sandboxes are visible to anyone with access to it.
+
+## SmithDB resource tiers
+
+`smithdb.resourceTier` selects the default per-replica resource sizes shown below. The default is `small`. For components that use local disk, the tier's ephemeral-storage limit also sets the generated `emptyDir.sizeLimit`.
+
+Replica counts and autoscaling remain controlled by each component's `deployment.replicas` and `autoscaling` settings. Explicit component `resources` or `volumes` settings take precedence over the tier defaults.
+
+| Component | Small | Medium | Large |
+|---|---|---|---|
+| Query | 4 CPU, 8Gi memory, 200Gi ephemeral | 28 CPU, 48Gi memory, 200Gi ephemeral | 28 CPU, 50Gi memory, 1000Gi ephemeral |
+| Ingestion | 4 CPU, 8Gi memory, 100Gi ephemeral | 16 CPU, 32Gi memory, 100Gi ephemeral | 56 CPU, 150Gi memory, 1000Gi ephemeral |
+| Compaction | 2 CPU, 4Gi memory | 4 CPU, 8Gi memory | 8 CPU, 16Gi memory |
+| Compaction worker | 8 CPU, 16Gi memory, 100Gi ephemeral | 16 CPU, 32Gi memory, 100Gi ephemeral | 28 CPU, 50Gi memory, 300Gi ephemeral |
+| Cluster manager | 250m CPU, 256Mi memory | 250m CPU, 256Mi memory | 2 CPU, 2Gi memory |
 
 ## General parameters
 
@@ -977,10 +991,6 @@ Two things worth planning for before you enable it:
 | smithdb.clusterManager.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.clusterManager.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.clusterManager.deployment.replicas | int | `1` |  |
-| smithdb.clusterManager.deployment.resources.limits.cpu | string | `"250m"` |  |
-| smithdb.clusterManager.deployment.resources.limits.memory | string | `"256Mi"` |  |
-| smithdb.clusterManager.deployment.resources.requests.cpu | string | `"250m"` |  |
-| smithdb.clusterManager.deployment.resources.requests.memory | string | `"256Mi"` |  |
 | smithdb.clusterManager.deployment.securityContext | object | `{}` |  |
 | smithdb.clusterManager.deployment.sidecars | list | `[]` |  |
 | smithdb.clusterManager.deployment.tolerations | list | `[]` |  |
@@ -1024,10 +1034,6 @@ Two things worth planning for before you enable it:
 | smithdb.compaction.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.compaction.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.compaction.deployment.replicas | int | `1` |  |
-| smithdb.compaction.deployment.resources.limits.cpu | string | `"2"` |  |
-| smithdb.compaction.deployment.resources.limits.memory | string | `"4Gi"` |  |
-| smithdb.compaction.deployment.resources.requests.cpu | string | `"2"` |  |
-| smithdb.compaction.deployment.resources.requests.memory | string | `"4Gi"` |  |
 | smithdb.compaction.deployment.securityContext | object | `{}` |  |
 | smithdb.compaction.deployment.sidecars | list | `[]` |  |
 | smithdb.compaction.deployment.tolerations | list | `[]` |  |
@@ -1078,12 +1084,6 @@ Two things worth planning for before you enable it:
 | smithdb.compactionWorker.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.compactionWorker.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.compactionWorker.deployment.replicas | int | `2` |  |
-| smithdb.compactionWorker.deployment.resources.limits.cpu | string | `"8"` |  |
-| smithdb.compactionWorker.deployment.resources.limits.ephemeral-storage | string | `"100Gi"` |  |
-| smithdb.compactionWorker.deployment.resources.limits.memory | string | `"16Gi"` |  |
-| smithdb.compactionWorker.deployment.resources.requests.cpu | string | `"8"` |  |
-| smithdb.compactionWorker.deployment.resources.requests.ephemeral-storage | string | `"100Gi"` |  |
-| smithdb.compactionWorker.deployment.resources.requests.memory | string | `"16Gi"` |  |
 | smithdb.compactionWorker.deployment.securityContext | object | `{}` |  |
 | smithdb.compactionWorker.deployment.sidecars | list | `[]` |  |
 | smithdb.compactionWorker.deployment.terminationGracePeriodSeconds | int | `120` |  |
@@ -1091,8 +1091,6 @@ Two things worth planning for before you enable it:
 | smithdb.compactionWorker.deployment.topologySpreadConstraints | list | `[]` |  |
 | smithdb.compactionWorker.deployment.volumeMounts[0].mountPath | string | `"/data"` |  |
 | smithdb.compactionWorker.deployment.volumeMounts[0].name | string | `"local-ssd-storage"` |  |
-| smithdb.compactionWorker.deployment.volumes[0].emptyDir.sizeLimit | string | `"100Gi"` |  |
-| smithdb.compactionWorker.deployment.volumes[0].name | string | `"local-ssd-storage"` |  |
 | smithdb.compactionWorker.maxConcurrentJobs | string | `""` | Maximum concurrent jobs per compaction worker. Empty uses the SmithDB default. |
 | smithdb.compactionWorker.name | string | `"compaction-worker"` |  |
 | smithdb.compactionWorker.pdb.annotations | object | `{}` |  |
@@ -1154,12 +1152,6 @@ Two things worth planning for before you enable it:
 | smithdb.ingestion.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.ingestion.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.ingestion.deployment.replicas | int | `1` |  |
-| smithdb.ingestion.deployment.resources.limits.cpu | string | `"4"` |  |
-| smithdb.ingestion.deployment.resources.limits.ephemeral-storage | string | `"100Gi"` |  |
-| smithdb.ingestion.deployment.resources.limits.memory | string | `"8Gi"` |  |
-| smithdb.ingestion.deployment.resources.requests.cpu | string | `"4"` |  |
-| smithdb.ingestion.deployment.resources.requests.ephemeral-storage | string | `"100Gi"` |  |
-| smithdb.ingestion.deployment.resources.requests.memory | string | `"8Gi"` |  |
 | smithdb.ingestion.deployment.securityContext | object | `{}` |  |
 | smithdb.ingestion.deployment.sidecars | list | `[]` |  |
 | smithdb.ingestion.deployment.strategy.rollingUpdate.maxSurge | int | `1` |  |
@@ -1170,8 +1162,6 @@ Two things worth planning for before you enable it:
 | smithdb.ingestion.deployment.topologySpreadConstraints | list | `[]` |  |
 | smithdb.ingestion.deployment.volumeMounts[0].mountPath | string | `"/data"` |  |
 | smithdb.ingestion.deployment.volumeMounts[0].name | string | `"local-ssd-storage"` |  |
-| smithdb.ingestion.deployment.volumes[0].emptyDir.sizeLimit | string | `"100Gi"` |  |
-| smithdb.ingestion.deployment.volumes[0].name | string | `"local-ssd-storage"` |  |
 | smithdb.ingestion.name | string | `"ingestion"` |  |
 | smithdb.ingestion.pdb.annotations | object | `{}` |  |
 | smithdb.ingestion.pdb.enabled | bool | `false` |  |
@@ -1325,12 +1315,6 @@ Two things worth planning for before you enable it:
 | smithdb.query.deployment.probes.startupProbe.periodSeconds | int | `10` |  |
 | smithdb.query.deployment.probes.startupProbe.timeoutSeconds | int | `1` |  |
 | smithdb.query.deployment.replicas | int | `1` |  |
-| smithdb.query.deployment.resources.limits.cpu | string | `"4"` |  |
-| smithdb.query.deployment.resources.limits.ephemeral-storage | string | `"200Gi"` |  |
-| smithdb.query.deployment.resources.limits.memory | string | `"8Gi"` |  |
-| smithdb.query.deployment.resources.requests.cpu | string | `"4"` |  |
-| smithdb.query.deployment.resources.requests.ephemeral-storage | string | `"200Gi"` |  |
-| smithdb.query.deployment.resources.requests.memory | string | `"8Gi"` |  |
 | smithdb.query.deployment.securityContext | object | `{}` |  |
 | smithdb.query.deployment.sidecars | list | `[]` |  |
 | smithdb.query.deployment.strategy.rollingUpdate.maxSurge | int | `1` |  |
@@ -1340,8 +1324,6 @@ Two things worth planning for before you enable it:
 | smithdb.query.deployment.topologySpreadConstraints | list | `[]` |  |
 | smithdb.query.deployment.volumeMounts[0].mountPath | string | `"/data"` |  |
 | smithdb.query.deployment.volumeMounts[0].name | string | `"local-ssd-storage"` |  |
-| smithdb.query.deployment.volumes[0].emptyDir.sizeLimit | string | `"200Gi"` |  |
-| smithdb.query.deployment.volumes[0].name | string | `"local-ssd-storage"` |  |
 | smithdb.query.name | string | `"query"` |  |
 | smithdb.query.pdb.annotations | object | `{}` |  |
 | smithdb.query.pdb.enabled | bool | `false` |  |
@@ -1350,6 +1332,7 @@ Two things worth planning for before you enable it:
 | smithdb.query.service.annotations | object | `{}` |  |
 | smithdb.query.service.labels | object | `{}` |  |
 | smithdb.query.service.port | int | `8080` |  |
+| smithdb.resourceTier | string | `"small"` | Per-replica resource tier for SmithDB runtime components. Supported values: small, medium, large. See the README for sizing and override behavior. |
 | smithdb.serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"create":true,"labels":{},"name":""}` | Shared ServiceAccount for SmithDB workloads. |
 | smithdb.serviceAccount.name | string | `""` | Defaults to <release>-<smithdb.name>. |
 

--- a/charts/langsmith/README.md.gotmpl
+++ b/charts/langsmith/README.md.gotmpl
@@ -32,6 +32,20 @@ Two things worth planning for before you enable it:
 
 {{ template "chart.requirementsSection" . }}
 
+## SmithDB resource tiers
+
+`smithdb.resourceTier` selects the default per-replica resource sizes shown below. The default is `small`. For components that use local disk, the tier's ephemeral-storage limit also sets the generated `emptyDir.sizeLimit`.
+
+Replica counts and autoscaling remain controlled by each component's `deployment.replicas` and `autoscaling` settings. Explicit component `resources` or `volumes` settings take precedence over the tier defaults.
+
+| Component | Small | Medium | Large |
+|---|---|---|---|
+| Query | 4 CPU, 8Gi memory, 200Gi ephemeral | 28 CPU, 48Gi memory, 200Gi ephemeral | 28 CPU, 50Gi memory, 1000Gi ephemeral |
+| Ingestion | 4 CPU, 8Gi memory, 100Gi ephemeral | 16 CPU, 32Gi memory, 100Gi ephemeral | 56 CPU, 150Gi memory, 1000Gi ephemeral |
+| Compaction | 2 CPU, 4Gi memory | 4 CPU, 8Gi memory | 8 CPU, 16Gi memory |
+| Compaction worker | 8 CPU, 16Gi memory, 100Gi ephemeral | 16 CPU, 32Gi memory, 100Gi ephemeral | 28 CPU, 50Gi memory, 300Gi ephemeral |
+| Cluster manager | 250m CPU, 256Mi memory | 250m CPU, 256Mi memory | 2 CPU, 2Gi memory |
+
 ## General parameters
 
 | Key | Type | Default | Description |

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -511,6 +511,65 @@ Template containing common environment variables that are used by several servic
 {{- end }}
 {{- end }}
 
+{{/*
+Resolve a SmithDB component's resources. An explicit non-empty component resources
+block replaces the selected tier resources.
+Args: root, component.
+*/}}
+{{- define "langsmith.smithdb.resources" -}}
+{{- $root := .root -}}
+{{- $component := .component -}}
+{{- $deployment := (index $root.Values.smithdb $component).deployment -}}
+{{- $componentResources := get $deployment "resources" -}}
+{{- if $componentResources -}}
+{{- toYaml $componentResources -}}
+{{- else -}}
+{{- $tiers := dict
+  "small" (dict
+    "query" (dict "cpu" "4" "memory" "8Gi" "ephemeral-storage" "200Gi")
+    "ingestion" (dict "cpu" "4" "memory" "8Gi" "ephemeral-storage" "100Gi")
+    "compaction" (dict "cpu" "2" "memory" "4Gi")
+    "compactionWorker" (dict "cpu" "8" "memory" "16Gi" "ephemeral-storage" "100Gi")
+    "clusterManager" (dict "cpu" "250m" "memory" "256Mi"))
+  "medium" (dict
+    "query" (dict "cpu" "28" "memory" "48Gi" "ephemeral-storage" "200Gi")
+    "ingestion" (dict "cpu" "16" "memory" "32Gi" "ephemeral-storage" "100Gi")
+    "compaction" (dict "cpu" "4" "memory" "8Gi")
+    "compactionWorker" (dict "cpu" "16" "memory" "32Gi" "ephemeral-storage" "100Gi")
+    "clusterManager" (dict "cpu" "250m" "memory" "256Mi"))
+  "large" (dict
+    "query" (dict "cpu" "28" "memory" "50Gi" "ephemeral-storage" "1000Gi")
+    "ingestion" (dict "cpu" "56" "memory" "150Gi" "ephemeral-storage" "1000Gi")
+    "compaction" (dict "cpu" "8" "memory" "16Gi")
+    "compactionWorker" (dict "cpu" "28" "memory" "50Gi" "ephemeral-storage" "300Gi")
+    "clusterManager" (dict "cpu" "2" "memory" "2Gi")) -}}
+{{- $resources := index (index $tiers $root.Values.smithdb.resourceTier) $component -}}
+{{- toYaml (dict "requests" $resources "limits" $resources) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Resolve volumes for a disk-using SmithDB component. When the volumes key is
+omitted, generate the standard emptyDir and align its size limit with the
+resolved ephemeral-storage limit. A user-provided list, including [], replaces
+the generated volumes.
+Args: root, component, resources.
+*/}}
+{{- define "langsmith.smithdb.volumes" -}}
+{{- $root := .root -}}
+{{- $deployment := (index $root.Values.smithdb .component).deployment -}}
+{{- if hasKey $deployment "volumes" -}}
+{{- toYaml $deployment.volumes -}}
+{{- else -}}
+{{- $ephemeralStorage := index (default (dict) .resources.limits) "ephemeral-storage" -}}
+- name: local-ssd-storage
+  emptyDir:
+    {{- with $ephemeralStorage }}
+    sizeLimit: {{ . }}
+    {{- end }}
+{{- end -}}
+{{- end }}
+
 {{/* Compute NUM_WORKERS from a CPU limit (cores or millicores). */}}
 {{- define "langsmith.smithdb.migrationNumWorkers" -}}
 {{- $cpu := toString . -}}

--- a/charts/langsmith/templates/smithdb/cluster-manager-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/cluster-manager-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.smithdb.enabled }}
+{{- $resources := include "langsmith.smithdb.resources" (dict "root" . "component" "clusterManager") | fromYaml -}}
 {{- $envVars := concat .Values.commonEnv .Values.smithdb.commonEnv .Values.smithdb.clusterManager.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: apps/v1
@@ -102,7 +103,7 @@ spec:
             {{- toYaml . | nindent 10 }}
           {{- end }}
           resources:
-            {{- toYaml .Values.smithdb.clusterManager.deployment.resources | nindent 12 }}
+            {{- toYaml $resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.smithdb.clusterManager.deployment.securityContext | nindent 12 }}
           {{- with .Values.smithdb.clusterManager.deployment.volumeMounts }}

--- a/charts/langsmith/templates/smithdb/compaction-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.smithdb.enabled }}
+{{- $resources := include "langsmith.smithdb.resources" (dict "root" . "component" "compaction") | fromYaml -}}
 {{- $envVars := concat (include "langsmith.smithdb.componentEnv" (dict "root" . "service" "COMPACTION" "displayName" "smithdb-compaction") | fromYamlArray) .Values.smithdb.compaction.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: apps/v1
@@ -83,7 +84,7 @@ spec:
             {{- toYaml . | nindent 10 }}
           {{- end }}
           resources:
-            {{- toYaml .Values.smithdb.compaction.deployment.resources | nindent 12 }}
+            {{- toYaml $resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.smithdb.compaction.deployment.securityContext | nindent 12 }}
           {{- with .Values.smithdb.compaction.deployment.volumeMounts }}

--- a/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/compaction-worker-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.smithdb.enabled }}
+{{- $resources := include "langsmith.smithdb.resources" (dict "root" . "component" "compactionWorker") | fromYaml -}}
 {{- $envVars := concat (include "langsmith.smithdb.componentEnv" (dict "root" . "service" "COMPACTION_WORKER" "displayName" "smithdb-compaction-worker") | fromYamlArray) .Values.smithdb.compactionWorker.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: apps/v1
@@ -85,7 +86,7 @@ spec:
             {{- toYaml . | nindent 10 }}
           {{- end }}
           resources:
-            {{- toYaml .Values.smithdb.compactionWorker.deployment.resources | nindent 12 }}
+            {{- toYaml $resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.smithdb.compactionWorker.deployment.securityContext | nindent 12 }}
           {{- with .Values.smithdb.compactionWorker.deployment.volumeMounts }}
@@ -114,7 +115,7 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.smithdb.compactionWorker.deployment.volumes }}
+      {{- with (include "langsmith.smithdb.volumes" (dict "root" . "component" "compactionWorker" "resources" $resources) | fromYamlArray) }}
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/langsmith/templates/smithdb/ingestion-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/ingestion-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.smithdb.enabled }}
+{{- $resources := include "langsmith.smithdb.resources" (dict "root" . "component" "ingestion") | fromYaml -}}
 {{- $envVars := concat (include "langsmith.smithdb.componentEnv" (dict "root" . "service" "INGESTION" "displayName" "smithdb-ingestion") | fromYamlArray) .Values.smithdb.ingestion.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: apps/v1
@@ -84,7 +85,7 @@ spec:
             {{- toYaml . | nindent 10 }}
           {{- end }}
           resources:
-            {{- toYaml .Values.smithdb.ingestion.deployment.resources | nindent 12 }}
+            {{- toYaml $resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.smithdb.ingestion.deployment.securityContext | nindent 12 }}
           {{- with .Values.smithdb.ingestion.deployment.volumeMounts }}
@@ -113,7 +114,7 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.smithdb.ingestion.deployment.volumes }}
+      {{- with (include "langsmith.smithdb.volumes" (dict "root" . "component" "ingestion" "resources" $resources) | fromYamlArray) }}
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/langsmith/templates/smithdb/query-deployment.yaml
+++ b/charts/langsmith/templates/smithdb/query-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.smithdb.enabled }}
+{{- $resources := include "langsmith.smithdb.resources" (dict "root" . "component" "query") | fromYaml -}}
 {{- $envVars := concat (include "langsmith.smithdb.componentEnv" (dict "root" . "service" "QUERY" "displayName" "smithdb-query") | fromYamlArray) .Values.smithdb.query.deployment.extraEnv -}}
 {{- include "langsmith.detectDuplicates" $envVars -}}
 apiVersion: apps/v1
@@ -67,13 +68,13 @@ spec:
               value: {{ .Values.smithdb.query.containerPort | quote }}
             - name: SMITHDB_QUERY__GRPC_PORT
               value: {{ .Values.smithdb.query.containerGrpcPort | quote }}
-            {{- if (index (default (dict) .Values.smithdb.query.deployment.resources.limits) "ephemeral-storage") }}
+            {{- if (index (default (dict) $resources.limits) "ephemeral-storage") }}
             - name: SMITHDB_QUERY__VORTEX_CACHE__DISK__LIMIT
               valueFrom:
                 resourceFieldRef:
                   resource: limits.ephemeral-storage
             {{- end }}
-            {{- if (index (default (dict) .Values.smithdb.query.deployment.resources.limits) "memory") }}
+            {{- if (index (default (dict) $resources.limits) "memory") }}
             - name: SMITHDB_QUERY__VORTEX_CACHE__MEMORY__LIMIT
               valueFrom:
                 resourceFieldRef:
@@ -95,7 +96,7 @@ spec:
             {{- toYaml . | nindent 10 }}
           {{- end }}
           resources:
-            {{- toYaml .Values.smithdb.query.deployment.resources | nindent 12 }}
+            {{- toYaml $resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.smithdb.query.deployment.securityContext | nindent 12 }}
           {{- with .Values.smithdb.query.deployment.volumeMounts }}
@@ -124,7 +125,7 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.smithdb.query.deployment.volumes }}
+      {{- with (include "langsmith.smithdb.volumes" (dict "root" . "component" "query" "resources" $resources) | fromYamlArray) }}
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/langsmith/templates/validate.yaml
+++ b/charts/langsmith/templates/validate.yaml
@@ -29,6 +29,9 @@ AWS Marketplace Helm template verification).
 {{- if not (kindIs "bool" .Values.smithdb.langsmith.query.enabled) -}}
 {{- fail "smithdb.langsmith.query.enabled must be a boolean. Do not quote true or false." -}}
 {{- end -}}
+{{- if not (has .Values.smithdb.resourceTier (list "small" "medium" "large")) -}}
+{{- fail "smithdb.resourceTier must be one of: small, medium, large." -}}
+{{- end -}}
 {{- if not .Values.config.skipValidation -}}
 
 {{- /* Validate deprecated fleet server value keys */ -}}

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -79,6 +79,96 @@ tests:
           path: spec.template.spec.containers[0].resources.requests.ephemeral-storage
           value: "200Gi"
 
+  - it: should apply the selected SmithDB resource tier
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.resourceTier: medium
+    template: smithdb/query-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            requests:
+              cpu: "28"
+              memory: "48Gi"
+              ephemeral-storage: "200Gi"
+            limits:
+              cpu: "28"
+              memory: "48Gi"
+              ephemeral-storage: "200Gi"
+      - equal:
+          path: spec.template.spec.volumes[0]
+          value:
+            name: local-ssd-storage
+            emptyDir:
+              sizeLimit: "200Gi"
+
+  - it: should use the large SmithDB ingestion resources
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.resourceTier: large
+    template: smithdb/ingestion-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: "56"
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: "150Gi"
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.ephemeral-storage
+          value: "1000Gi"
+      - equal:
+          path: spec.template.spec.volumes[0].emptyDir.sizeLimit
+          value: "1000Gi"
+
+  - it: should replace tier resources with an explicit component resources block
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.resourceTier: large
+      smithdb.query.deployment.resources.requests.cpu: 750m
+      smithdb.query.deployment.resources.limits.cpu: "1"
+    template: smithdb/query-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            requests:
+              cpu: 750m
+            limits:
+              cpu: "1"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_QUERY__VORTEX_CACHE__DISK__LIMIT
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_QUERY__VORTEX_CACHE__MEMORY__LIMIT
+      - notExists:
+          path: spec.template.spec.volumes[0].emptyDir.sizeLimit
+
+  - it: should replace generated tier volumes with explicit component volumes
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.resourceTier: large
+      smithdb.query.deployment.volumes:
+        - name: local-ssd-storage
+          emptyDir:
+            sizeLimit: 500Gi
+    template: smithdb/query-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: local-ssd-storage
+              emptyDir:
+                sizeLimit: 500Gi
+
   - it: should configure SmithDB Beacon log export with the LangSmith license secret
     values:
       - ./values/smithdb-enabled.yaml

--- a/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_validation_test.yaml
@@ -2,6 +2,13 @@ suite: test smithdb phase validation
 templates:
   - validate.yaml
 tests:
+  - it: should reject an unsupported SmithDB resource tier
+    set:
+      smithdb.resourceTier: extra-large
+    asserts:
+      - failedTemplate:
+          errorMessage: "smithdb.resourceTier must be one of: small, medium, large."
+
   - it: should reject smithdb without query replicas
     values:
       - ./values/smithdb-enabled.yaml
@@ -203,4 +210,3 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "smithdb.commonInitContainers[0] must be a container object."
-

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1414,6 +1414,9 @@ smithdb:
   # -- V16 supports SmithDB in beta. We do not support or recommend customers setting this up on their own.
   # -- Please express interest (https://www.langchain.com/smithdb-early-access-waitlist) and we will reach out promptly to ensure we can set you up for success with SmithDB.
   enabled: false
+  # -- Per-replica resource tier for SmithDB runtime components.
+  # Supported values: small, medium, large. See the README for sizing and override behavior.
+  resourceTier: "small"
   # -- LangSmith configuration for SmithDB.
   langsmith:
     ingestion:
@@ -1483,15 +1486,6 @@ smithdb:
       podSecurityContext: {}
       securityContext: {}
       priorityClassName: ""
-      resources:
-        requests:
-          cpu: "4"
-          memory: "8Gi"
-          ephemeral-storage: "200Gi"
-        limits:
-          cpu: "4"
-          memory: "8Gi"
-          ephemeral-storage: "200Gi"
       probes:
         startupProbe:
           httpGet:
@@ -1524,10 +1518,6 @@ smithdb:
       tolerations: []
       affinity: {}
       topologySpreadConstraints: []
-      volumes:
-        - name: local-ssd-storage
-          emptyDir:
-            sizeLimit: 200Gi
       volumeMounts:
         - name: local-ssd-storage
           mountPath: /data
@@ -1566,15 +1556,6 @@ smithdb:
       podSecurityContext: {}
       securityContext: {}
       priorityClassName: ""
-      resources:
-        requests:
-          cpu: "4"
-          memory: "8Gi"
-          ephemeral-storage: "100Gi"
-        limits:
-          cpu: "4"
-          memory: "8Gi"
-          ephemeral-storage: "100Gi"
       probes:
         startupProbe:
           httpGet:
@@ -1612,10 +1593,6 @@ smithdb:
       tolerations: []
       affinity: {}
       topologySpreadConstraints: []
-      volumes:
-        - name: local-ssd-storage
-          emptyDir:
-            sizeLimit: 100Gi
       volumeMounts:
         - name: local-ssd-storage
           mountPath: /data
@@ -1649,13 +1626,6 @@ smithdb:
       podSecurityContext: {}
       securityContext: {}
       priorityClassName: ""
-      resources:
-        requests:
-          cpu: "2"
-          memory: "4Gi"
-        limits:
-          cpu: "2"
-          memory: "4Gi"
       probes:
         startupProbe:
           httpGet:
@@ -1715,15 +1685,6 @@ smithdb:
       securityContext: {}
       priorityClassName: ""
       terminationGracePeriodSeconds: 120
-      resources:
-        requests:
-          cpu: "8"
-          memory: "16Gi"
-          ephemeral-storage: "100Gi"
-        limits:
-          cpu: "8"
-          memory: "16Gi"
-          ephemeral-storage: "100Gi"
       probes:
         startupProbe:
           httpGet:
@@ -1757,10 +1718,6 @@ smithdb:
       tolerations: []
       affinity: {}
       topologySpreadConstraints: []
-      volumes:
-        - name: local-ssd-storage
-          emptyDir:
-            sizeLimit: 100Gi
       volumeMounts:
         - name: local-ssd-storage
           mountPath: /data
@@ -1790,13 +1747,6 @@ smithdb:
       podSecurityContext: {}
       securityContext: {}
       priorityClassName: ""
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "256Mi"
-        limits:
-          cpu: "250m"
-          memory: "256Mi"
       probes:
         startupProbe:
           httpGet:


### PR DESCRIPTION
## Summary

Backports #989 to `v16-stable`.

- add `smithdb.resourceTier` with small, medium, and large per-replica resource defaults
- preserve explicit component `resources` and `volumes` as higher-precedence overrides
- size generated `emptyDir` volumes from resolved ephemeral-storage limits
- document tier sizes and bump the v16 LangSmith chart to `0.16.14`

## Testing

- `helm unittest -f 'tests/langsmith_smithdb*_test.yaml' charts/langsmith` (76 tests)\n- `helm lint charts/langsmith -f charts/langsmith/tests/values/smithdb-enabled.yaml --set config.existingSecretName=runtime`\n- default-small runtime resources and volumes match `v16-stable` exactly\n- full-suite JuiceFS annotation failures reproduce on the untouched `v16-stable` baseline