### PR TITLE
ci: pin Redis TLS fixture version on v16

### DIFF
--- a/.github/workflows/helm_checks.yaml
+++ b/.github/workflows/helm_checks.yaml
@@ -112,7 +112,10 @@ jobs:
           helm repo update
 
           helm install redis-tls bitnami/redis \
+            --version 22.0.7 \
             --namespace default \
+            --set image.repository=bitnamilegacy/redis \
+            --set image.tag=8.2.1-debian-12-r0 \
             --set auth.enabled=false \
             --set master.persistence.enabled=false \
             --set replica.replicaCount=0 \


### PR DESCRIPTION
## Summary

- pin the Bitnami Redis chart used by the TLS CI fixture
- use the matching versioned image from Bitnami's legacy archive
- avoid failures caused by the floating `bitnami/redis:latest` image

## Validation

- rendered the pinned chart with the workflow's TLS configuration
- confirmed it selects `bitnamilegacy/redis:8.2.1-debian-12-r0`