### PR TITLE
feat(langsmith): add SSE-KMS encryption values for SmithDB S3 object store

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.17.0-rc.25
+version: 0.17.0-rc.26
 appVersion: "0.17.20rc1"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1097,7 +1097,7 @@ Replica counts and autoscaling remain controlled by each component's `deployment
 | smithdb.config.objectStore.bucket | string | `""` |  |
 | smithdb.config.objectStore.s3.accessKeyIdSecretKey | string | `""` | Keys in smithdb.config.existingSecretName for static S3 credentials. Set both to "" when using ambient cloud identity, such as IRSA. |
 | smithdb.config.objectStore.s3.endpoint | string | `""` |  |
-| smithdb.config.objectStore.s3.kmsEncryptionEnabled | bool | `false` | Send SSE-KMS encryption headers on S3 writes. Mirrors config.blobStorage.kmsEncryptionEnabled. |
+| smithdb.config.objectStore.s3.kmsEncryptionEnabled | bool | `false` | Send SSE-KMS encryption headers on S3 writes. Same semantics as config.blobStorage.kmsEncryptionEnabled. |
 | smithdb.config.objectStore.s3.kmsKeyArn | string | `""` | KMS key ARN for SSE-KMS. When empty, S3 encrypts with the AWS managed aws/s3 key, not the bucket default key. |
 | smithdb.config.objectStore.s3.region | string | `""` | Defaults to the SmithDB S3 client default when empty. |
 | smithdb.config.objectStore.s3.secretAccessKeySecretKey | string | `""` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.17.0-rc.25](https://img.shields.io/badge/Version-0.17.0--rc.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.20rc1](https://img.shields.io/badge/AppVersion-0.17.20rc1-informational?style=flat-square)
+![Version: 0.17.0-rc.26](https://img.shields.io/badge/Version-0.17.0--rc.26-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.20rc1](https://img.shields.io/badge/AppVersion-0.17.20rc1-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -1097,6 +1097,8 @@ Replica counts and autoscaling remain controlled by each component's `deployment
 | smithdb.config.objectStore.bucket | string | `""` |  |
 | smithdb.config.objectStore.s3.accessKeyIdSecretKey | string | `""` | Keys in smithdb.config.existingSecretName for static S3 credentials. Set both to "" when using ambient cloud identity, such as IRSA. |
 | smithdb.config.objectStore.s3.endpoint | string | `""` |  |
+| smithdb.config.objectStore.s3.kmsEncryptionEnabled | bool | `false` | Send SSE-KMS encryption headers on S3 writes. Mirrors config.blobStorage.kmsEncryptionEnabled. |
+| smithdb.config.objectStore.s3.kmsKeyArn | string | `""` | KMS key ARN for SSE-KMS. When empty, S3 encrypts with the AWS managed aws/s3 key, not the bucket default key. |
 | smithdb.config.objectStore.s3.region | string | `""` | Defaults to the SmithDB S3 client default when empty. |
 | smithdb.config.objectStore.s3.secretAccessKeySecretKey | string | `""` |  |
 | smithdb.config.objectStore.type | string | `"s3"` | Supported values: s3, gcs, azure. |

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -831,6 +831,14 @@ Args: root, service, displayName.
       name: {{ $root.Values.smithdb.config.existingSecretName }}
       key: {{ $root.Values.smithdb.config.objectStore.s3.secretAccessKeySecretKey }}
 {{- end }}
+{{- if $root.Values.smithdb.config.objectStore.s3.kmsEncryptionEnabled }}
+- name: {{ $prefix }}__OBJECT_STORE__S3__KMS_ENCRYPTION_ENABLED
+  value: {{ $root.Values.smithdb.config.objectStore.s3.kmsEncryptionEnabled | quote }}
+{{- with $root.Values.smithdb.config.objectStore.s3.kmsKeyArn }}
+- name: {{ $prefix }}__OBJECT_STORE__S3__KMS_KEY_ARN
+  value: {{ . | quote }}
+{{- end }}
+{{- end }}
 {{- else if eq $objectStoreType "gcs" }}
 - name: {{ $prefix }}__OBJECT_STORE__GCS__BUCKET
   value: {{ $root.Values.smithdb.config.objectStore.bucket | quote }}

--- a/charts/langsmith/templates/smithdb/migration-job.yaml
+++ b/charts/langsmith/templates/smithdb/migration-job.yaml
@@ -247,6 +247,14 @@ spec:
                   name: {{ .Values.smithdb.config.existingSecretName }}
                   key: {{ $smithdbObjectStore.s3.secretAccessKeySecretKey }}
             {{- end }}
+            {{- if $smithdbObjectStore.s3.kmsEncryptionEnabled }}
+            - name: SMITHDB_MIGRATION__OUTPUT__OBJECT_STORE__S3__KMS_ENCRYPTION_ENABLED
+              value: {{ $smithdbObjectStore.s3.kmsEncryptionEnabled | quote }}
+            {{- with $smithdbObjectStore.s3.kmsKeyArn }}
+            - name: SMITHDB_MIGRATION__OUTPUT__OBJECT_STORE__S3__KMS_KEY_ARN
+              value: {{ . | quote }}
+            {{- end }}
+            {{- end }}
             {{- else if eq $smithdbObjectStoreType "gcs" }}
             - name: SMITHDB_MIGRATION__OUTPUT__OBJECT_STORE__GCS__BUCKET
               value: {{ $smithdbObjectStore.bucket | quote }}

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -80,6 +80,62 @@ tests:
           path: spec.template.spec.containers[0].resources.requests.ephemeral-storage
           value: "200Gi"
 
+  - it: should send SSE-KMS encryption env for S3 when enabled
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.config.objectStore.s3.kmsEncryptionEnabled: true
+      smithdb.config.objectStore.s3.kmsKeyArn: arn:aws:kms:us-west-2:123456789012:key/smithdb
+    template: smithdb/query-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_QUERY__OBJECT_STORE__S3__KMS_ENCRYPTION_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_QUERY__OBJECT_STORE__S3__KMS_KEY_ARN
+            value: arn:aws:kms:us-west-2:123456789012:key/smithdb
+  - it: should omit SSE-KMS encryption env for S3 by default
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.config.objectStore.s3.kmsKeyArn: arn:aws:kms:us-west-2:123456789012:key/smithdb
+    template: smithdb/query-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_QUERY__OBJECT_STORE__S3__KMS_ENCRYPTION_ENABLED
+            value: "true"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_QUERY__OBJECT_STORE__S3__KMS_KEY_ARN
+            value: arn:aws:kms:us-west-2:123456789012:key/smithdb
+  - it: should send SSE-KMS encryption env for the S3 migration output
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.config.objectStore.s3.kmsEncryptionEnabled: true
+      smithdb.config.objectStore.s3.kmsKeyArn: arn:aws:kms:us-west-2:123456789012:key/smithdb
+      smithdb.langsmith.migration.enabled: true
+      smithdb.langsmith.query.enabled: false
+      smithdb.migration.taskdb.postgres.auth.password: taskdb-password
+    template: smithdb/migration-job.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_MIGRATION__OUTPUT__OBJECT_STORE__S3__KMS_ENCRYPTION_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_MIGRATION__OUTPUT__OBJECT_STORE__S3__KMS_KEY_ARN
+            value: arn:aws:kms:us-west-2:123456789012:key/smithdb
   - it: should configure Azure Blob Storage for SmithDB
     values:
       - ./values/smithdb-enabled.yaml

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1435,7 +1435,7 @@ smithdb:
         # Set both to "" when using ambient cloud identity, such as IRSA.
         accessKeyIdSecretKey: ""
         secretAccessKeySecretKey: ""
-        # -- Send SSE-KMS encryption headers on S3 writes. Mirrors config.blobStorage.kmsEncryptionEnabled.
+        # -- Send SSE-KMS encryption headers on S3 writes. Same semantics as config.blobStorage.kmsEncryptionEnabled.
         kmsEncryptionEnabled: false
         # -- KMS key ARN for SSE-KMS. When empty, S3 encrypts with the AWS managed aws/s3 key, not the bucket default key.
         kmsKeyArn: ""

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1435,6 +1435,10 @@ smithdb:
         # Set both to "" when using ambient cloud identity, such as IRSA.
         accessKeyIdSecretKey: ""
         secretAccessKeySecretKey: ""
+        # -- Send SSE-KMS encryption headers on S3 writes. Mirrors config.blobStorage.kmsEncryptionEnabled.
+        kmsEncryptionEnabled: false
+        # -- KMS key ARN for SSE-KMS. When empty, S3 encrypts with the AWS managed aws/s3 key, not the bucket default key.
+        kmsKeyArn: ""
       azure:
         # -- Azure Storage account name. Required when type is azure.
         accountName: ""


### PR DESCRIPTION
## Summary

Gives SmithDB's S3 object store the same SSE-KMS configuration surface LangSmith blob storage already has (`config.blobStorage.kmsEncryptionEnabled` / `kmsKeyArn`). Pairs with [langchain-ai/smithdb#2824](https://github.com/langchain-ai/smithdb/pull/2824), which adds the corresponding `S3Cfg` fields; the env vars are ignored by SmithDB builds that predate it.

New values under `smithdb.config.objectStore.s3`:

| Value | Default | Renders |
|---|---|---|
| `kmsEncryptionEnabled` | `false` | `SMITHDB_<SERVICE>__OBJECT_STORE__S3__KMS_ENCRYPTION_ENABLED` |
| `kmsKeyArn` | `""` | `SMITHDB_<SERVICE>__OBJECT_STORE__S3__KMS_KEY_ARN` (only when enabled) |

Rendered via `langsmith.smithdb.serviceEnv`, so it reaches query, query-services, ingestion, compaction, compaction-worker, migration and metastore-migration. The migration job's separate `SMITHDB_MIGRATION__OUTPUT__OBJECT_STORE__S3__*` block — where the migration actually writes Vortex files — is updated explicitly. Cluster-manager uses `baseEnv` and gets no object-store env, unchanged.

## Notes for reviewers

- **Deliberately not derived from `config.blobStorage`.** With `aws:kms` and no key id, S3 uses the AWS-managed `aws/s3` key — *not* the bucket's default CMK (bucket default encryption only applies when a request carries no SSE headers). Auto-inheriting the backend's setting would silently switch SmithDB objects from a customer's bucket-default CMK to `aws/s3`. Keeping it an explicit opt-in avoids that; the `kmsKeyArn` doc comment calls out the `aws/s3` behavior.
- **Zero impact when unset.** A default render (`smithdb-enabled.yaml` test values) produces no `KMS` env anywhere; both new values are gated on `kmsEncryptionEnabled`.
- The ARN is a non-secret identifier, so it's a plain value rather than a `secretKeyRef`, same as `config.blobStorage.kmsKeyArn`.
- Chart version bumped `0.17.0-rc.25` → `rc.26`; README regenerated with `helm-docs` (diff is the two new rows plus badge).

## Operational follow-up (not in this PR)

SmithDB's service accounts are distinct from backend/queue, so the KMS key policy and IRSA roles need `kms:Decrypt` and `kms:GenerateDataKey` for the SmithDB roles before enabling this.

## Test plan

- `helm unittest charts/langsmith` — 331/331 pass, including 3 new cases in `langsmith_smithdb_test.yaml` (enabled on query-deployment; omitted by default even with an ARN set; enabled on the migration output).
- `helm lint` clean with the values enabled.
- `helm template` with KMS enabled: both vars rendered on compaction-worker, compaction, ingestion, and query deployments; none on cluster-manager. Default render: rc=0, S3 env present, zero KMS lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
