### PR TITLE
feat(langsmith): backport SmithDB S3 SSE-KMS encryption values to v16

### DIFF
--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.18
+version: 0.16.19
 appVersion: "0.16.52"

--- a/charts/langsmith/Chart.yaml
+++ b/charts/langsmith/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
     email: ankush@langchain.dev
 description: Helm chart to deploy the langsmith application and all services it depends on.
 type: application
-version: 0.16.17
-appVersion: "0.16.50"
+version: 0.16.18
+appVersion: "0.16.52"

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.16.17](https://img.shields.io/badge/Version-0.16.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.50](https://img.shields.io/badge/AppVersion-0.16.50-informational?style=flat-square)
+![Version: 0.16.18](https://img.shields.io/badge/Version-0.16.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.52](https://img.shields.io/badge/AppVersion-0.16.52-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -581,22 +581,22 @@ Replica counts and autoscaling remain controlled by each component's `deployment
 | gateway.sectionName | string | `""` |  |
 | images.aceBackendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.aceBackendImage.repository | string | `"docker.io/langchain/langsmith-ace-backend"` |  |
-| images.aceBackendImage.tag | string | `"0.16.50"` |  |
+| images.aceBackendImage.tag | string | `"0.16.52"` |  |
 | images.agentBuilderImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.agentBuilderImage.repository | string | `"docker.io/langchain/agent-builder-deep-agent"` |  |
-| images.agentBuilderImage.tag | string | `"0.16.50"` |  |
+| images.agentBuilderImage.tag | string | `"0.16.52"` |  |
 | images.backendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.backendImage.repository | string | `"docker.io/langchain/langsmith-backend"` |  |
-| images.backendImage.tag | string | `"0.16.50"` |  |
+| images.backendImage.tag | string | `"0.16.52"` |  |
 | images.clickhouseImage.pullPolicy | string | `"Always"` |  |
 | images.clickhouseImage.repository | string | `"docker.io/clickhouse/clickhouse-server"` |  |
 | images.clickhouseImage.tag | string | `"25.12"` |  |
 | images.engineInsightsAgentImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.engineInsightsAgentImage.repository | string | `"docker.io/langchain/langsmith-insights-engine"` |  |
-| images.engineInsightsAgentImage.tag | string | `"0.16.50"` |  |
+| images.engineInsightsAgentImage.tag | string | `"0.16.52"` |  |
 | images.frontendImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.frontendImage.repository | string | `"docker.io/langchain/langsmith-frontend"` |  |
-| images.frontendImage.tag | string | `"0.16.50"` |  |
+| images.frontendImage.tag | string | `"0.16.52"` |  |
 | images.imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Specified as name: value. |
 | images.juicefsCSIImage | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/juicedata/juicefs-csi-driver","tag":"v0.31.4"}` | JuiceFS CSI driver image. Only used when config.sandboxes.enabled is true. |
 | images.juicefsCSINodeDriverRegistrarImage | object | `{"pullPolicy":"IfNotPresent","repository":"registry.k8s.io/sig-storage/csi-node-driver-registrar","tag":"v2.9.0"}` | JuiceFS CSI node-driver-registrar sidecar image. Only used when config.sandboxes.enabled is true. |
@@ -606,7 +606,7 @@ Replica counts and autoscaling remain controlled by each component's `deployment
 | images.operatorImage.tag | string | `"0.1.47"` |  |
 | images.pollyAgentImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.pollyAgentImage.repository | string | `"docker.io/langchain/langsmith-polly"` |  |
-| images.pollyAgentImage.tag | string | `"0.16.50"` |  |
+| images.pollyAgentImage.tag | string | `"0.16.52"` |  |
 | images.postgresImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.postgresImage.repository | string | `"docker.io/postgres"` |  |
 | images.postgresImage.tag | string | `"14.7"` |  |
@@ -620,7 +620,7 @@ Replica counts and autoscaling remain controlled by each component's `deployment
 | images.sandboxHostImage | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/langchain/sandbox-host","tag":""}` | sandbox-host image. Only used when config.sandboxes.enabled is true. |
 | images.smithdbImage.pullPolicy | string | `"IfNotPresent"` |  |
 | images.smithdbImage.repository | string | `"docker.io/langchain/smithdb"` |  |
-| images.smithdbImage.tag | string | `"0.16.50"` |  |
+| images.smithdbImage.tag | string | `"0.16.52"` |  |
 | ingestQueue.autoscaling.hpa.enabled | bool | `false` |  |
 | ingestQueue.autoscaling.hpa.maxReplicas | int | `10` |  |
 | ingestQueue.autoscaling.hpa.minReplicas | int | `3` |  |

--- a/charts/langsmith/README.md
+++ b/charts/langsmith/README.md
@@ -1,6 +1,6 @@
 # langsmith
 
-![Version: 0.16.18](https://img.shields.io/badge/Version-0.16.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.52](https://img.shields.io/badge/AppVersion-0.16.52-informational?style=flat-square)
+![Version: 0.16.19](https://img.shields.io/badge/Version-0.16.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.52](https://img.shields.io/badge/AppVersion-0.16.52-informational?style=flat-square)
 
 Helm chart to deploy the langsmith application and all services it depends on.
 
@@ -1109,6 +1109,8 @@ Replica counts and autoscaling remain controlled by each component's `deployment
 | smithdb.config.objectStore.bucket | string | `""` |  |
 | smithdb.config.objectStore.s3.accessKeyIdSecretKey | string | `""` | Keys in smithdb.config.existingSecretName for static S3 credentials. Set both to "" when using ambient cloud identity, such as IRSA. |
 | smithdb.config.objectStore.s3.endpoint | string | `""` |  |
+| smithdb.config.objectStore.s3.kmsEncryptionEnabled | bool | `false` | Send SSE-KMS encryption headers on S3 writes. Same semantics as config.blobStorage.kmsEncryptionEnabled. |
+| smithdb.config.objectStore.s3.kmsKeyArn | string | `""` | KMS key ARN for SSE-KMS. When empty, S3 encrypts with the AWS managed aws/s3 key, not the bucket default key. |
 | smithdb.config.objectStore.s3.region | string | `""` | Defaults to the SmithDB S3 client default when empty. |
 | smithdb.config.objectStore.s3.secretAccessKeySecretKey | string | `""` |  |
 | smithdb.config.objectStore.type | string | `"s3"` | Supported values: s3, gcs. |

--- a/charts/langsmith/templates/_helpers.tpl
+++ b/charts/langsmith/templates/_helpers.tpl
@@ -827,6 +827,14 @@ Args: root, service, displayName.
       name: {{ $root.Values.smithdb.config.existingSecretName }}
       key: {{ $root.Values.smithdb.config.objectStore.s3.secretAccessKeySecretKey }}
 {{- end }}
+{{- if $root.Values.smithdb.config.objectStore.s3.kmsEncryptionEnabled }}
+- name: {{ $prefix }}__OBJECT_STORE__S3__KMS_ENCRYPTION_ENABLED
+  value: {{ $root.Values.smithdb.config.objectStore.s3.kmsEncryptionEnabled | quote }}
+{{- with $root.Values.smithdb.config.objectStore.s3.kmsKeyArn }}
+- name: {{ $prefix }}__OBJECT_STORE__S3__KMS_KEY_ARN
+  value: {{ . | quote }}
+{{- end }}
+{{- end }}
 {{- else if eq $objectStoreType "gcs" }}
 - name: {{ $prefix }}__OBJECT_STORE__GCS__BUCKET
   value: {{ $root.Values.smithdb.config.objectStore.bucket | quote }}

--- a/charts/langsmith/templates/smithdb/migration-job.yaml
+++ b/charts/langsmith/templates/smithdb/migration-job.yaml
@@ -226,6 +226,14 @@ spec:
                   name: {{ .Values.smithdb.config.existingSecretName }}
                   key: {{ $smithdbObjectStore.s3.secretAccessKeySecretKey }}
             {{- end }}
+            {{- if $smithdbObjectStore.s3.kmsEncryptionEnabled }}
+            - name: SMITHDB_MIGRATION__OUTPUT__OBJECT_STORE__S3__KMS_ENCRYPTION_ENABLED
+              value: {{ $smithdbObjectStore.s3.kmsEncryptionEnabled | quote }}
+            {{- with $smithdbObjectStore.s3.kmsKeyArn }}
+            - name: SMITHDB_MIGRATION__OUTPUT__OBJECT_STORE__S3__KMS_KEY_ARN
+              value: {{ . | quote }}
+            {{- end }}
+            {{- end }}
             {{- else if eq $smithdbObjectStoreType "gcs" }}
             - name: SMITHDB_MIGRATION__OUTPUT__OBJECT_STORE__GCS__BUCKET
               value: {{ $smithdbObjectStore.bucket | quote }}

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -620,6 +620,62 @@ tests:
             name: VITE_SELF_HOSTED_SMITHDB_V2_ENDPOINTS_ENABLED
             value: "true"
 
+  - it: should send SSE-KMS encryption env for S3 when enabled
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.config.objectStore.s3.kmsEncryptionEnabled: true
+      smithdb.config.objectStore.s3.kmsKeyArn: arn:aws:kms:us-west-2:123456789012:key/smithdb
+    template: smithdb/query-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_QUERY__OBJECT_STORE__S3__KMS_ENCRYPTION_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_QUERY__OBJECT_STORE__S3__KMS_KEY_ARN
+            value: arn:aws:kms:us-west-2:123456789012:key/smithdb
+  - it: should omit SSE-KMS encryption env for S3 by default
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.config.objectStore.s3.kmsKeyArn: arn:aws:kms:us-west-2:123456789012:key/smithdb
+    template: smithdb/query-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_QUERY__OBJECT_STORE__S3__KMS_ENCRYPTION_ENABLED
+            value: "true"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_QUERY__OBJECT_STORE__S3__KMS_KEY_ARN
+            value: arn:aws:kms:us-west-2:123456789012:key/smithdb
+  - it: should send SSE-KMS encryption env for the S3 migration output
+    values:
+      - ./values/smithdb-enabled.yaml
+    set:
+      smithdb.config.objectStore.s3.kmsEncryptionEnabled: true
+      smithdb.config.objectStore.s3.kmsKeyArn: arn:aws:kms:us-west-2:123456789012:key/smithdb
+      smithdb.langsmith.migration.enabled: true
+      smithdb.langsmith.query.enabled: false
+      smithdb.migration.taskdb.postgres.auth.password: taskdb-password
+    template: smithdb/migration-job.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_MIGRATION__OUTPUT__OBJECT_STORE__S3__KMS_ENCRYPTION_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMITHDB_MIGRATION__OUTPUT__OBJECT_STORE__S3__KMS_KEY_ARN
+            value: arn:aws:kms:us-west-2:123456789012:key/smithdb
   - it: should skip all smithdb resources when disabled
     values:
       - ./values/smithdb-enabled.yaml

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -1469,6 +1469,10 @@ smithdb:
         # Set both to "" when using ambient cloud identity, such as IRSA.
         accessKeyIdSecretKey: ""
         secretAccessKeySecretKey: ""
+        # -- Send SSE-KMS encryption headers on S3 writes. Same semantics as config.blobStorage.kmsEncryptionEnabled.
+        kmsEncryptionEnabled: false
+        # -- KMS key ARN for SSE-KMS. When empty, S3 encrypts with the AWS managed aws/s3 key, not the bucket default key.
+        kmsKeyArn: ""
 
   query:
     name: "query"

--- a/charts/langsmith/values.yaml
+++ b/charts/langsmith/values.yaml
@@ -65,22 +65,22 @@ images:
   aceBackendImage:
     repository: "docker.io/langchain/langsmith-ace-backend"
     pullPolicy: IfNotPresent
-    tag: "0.16.50"
+    tag: "0.16.52"
   backendImage:
     repository: "docker.io/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
-    tag: "0.16.50"
+    tag: "0.16.52"
   # Image for the shared Engine/Insights agent deployment. Serves both the
   # `insights` and `engine` graphs; which of them run is set by insights.enabled
   # and engine.enabled.
   engineInsightsAgentImage:
     repository: "docker.io/langchain/langsmith-insights-engine"
     pullPolicy: IfNotPresent
-    tag: "0.16.50"
+    tag: "0.16.52"
   frontendImage:
     repository: "docker.io/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
-    tag: "0.16.50"
+    tag: "0.16.52"
   operatorImage:
     repository: "docker.io/langchain/langgraph-operator"
     pullPolicy: IfNotPresent
@@ -104,15 +104,15 @@ images:
   agentBuilderImage:
     repository: "docker.io/langchain/agent-builder-deep-agent"
     pullPolicy: IfNotPresent
-    tag: "0.16.50"
+    tag: "0.16.52"
   pollyAgentImage:
     repository: "docker.io/langchain/langsmith-polly"
     pullPolicy: IfNotPresent
-    tag: "0.16.50"
+    tag: "0.16.52"
   smithdbImage:
     repository: "docker.io/langchain/smithdb"
     pullPolicy: IfNotPresent
-    tag: "0.16.50"
+    tag: "0.16.52"
   # Optional: only mirror/pull when presidioAnalyzer.enabled is true
   presidioAnalyzerImage:
     repository: "mcr.microsoft.com/presidio-analyzer"


### PR DESCRIPTION
## Summary

Backports #1021 to `v16-stable`. Pairs with the SmithDB side, already merged to `v16-stable` as langchain-ai/smithdb#2826.

**Stacked on #1023** (appVersion bump to `0.16.52`, chart `0.16.18`) and must merge after it; the base is set to #1023's branch so GitHub retargets to `v16-stable` on its merge.

- add `smithdb.config.objectStore.s3.kmsEncryptionEnabled` and `kmsKeyArn`, same semantics as `config.blobStorage.kmsEncryptionEnabled` / `kmsKeyArn`
- render `SMITHDB_<SERVICE>__OBJECT_STORE__S3__KMS_ENCRYPTION_ENABLED` / `__KMS_KEY_ARN` via `langsmith.smithdb.serviceEnv` (query, ingestion, compaction, compaction-worker, migration, metastore-migration) and in the migration job's separate `SMITHDB_MIGRATION__OUTPUT__OBJECT_STORE__S3__*` block
- the ARN is only rendered when `kmsEncryptionEnabled` is true; nothing is rendered by default
- bump the v16 LangSmith chart to `0.16.19` (on top of #1023's `0.16.18`); README regenerated with `helm-docs`

The two template hunks cherry-picked cleanly. `values.yaml`, `Chart.yaml`, `README.md` and the test file were re-applied by hand against v16's layout (v16 has no `azure` object-store block and a different test-suite anchor).

## Notes for reviewers

- **Deliberately an explicit opt-in, not derived from `config.blobStorage`.** With `aws:kms` and no key id, S3 encrypts with the AWS-managed `aws/s3` key — not the bucket's default CMK — so auto-inheriting the backend's flag could silently move SmithDB objects off a customer's CMK. The `kmsKeyArn` doc comment calls this out.
- **Zero impact when unset.** Default render (`smithdb-enabled.yaml` fixture) produces no `KMS` env anywhere.
- Cluster-manager uses `baseEnv` and receives no object-store env, unchanged.

## Testing

- `helm unittest -f 'tests/langsmith_smithdb_test.yaml' charts/langsmith` — 54 passed (51 → 54; new: enabled on query-deployment, omitted by default even with an ARN set, enabled on the migration output)
- all suites except JuiceFS CSI — 305 passed
- `sandbox_juicefs_csi_driver_test.yaml` — the same 2 `equal` asserts fail on the untouched `v16-stable` baseline (`872338de`), matching the note in #998; not introduced here
- `helm lint charts/langsmith -f charts/langsmith/tests/values/smithdb-enabled.yaml --set config.existingSecretName=runtime` with KMS enabled — clean
- `helm template` with KMS enabled: 2 KMS env vars on compaction-worker and query, 0 on cluster-manager; default render rc=0 with 0 KMS lines and S3 env present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

