### PR TITLE
fix(langsmith): allow Fleet common SSRF env override

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.17.0-rc.16
+version: 0.17.0-rc.17
 appVersion: "0.17.14rc1"

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -1162,8 +1162,14 @@ Extra env vars for fleet api-server and queue pods.
   (dict "name" "LANGSMITH_LICENSE_REQUIRED_CLAIMS" "value" "agent_builder_enabled")
   (dict "name" "SSRF_ALLOW_PRIVATE_IPS_MCP_SERVERS" "value" "true")
   (dict "name" "SSRF_ALLOW_PRIVATE_IPS_TOOLS" "value" "true")
-  (dict "name" "SSRF_ALLOW_K8S_INTERNAL" "value" "true")
 -}}
+{{- $commonEnvKeys := list -}}
+{{- range $root.Values.commonEnv -}}
+{{- $commonEnvKeys = append $commonEnvKeys .name -}}
+{{- end -}}
+{{- if not (has "SSRF_ALLOW_K8S_INTERNAL" $commonEnvKeys) -}}
+{{- $out = append $out (dict "name" "SSRF_ALLOW_K8S_INTERNAL" "value" "true") -}}
+{{- end -}}
 {{- if $feature.postgres.external.iamProvider -}}
 {{- $out = append $out (dict "name" "AGENT_POSTGRES_IAM_AUTH_PROVIDER" "value" $feature.postgres.external.iamProvider) -}}
 {{- end -}}

--- a/charts/langsmith/tests/agent_iam_provider_test.yaml
+++ b/charts/langsmith/tests/agent_iam_provider_test.yaml
@@ -44,6 +44,24 @@ tests:
           content:
             name: AGENT_REDIS_IAM_AUTH_PROVIDER
             value: gcp
+  - it: preserves common SSRF configuration for fleet workloads
+    set:
+      commonEnv:
+        - name: SSRF_ALLOW_K8S_INTERNAL
+          value: "false"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SSRF_ALLOW_K8S_INTERNAL
+            value: "false"
+        template: agent-features/fleet/api-server/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SSRF_ALLOW_K8S_INTERNAL
+            value: "false"
+        template: agent-features/fleet/queue/deployment.yaml
   - it: maps insights IAM providers to the api-server
     template: agent-features/insights/api-server/deployment.yaml
     asserts:


### PR DESCRIPTION
## Summary
- avoid adding Fleet’s managed `SSRF_ALLOW_K8S_INTERNAL=true` when `commonEnv` already configures the variable
- preserve Fleet’s existing default when no global override is provided
- cover both Fleet API server and queue rendering with a focused Helm unit test
- bump the LangSmith chart to `0.17.0-rc.17`

## Test plan
- [x] `helm unittest --file tests/agent_iam_provider_test.yaml charts/langsmith`
- [x] `helm lint charts/langsmith`
- [x] Render Fleet API server and queue with `commonEnv.SSRF_ALLOW_K8S_INTERNAL=false`

Made by [Open SWE](https://openswe.vercel.app/agents/02007d11-16e8-542a-b3a6-d572923fb705)