### PR TITLE
refactor: remove obsolete Redis tracking setting

### DIFF
--- a/charts/langsmith/templates/config-map.yaml
+++ b/charts/langsmith/templates/config-map.yaml
@@ -73,7 +73,6 @@ data:
   {{- $mutationsValues := index .Values.smithdb $mutationsComponent }}
   SMITHDB_MUTATIONS_SERVICE_URL: {{ include "langsmith.smithdb.grpcServiceUrl" (dict "root" . "component" $mutationsComponent "port" $mutationsValues.service.port) | quote }}
   SMITHDB_INGESTION_SERVICE_URL: {{ include "langsmith.smithdb.grpcServiceUrl" (dict "root" . "component" "ingestion" "port" .Values.smithdb.ingestion.service.port) | quote }}
-  RULES_REDIS_TRACKING_ENABLED: "true"
   RULES_REDIS_TRACKING_MULTIPART_ENABLED: "true"
   {{- end }}
   {{- if .Values.smithdb.enabled }}

--- a/charts/langsmith/tests/langsmith_smithdb_test.yaml
+++ b/charts/langsmith/tests/langsmith_smithdb_test.yaml
@@ -560,9 +560,6 @@ tests:
           path: data.SMITHDB_MUTATIONS_SERVICE_URL
           value: RELEASE-NAME-langsmith-smithdb-query.NAMESPACE.svc.cluster.local:8080
       - equal:
-          path: data.RULES_REDIS_TRACKING_ENABLED
-          value: "true"
-      - equal:
           path: data.RULES_REDIS_TRACKING_MULTIPART_ENABLED
           value: "true"
       - equal:
@@ -620,9 +617,6 @@ tests:
       - equal:
           path: data.SMITHDB_QUERY_ENABLED
           value: "false"
-      - equal:
-          path: data.RULES_REDIS_TRACKING_ENABLED
-          value: "true"
       - equal:
           path: data.RULES_REDIS_TRACKING_MULTIPART_ENABLED
           value: "true"
@@ -688,8 +682,6 @@ tests:
           path: data.SMITHDB_CLUSTER_MANAGER_ENABLED
       - notExists:
           path: data.SMITHDB_CLUSTER_MANAGER_URL
-      - notExists:
-          path: data.RULES_REDIS_TRACKING_ENABLED
       - notExists:
           path: data.RULES_REDIS_TRACKING_MULTIPART_ENABLED
       - notExists:


### PR DESCRIPTION
## Description

Remove the obsolete `RULES_REDIS_TRACKING_ENABLED` ConfigMap entry and its three test assertions while preserving the surrounding SmithDB scenarios.

Keep this draft until the application cleanup is deployed and a compatible chart application image is selected. Earlier binaries defaulted tracking to false, so custom image overrides must also be checked before release. Chart and application versions remain unchanged pending that compatibility verification.

## Test Plan

- [x] Verify all references to the removed flag are gone from this repository and the SmithDB scenarios remain.
- [ ] Run the focused SmithDB Helm suite and normal chart CI checks; local attempts were blocked by unavailable `helm` and `ct` executables.
- [ ] Verify application image compatibility, including custom overrides, and complete chart release versioning before merging.

`git diff --check` and the commit secret scan passed.

Application companion: https://github.com/langchain-ai/langchainplus/pull/39134
