### PR TITLE
fix(langsmith): drain the adhoc asynq queue on self-hosted

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.17.0-rc.23
+version: 0.17.0-rc.24
 appVersion: "0.17.20rc1"

--- a/charts/langsmith/templates/ingest-queue/deployment.yaml
+++ b/charts/langsmith/templates/ingest-queue/deployment.yaml
@@ -3,6 +3,8 @@
   value: "3"
 - name: "QUEUE_PORT"
   value: {{ .Values.ingestQueue.containerPort | quote }}
+- name: "GO_ADHOC_QUEUE_PRIORITY"
+  value: {{ .Values.ingestQueue.adhocQueuePriority | quote }}
 {{ include "langsmith.engine.smithGoEnv" . }}
 {{- if .Values.sandboxes.enabled }}
 - name: SANDBOX_QUEUE_PRIORITY

--- a/charts/langsmith/tests/adhoc_queue_priority_test.yaml
+++ b/charts/langsmith/tests/adhoc_queue_priority_test.yaml
@@ -1,0 +1,39 @@
+suite: adhoc queue priority
+templates:
+  - config-map.yaml
+  - secrets.yaml
+  - redis/secrets.yaml
+  - postgres/secrets.yaml
+  - clickhouse/secrets.yaml
+  - frontend/config-map.yaml
+  - ingest-queue/deployment.yaml
+tests:
+  - it: should give the adhoc queue a positive priority by default
+    template: ingest-queue/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "GO_ADHOC_QUEUE_PRIORITY"
+            value: "1"
+
+  - it: should allow operators to stop draining the adhoc queue
+    set:
+      ingestQueue.adhocQueuePriority: 0
+    template: ingest-queue/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "GO_ADHOC_QUEUE_PRIORITY"
+            value: "0"
+
+  - it: should fail when an operator also sets the priority via extraEnv
+    set:
+      ingestQueue.deployment.extraEnv:
+        - name: GO_ADHOC_QUEUE_PRIORITY
+          value: "1"
+    template: ingest-queue/deployment.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "Duplicate keys detected: [GO_ADHOC_QUEUE_PRIORITY]"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -3548,6 +3548,11 @@ ingestQueue:
   enabled: true
   name: "ingest-queue"
   containerPort: 1989
+  # -- Priority of the `adhoc` asynq queue for this worker. This is the only Go
+  # asynq worker in the chart, so a value of 0 makes it skip the queue entirely
+  # and Engine runs and platform cron jobs are enqueued but never processed.
+  # Set to 0 only to deliberately stop draining the queue.
+  adhocQueuePriority: 1
   # -- ArgoCD Rollouts configuration. If enabled, will create a Rollout resource instead of a Deployment. See https://argo-rollouts.readthedocs.io/
   rollout:
     enabled: false


### PR DESCRIPTION
## Problem

Self-hosted installs never consume the `adhoc` asynq queue, so everything routed to it is enqueued and left pending forever.

smith-go defaults the priority to `0`:

```go
// smith-go/config/config.go
GoAdhocQueuePriority int `env:"GO_ADHOC_QUEUE_PRIORITY,default=0"`
```

Every other queue defaults to `1`. That value feeds `BuildWorkerQueueMap()` (`smith-go/queue/partitions.go`), and asynq drops any queue with a non-positive priority — "If a queue has a zero or negative priority value, the queue will be ignored" (`server.go:469`). Ingestion is still `1`, so there's no fallback to asynq's default queue config; `adhoc` is just silently omitted from the set the worker polls.

`ingest-queue` is the chart's only Go asynq worker (`command: ["asynq_worker_entrypoint.sh"]` → `./asynq-worker`), and the chart has never set `GO_ADHOC_QUEUE_PRIORITY`. SaaS doesn't hit this because it runs a dedicated `asynqAdhocQueue` deployment with the priority set to `1`.

The chart's KEDA ScaledObject already scales `ingest-queue` on `adhoc_queue.pending`, so the chart clearly intends this worker to drain the queue — it just never turned it on.

## Impact

Found while debugging a customer whose Engine did nothing when enabled for a project. All Engine work targets this queue: the per-project scan cron registered off `tracer_session_issues_agent`, `run_issues_agent`, issue validation, run-webhook callbacks, short-lived API key cleanup, and Linear sync. Tasks were enqueued and never dequeued — no errors, nothing in the UI.

It isn't Engine-only, though. These crons are registered unconditionally in `cmd/asynq_worker/scheduled_jobs.go` and all target the adhoc queue:

- `insights-running-cleanup-cron`
- `postgres-invalid-index-monitor-cron`
- `tracer-session-stats-sync`
- `custom-app-view-count-sync`
- `oauth-cleanup`

The cron scheduler itself runs unconditionally in the worker under leader election, so on every self-hosted install these have been enqueuing since install day with nothing draining them.

## Change

Set `GO_ADHOC_QUEUE_PRIORITY` in `ingestQueueEnvVars` from a new `ingestQueue.adhocQueuePriority` value, defaulting to `1`. Follows the existing `SANDBOX_QUEUE_PRIORITY` pattern in the same block.

Deliberately **not** gated on `engine.enabled` — the non-Engine crons above need the queue drained too, and gating would fix Engine while leaving those broken.

## Reviewer notes

Two things worth a second opinion:

1. **Backlog drain on upgrade.** Installs that have been running a while have an accumulated adhoc backlog, and this makes the worker drain all of it at once. Payloads are tiny so it's more likely slow bloat than a Redis problem, but operators with a large backlog may want to flush `asynq:{adhoc}:pending` before upgrading. `adhocQueuePriority: 0` is the escape hatch for anyone who needs to stage it.

2. **Operators who already worked around this** via `ingestQueue.deployment.extraEnv` will get a hard render failure from `langsmith.detectDuplicates` on upgrade and must switch to the new value. That matches the chart's existing deliberate behavior (see the `SANDBOX_RUNTIME_V2` conflict test in `sandboxes_test.yaml`), and there's a test pinning it here. Flagging it because it needs a release note.

Separately, the durable fix belongs in smith-go: `scheduler/scheduler.go` enqueues periodic tasks with no `asynq.TaskID`, so a stalled queue accumulates without bound. A deterministic task ID would make this class of bug self-limiting. Filing that separately.

## Testing

- `helm unittest charts/langsmith` — 329/329 pass, including three new cases (default, operator override to `0`, duplicate-`extraEnv` failure)
- `helm lint charts/langsmith` — clean
- Verified the rendered `ingest-queue` Deployment carries `GO_ADHOC_QUEUE_PRIORITY: "1"` with Engine disabled, and that it lands only on that Deployment
- Chart version bumped `0.17.0-rc.23` → `rc.24` for `ct lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
