### PR TITLE
fix(langsmith): backport metastore migration resource requests

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.16
+version: 0.16.17
 appVersion: "0.16.50"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.16.16](https://img.shields.io/badge/Version-0.16.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.50](https://img.shields.io/badge/AppVersion-0.16.50-informational?style=flat-square)
+![Version: 0.16.17](https://img.shields.io/badge/Version-0.16.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.50](https://img.shields.io/badge/AppVersion-0.16.50-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -1185,7 +1185,8 @@ Replica counts and autoscaling remain controlled by each component's `deployment
 | smithdb.metastoreMigration.job.nodeSelector | object | `{}` |  |
 | smithdb.metastoreMigration.job.podAnnotations | object | `{}` |  |
 | smithdb.metastoreMigration.job.podSecurityContext | object | `{}` |  |
-| smithdb.metastoreMigration.job.resources | object | `{}` |  |
+| smithdb.metastoreMigration.job.resources.requests.cpu | string | `"200m"` |  |
+| smithdb.metastoreMigration.job.resources.requests.memory | string | `"500Mi"` |  |
 | smithdb.metastoreMigration.job.restartPolicy | string | `"Never"` |  |
 | smithdb.metastoreMigration.job.securityContext | object | `{}` |  |
 | smithdb.metastoreMigration.job.tolerations | list | `[]` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1185,6 +1185,8 @@ Replica counts and autoscaling remain controlled by each component's `deployment
 | smithdb.metastoreMigration.job.nodeSelector | object | `{}` |  |
 | smithdb.metastoreMigration.job.podAnnotations | object | `{}` |  |
 | smithdb.metastoreMigration.job.podSecurityContext | object | `{}` |  |
+| smithdb.metastoreMigration.job.resources.limits.cpu | string | `"1000m"` |  |
+| smithdb.metastoreMigration.job.resources.limits.memory | string | `"1Gi"` |  |
 | smithdb.metastoreMigration.job.resources.requests.cpu | string | `"200m"` |  |
 | smithdb.metastoreMigration.job.resources.requests.memory | string | `"500Mi"` |  |
 | smithdb.metastoreMigration.job.restartPolicy | string | `"Never"` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1185,10 +1185,10 @@ Replica counts and autoscaling remain controlled by each component's `deployment
 | smithdb.metastoreMigration.job.nodeSelector | object | `{}` |  |
 | smithdb.metastoreMigration.job.podAnnotations | object | `{}` |  |
 | smithdb.metastoreMigration.job.podSecurityContext | object | `{}` |  |
-| smithdb.metastoreMigration.job.resources.limits.cpu | string | `"1000m"` |  |
-| smithdb.metastoreMigration.job.resources.limits.memory | string | `"1Gi"` |  |
-| smithdb.metastoreMigration.job.resources.requests.cpu | string | `"200m"` |  |
-| smithdb.metastoreMigration.job.resources.requests.memory | string | `"500Mi"` |  |
+| smithdb.metastoreMigration.job.resources.limits.cpu | string | `"500m"` |  |
+| smithdb.metastoreMigration.job.resources.limits.memory | string | `"512Mi"` |  |
+| smithdb.metastoreMigration.job.resources.requests.cpu | string | `"250m"` |  |
+| smithdb.metastoreMigration.job.resources.requests.memory | string | `"256Mi"` |  |
 | smithdb.metastoreMigration.job.restartPolicy | string | `"Never"` |  |
 | smithdb.metastoreMigration.job.securityContext | object | `{}` |  |
 | smithdb.metastoreMigration.job.tolerations | list | `[]` |  |

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -903,7 +903,7 @@ tests:
             name: SMITHDB_COMPACTION_WORKER__MAX_CONCURRENT_JOBS
             value: "8"
 
-  - it: should set metastore migration resource requests
+  - it: should set metastore migration resources
     values:
       - ./values/smithdb-enabled.yaml
     template: smithdb/metastore-migration.yaml
@@ -914,6 +914,12 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
           value: 500Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 1000m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 1Gi
 
   - it: should omit smithdb migration resources by default
     values:

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -903,6 +903,18 @@ tests:
             name: SMITHDB_COMPACTION_WORKER__MAX_CONCURRENT_JOBS
             value: "8"
 
+  - it: should set metastore migration resource requests
+    values:
+      - ./values/smithdb-enabled.yaml
+    template: smithdb/metastore-migration.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 200m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 500Mi
+
   - it: should omit smithdb migration resources by default
     values:
       - ./values/smithdb-enabled.yaml

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -910,16 +910,16 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
-          value: 200m
+          value: 250m
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
-          value: 500Mi
+          value: 256Mi
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
-          value: 1000m
+          value: 500m
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
-          value: 1Gi
+          value: 512Mi
 
   - it: should omit smithdb migration resources by default
     values:

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1958,11 +1958,11 @@ smithdb:
       securityContext: {}
       resources:
         limits:
-          cpu: 1000m
-          memory: 1Gi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 200m
-          memory: 500Mi
+          cpu: 250m
+          memory: 256Mi
       extraEnv: []
       nodeSelector: {}
       tolerations: []

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1956,7 +1956,10 @@ smithdb:
       podAnnotations: {}
       podSecurityContext: {}
       securityContext: {}
-      resources: {}
+      resources:
+        requests:
+          cpu: 200m
+          memory: 500Mi
       extraEnv: []
       nodeSelector: {}
       tolerations: []

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1957,6 +1957,9 @@ smithdb:
       podSecurityContext: {}
       securityContext: {}
       resources:
+        limits:
+          cpu: 1000m
+          memory: 1Gi
         requests:
           cpu: 200m
           memory: 500Mi


### PR DESCRIPTION
Backports #1016 to `v16-stable`.

Set default CPU and memory requests and limits on the SmithDB metastore migration Job, matching the backend migration defaults. This gives the hook predictable scheduling and resource bounds.

Bump the v16 LangSmith chart to `0.16.17` and document the new defaults.

Test plan:
- `helm lint charts/langsmith`
- `helm unittest --color=false -f 'tests/langsmith_smithdb_test.yaml' charts/langsmith` (51 tests passed)

Made by [Open SWE](https://openswe.vercel.app/agents/5f6ff721-e952-53d1-a996-e9852b23d2ad) · openai:gpt-5.6-sol (medium)