### PR TITLE
chore(langsmith): replace SmithDB waitlist comment with support and docs pointers

### DIFF
--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1100,7 +1100,7 @@ Replica counts and autoscaling remain controlled by each component's `deployment
 | smithdb.config.objectStore.s3.region | string | `""` | Defaults to the SmithDB S3 client default when empty. |
 | smithdb.config.objectStore.s3.secretAccessKeySecretKey | string | `""` |  |
 | smithdb.config.objectStore.type | string | `"s3"` | Supported values: s3, gcs, azure. |
-| smithdb.enabled | bool | `false` | Documentation: https://docs.langchain.com/langsmith/self-host-smithdb |
+| smithdb.enabled | bool | `false` | SmithDB is opt-in. Setup guide: https://docs.langchain.com/langsmith/self-host-smithdb. Users are encouraged to reach out to LangChain support (https://support.langchain.com/) before enabling it. |
 | smithdb.ingestion.autoscaling.hpa.enabled | bool | `true` |  |
 | smithdb.ingestion.autoscaling.hpa.maxReplicas | int | `10` |  |
 | smithdb.ingestion.autoscaling.hpa.minReplicas | int | `1` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1100,7 +1100,7 @@ Replica counts and autoscaling remain controlled by each component's `deployment
 | smithdb.config.objectStore.s3.region | string | `""` | Defaults to the SmithDB S3 client default when empty. |
 | smithdb.config.objectStore.s3.secretAccessKeySecretKey | string | `""` |  |
 | smithdb.config.objectStore.type | string | `"s3"` | Supported values: s3, gcs, azure. |
-| smithdb.enabled | bool | `false` | Please express interest (https://www.langchain.com/smithdb-early-access-waitlist) and we will reach out promptly to ensure we can set you up for success with SmithDB. |
+| smithdb.enabled | bool | `false` | Documentation: https://docs.langchain.com/langsmith/self-host-smithdb |
 | smithdb.ingestion.autoscaling.hpa.enabled | bool | `true` |  |
 | smithdb.ingestion.autoscaling.hpa.maxReplicas | int | `10` |  |
 | smithdb.ingestion.autoscaling.hpa.minReplicas | int | `1` |  |

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1377,8 +1377,7 @@ aceBackend:
 
 smithdb:
   # -- Deploy the in-chart SmithDB workloads.
-  # -- SmithDB is opt-in and needs dedicated infrastructure. Users are encouraged to reach out to LangChain support (https://support.langchain.com/) before enabling it.
-  # -- Documentation: https://docs.langchain.com/langsmith/self-host-smithdb
+  # -- SmithDB is opt-in. Setup guide: https://docs.langchain.com/langsmith/self-host-smithdb. Users are encouraged to reach out to LangChain support (https://support.langchain.com/) before enabling it.
   enabled: false
   # -- Per-replica resource tier for SmithDB runtime components.
   # Supported values: small, medium, large. See the README for sizing and override behavior.

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1377,8 +1377,8 @@ aceBackend:
 
 smithdb:
   # -- Deploy the in-chart SmithDB workloads.
-  # -- V16 supports SmithDB in beta. We do not support or recommend customers setting this up on their own.
-  # -- Please express interest (https://www.langchain.com/smithdb-early-access-waitlist) and we will reach out promptly to ensure we can set you up for success with SmithDB.
+  # -- SmithDB is opt-in and needs dedicated infrastructure. Users are encouraged to reach out to LangChain support (https://support.langchain.com/) before enabling it.
+  # -- Documentation: https://docs.langchain.com/langsmith/self-host-smithdb
   enabled: false
   # -- Per-replica resource tier for SmithDB runtime components.
   # Supported values: small, medium, large. See the README for sizing and override behavior.


### PR DESCRIPTION
Replaces the SmithDB early-access waitlist comment on `smithdb.enabled` with a pointer to the self-hosted docs and a note encouraging users to contact support before enabling. Drops the beta wording to match the docs.

README regenerated with `helm-docs`.

Merge after langchain-ai/docs#5796 so the documentation link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)